### PR TITLE
Add SdkResult class and improve result handling

### DIFF
--- a/src/SdkResult.ts
+++ b/src/SdkResult.ts
@@ -1,0 +1,57 @@
+import type { SDKResultSuccess } from '@anthropic-ai/claude-agent-sdk';
+
+const API_ERROR_REGEX = /API Error: (\d+) (\{.+\})$/s;
+
+export interface ApiErrorInfo {
+  readonly statusCode: number;
+  readonly errorType: string | null;
+  readonly errorMessage: string | null;
+}
+
+function parseApiError(result: string): ApiErrorInfo | null {
+  const match = API_ERROR_REGEX.exec(result);
+  if (!match) {
+    return null;
+  }
+
+  const statusCode = Number(match[1]);
+  const jsonBody = match[2];
+
+  try {
+    const parsed = JSON.parse(jsonBody) as { error?: { type?: string; message?: string } };
+    return {
+      statusCode,
+      errorType: parsed.error?.type ?? null,
+      errorMessage: parsed.error?.message ?? null,
+    };
+  } catch {
+    return {
+      statusCode,
+      errorType: null,
+      errorMessage: null,
+    };
+  }
+}
+
+export class SdkResult {
+  public readonly result: string;
+  public readonly isError: boolean;
+  public readonly stopReason: string | null;
+  public readonly apiError: ApiErrorInfo | null;
+  public readonly isApiError: boolean;
+  public readonly isRateLimited: boolean;
+  public readonly noTokens: boolean;
+
+  public constructor(msg: SDKResultSuccess) {
+    this.result = msg.result;
+    this.isError = msg.is_error;
+    this.stopReason = msg.stop_reason;
+
+    this.apiError = parseApiError(msg.result);
+    this.isApiError = this.apiError !== null;
+
+    const totalOutput = Object.values(msg.modelUsage).reduce((sum, mu) => sum + (mu.outputTokens ?? 0), 0);
+    this.noTokens = totalOutput === 0;
+    this.isRateLimited = this.noTokens && msg.result.includes('429') && msg.result.includes('rate_limit_error');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   type EditorState,
 } from './editor.js';
 import { AuditWriter } from './AuditWriter.js';
+import { SdkResult } from './SdkResult.js';
 import { SessionManager } from './SessionManager.js';
 import { initFiles } from './files.js';
 import { getConfig, isInsideCwd, isSafeBashCommand } from './config.js';
@@ -182,23 +183,35 @@ async function submit(override?: string): Promise<void> {
         break;
       }
       case 'result': {
-        const noTokens = msg.usage.input_tokens === 0 && msg.usage.output_tokens === 0;
-        if (noTokens) {
-          const errorDetail = msg.subtype === 'success' ? msg.result : msg.errors.join(', ');
-          logEvent(`\x1b[31mresult: ERROR (${msg.duration_ms}ms) ${errorDetail}\x1b[0m`);
-        } else {
-          logEvent(`result: ${msg.subtype} cost=$${msg.total_cost_usd.toFixed(4)} turns=${msg.num_turns} duration=${msg.duration_ms}ms`);
-          for (const [model, mu] of Object.entries(msg.modelUsage)) {
-            const shortModel = model.replace(/^claude-/, '');
-            const input = (mu.inputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0);
-            const output = mu.outputTokens ?? 0;
-            const window = mu.contextWindow ?? 0;
-            const pct = window > 0 ? ` (${((input / window) * 100).toFixed(1)}%)` : '';
-            logEvent(`  ${shortModel}: in=${input.toLocaleString()}${window > 0 ? `/${window.toLocaleString()}` : ''}${pct} out=${output.toLocaleString()} $${mu.costUSD.toFixed(4)}`);
-            if (mu.cacheReadInputTokens || mu.cacheCreationInputTokens) {
-              logEvent(`    cache: read=${(mu.cacheReadInputTokens ?? 0).toLocaleString()} created=${(mu.cacheCreationInputTokens ?? 0).toLocaleString()} uncached=${(mu.inputTokens ?? 0).toLocaleString()}`);
+        if (msg.subtype === 'success') {
+          const sdkResult = new SdkResult(msg);
+          if (sdkResult.isRateLimited) {
+            logEvent(`\x1b[31mresult: RATE LIMITED (${msg.duration_ms}ms) ${msg.result}\x1b[0m`);
+          } else if (sdkResult.isApiError) {
+            logEvent(`\x1b[31mresult: API ERROR ${sdkResult.apiError!.statusCode} (${msg.duration_ms}ms) ${sdkResult.apiError!.errorType}: ${sdkResult.apiError!.errorMessage}\x1b[0m`);
+          } else if (sdkResult.isError) {
+            logEvent(`\x1b[31mresult: ERROR is_error (${msg.duration_ms}ms) ${msg.result}\x1b[0m`, msg);
+          } else if (sdkResult.noTokens) {
+            logEvent(`\x1b[31mresult: ERROR no_tokens (${msg.duration_ms}ms) ${msg.result}\x1b[0m`, msg);
+          } else {
+            logEvent(`result: ${msg.subtype} cost=$${msg.total_cost_usd.toFixed(4)} turns=${msg.num_turns} duration=${msg.duration_ms}ms`);
+          }
+
+          if (!sdkResult.noTokens) {
+            for (const [model, mu] of Object.entries(msg.modelUsage)) {
+              const shortModel = model.replace(/^claude-/, '');
+              const input = (mu.inputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0);
+              const output = mu.outputTokens ?? 0;
+              const window = mu.contextWindow ?? 0;
+              const pct = window > 0 ? ` (${((input / window) * 100).toFixed(1)}%)` : '';
+              logEvent(`  ${shortModel}: in=${input.toLocaleString()}${window > 0 ? `/${window.toLocaleString()}` : ''}${pct} out=${output.toLocaleString()} $${mu.costUSD.toFixed(4)}`);
+              if (mu.cacheReadInputTokens || mu.cacheCreationInputTokens) {
+                logEvent(`    cache: read=${(mu.cacheReadInputTokens ?? 0).toLocaleString()} created=${(mu.cacheCreationInputTokens ?? 0).toLocaleString()} uncached=${(mu.inputTokens ?? 0).toLocaleString()}`);
+              }
             }
           }
+        } else {
+          logEvent(`\x1b[31mresult: ERROR ${msg.subtype} (${msg.duration_ms}ms) ${msg.errors.join(', ')}\x1b[0m`, msg);
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Add SdkResult class to parse API errors, detect rate limiting, and classify result states
- Improve result handling with distinct error paths: rate limited, API error, is_error, no_tokens
- Only show model usage stats when tokens are present

Co-Authored-By: Claude <noreply@anthropic.com>