### PR TITLE
Display context, cost, and model usage for error results

### DIFF
--- a/src/UsageTracker.ts
+++ b/src/UsageTracker.ts
@@ -1,6 +1,6 @@
 import { closeSync, createReadStream, openSync, readSync, statSync } from 'node:fs';
 import { createInterface } from 'node:readline';
-import type { SDKMessage, SDKResultSuccess } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage, SDKResultMessage } from '@anthropic-ai/claude-agent-sdk';
 
 export interface ContextUsage {
   readonly used: number;
@@ -131,7 +131,7 @@ export class UsageTracker {
     this.lastAssistantUsage = usage;
   }
 
-  public onResult(msg: SDKResultSuccess): void {
+  public onResult(msg: SDKResultMessage): void {
     this.cumulativeCost += msg.total_cost_usd;
 
     // Extract context window from modelUsage (use the largest, typically the primary model)
@@ -140,6 +140,7 @@ export class UsageTracker {
         this.lastContextWindow = mu.contextWindow;
       }
     }
+
     this.processedMessageIds.clear();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,31 +175,29 @@ async function submit(override?: string): Promise<void> {
           } else {
             logEvent(`result: ${msg.subtype} cost=$${msg.total_cost_usd.toFixed(4)} turns=${msg.num_turns} duration=${msg.duration_ms}ms`);
           }
-
-          usage.onResult(msg);
-
-          if (!sdkResult.noTokens) {
-            for (const [model, mu] of Object.entries(msg.modelUsage)) {
-              const shortModel = model.replace(/^claude-/, '');
-              const input = (mu.inputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0);
-              const output = mu.outputTokens ?? 0;
-              const window = mu.contextWindow ?? 0;
-              const pct = window > 0 ? ` (${((input / window) * 100).toFixed(1)}%)` : '';
-              logEvent(`  ${shortModel}: in=${input.toLocaleString()}${window > 0 ? `/${window.toLocaleString()}` : ''}${pct} out=${output.toLocaleString()} $${mu.costUSD.toFixed(4)}`);
-              if (mu.cacheReadInputTokens || mu.cacheCreationInputTokens) {
-                logEvent(`    cache: read=${(mu.cacheReadInputTokens ?? 0).toLocaleString()} created=${(mu.cacheCreationInputTokens ?? 0).toLocaleString()} uncached=${(mu.inputTokens ?? 0).toLocaleString()}`);
-              }
-            }
-
-            const ctx = usage.context;
-            if (ctx) {
-              logEvent(`  ${formatContext(ctx)}`);
-            }
-            logEvent(`  session: $${usage.sessionCost.toFixed(4)}`);
-          }
         } else {
-          logEvent(`\x1b[31mresult: ERROR ${msg.subtype} (${msg.duration_ms}ms) ${msg.errors.join(', ')}\x1b[0m`, msg);
+          logEvent(`\x1b[31mresult: ERROR ${msg.subtype} (${msg.duration_ms}ms) ${msg.errors.join(', ')}\x1b[0m`);
         }
+
+        usage.onResult(msg);
+
+        for (const [model, mu] of Object.entries(msg.modelUsage)) {
+          const shortModel = model.replace(/^claude-/, '');
+          const input = (mu.inputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0);
+          const output = mu.outputTokens ?? 0;
+          const window = mu.contextWindow ?? 0;
+          const pct = window > 0 ? ` (${((input / window) * 100).toFixed(1)}%)` : '';
+          logEvent(`  ${shortModel}: in=${input.toLocaleString()}${window > 0 ? `/${window.toLocaleString()}` : ''}${pct} out=${output.toLocaleString()} $${mu.costUSD.toFixed(4)}`);
+          if (mu.cacheReadInputTokens || mu.cacheCreationInputTokens) {
+            logEvent(`    cache: read=${(mu.cacheReadInputTokens ?? 0).toLocaleString()} created=${(mu.cacheCreationInputTokens ?? 0).toLocaleString()} uncached=${(mu.inputTokens ?? 0).toLocaleString()}`);
+          }
+        }
+
+        const ctx = usage.context;
+        if (ctx) {
+          logEvent(`  ${formatContext(ctx)}`);
+        }
+        logEvent(`  session: $${usage.sessionCost.toFixed(4)}`);
         break;
       }
       case 'stream_event':

--- a/src/session.ts
+++ b/src/session.ts
@@ -45,7 +45,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
       cwd: process.cwd(),
       settingSources: ['local', 'project', 'user'],
       allowedTools: [...READ_ONLY_TOOLS],
-      maxTurns: 25,
+      maxTurns: 100,
       includePartialMessages: true,
       abortController: abort,
       ...(this.sessionId ? { resume: this.sessionId } : {}),


### PR DESCRIPTION
## Summary
- Move `onResult()`, model usage logging, context display, and session cost outside the success-only block so they display for both success and error results
- Change `onResult` to accept `SDKResultMessage` (union of success + error) instead of `SDKResultSuccess`
- Bump `maxTurns` from 25 to 100

Closes #12