### PR TITLE
Add messageId display and ANSI reset for log lines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,9 @@ async function submit(override?: string): Promise<void> {
         }
         break;
       case 'assistant': {
+        const ctx = usage.context;
+        const pctSuffix = ctx ? ` (${ctx.percent.toFixed(1)}%)` : '';
+        logEvent(`\x1b[2mmessageId: ${msg.uuid}${pctSuffix}\x1b[0m`);
         for (const block of msg.message.content) {
           if (block.type === 'text') {
             logEvent(`assistant: ${block.text}`);
@@ -363,6 +366,10 @@ async function start(): Promise<void> {
     session.setSessionId(savedSession);
     term.info(`Resuming session: ${savedSession}`);
     usage.loadContextFromAudit(paths.auditFile, savedSession);
+    const lastAssistant = usage.lastAssistant;
+    if (lastAssistant) {
+      term.info(`\x1b[2mlast messageId: ${lastAssistant.uuid}\x1b[0m`);
+    }
     const ctx = usage.context;
     if (ctx) {
       term.info(formatContext(ctx));

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -10,7 +10,7 @@ export class Terminal {
   }
 
   public logLine(message: string, ...args: any[]): void {
-    process.stdout.write('[');
+    process.stdout.write('\x1b[0m[');
     process.stdout.write(this.timestamp());
     process.stdout.write('] ');
     process.stdout.write(message);


### PR DESCRIPTION
## Summary
- Display assistant messageId (UUID) with context % on each assistant message for self-service `/compact-at` recovery
- Show last messageId on session resume via `UsageTracker.lastAssistant`
- Add ANSI reset (`\x1b[0m`) at the start of `logLine()` to prevent colour bleed from truncated tool output

Closes #13
Closes #14