### PR TITLE
Add version and help support

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -6,7 +6,7 @@ import { glob } from 'glob';
 const watch = process.argv.some((x) => x === '--watch');
 const minify = !watch;
 
-const plugins = [cleanPlugin({ destructive: true }), versionPlugin({})];
+const plugins = [cleanPlugin({ destructive: true }), versionPlugin({ versionCalculator: 'git' })];
 
 const inject = await glob('./inject/*.ts');
 

--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -1,12 +1,12 @@
 import { appendFileSync } from 'node:fs';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
-import versionInfo from '@shellicar/build-version/version';
 import { AppState } from './AppState.js';
 import { AuditWriter } from './AuditWriter.js';
 import { getConfig, isInsideCwd } from './config.js';
 import { formatDiff } from './diff.js';
 import { backspace, clear, createEditor, deleteChar, deleteWord, deleteWordBackward, type EditorState, getText, insertChar, insertNewline, moveBufferEnd, moveBufferStart, moveDown, moveEnd, moveHome, moveLeft, moveRight, moveUp, moveWordLeft, moveWordRight } from './editor.js';
 import { discoverSkills, initFiles } from './files.js';
+import { printHelp, printVersion } from './help.js';
 import { type KeyAction, parseKeys } from './input.js';
 import { PermissionManager } from './PermissionManager.js';
 import { type AskQuestion, PromptManager } from './PromptManager.js';
@@ -47,6 +47,14 @@ export class ClaudeCli {
       this.cleanup();
       this.term.info('Goodbye.');
       process.exit(0);
+    }
+    if (trimmed === '/version') {
+      printVersion((msg) => this.term.info(msg));
+      return true;
+    }
+    if (trimmed === '/help') {
+      printHelp((msg) => this.term.info(msg));
+      return true;
     }
     if (trimmed === '/session' || trimmed.startsWith('/session ')) {
       const arg = trimmed.slice('/session'.length).trim();
@@ -378,7 +386,7 @@ export class ClaudeCli {
       return this.permissions.resolve(options?.toolUseID ?? '', input, signal);
     };
 
-    this.term.info(`claude-cli v${versionInfo.version}`);
+    printVersion((msg) => this.term.info(msg));
     this.term.info(`cwd: ${process.cwd()}`);
     this.term.info(`audit: ${paths.auditFile}`);
     this.term.info(`session file: ${paths.sessionFile}`);
@@ -404,7 +412,7 @@ export class ClaudeCli {
       this.term.info('Starting new session');
     }
     this.term.info('Enter = newline, Ctrl+Enter = send, Ctrl+C = quit');
-    this.term.info('Commands: /quit, /exit, /session [id], /compact-at <uuid>');
+    this.term.info('Commands: /help, /version, /quit, /exit, /session [id], /compact-at <uuid>');
     this.term.info('---');
 
     if (process.stdin.isTTY) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,0 +1,38 @@
+import versionInfo from '@shellicar/build-version/version';
+
+type Log = (msg: string) => void;
+
+export function printVersion(log: Log): void {
+  log(`claude-cli ${versionInfo.version}`);
+  log(`  branch:     ${versionInfo.branch}`);
+  log(`  sha:        ${versionInfo.sha}`);
+  log(`  shortSha:   ${versionInfo.shortSha}`);
+  log(`  commitDate: ${versionInfo.commitDate}`);
+  log(`  buildDate:  ${versionInfo.buildDate}`);
+}
+
+export function printUsage(log: Log): void {
+  log(`claude-cli ${versionInfo.version}`);
+  log('');
+  log('Usage: claude-cli [options]');
+  log('');
+  log('Options:');
+  log('  -v, --version  Show version information');
+  log('  -h, --help, -? Show this help message');
+}
+
+export function printHelp(log: Log): void {
+  log('Commands:');
+  log('  /version              Show version information');
+  log('  /help                 Show available commands');
+  log('  /session [id]         Show or switch session');
+  log('  /compact-at <uuid>    Compact at a specific message');
+  log('  /quit, /exit          Exit the CLI');
+  log('');
+  log('Controls:');
+  log('  Enter                 New line');
+  log('  Ctrl+Enter            Send message');
+  log('  Escape                Abort current query');
+  log('  Ctrl+C                Quit (any time)');
+  log('  Ctrl+D                Quit (at prompt)');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,26 @@
+import { parseArgs } from 'node:util';
 import { ClaudeCli } from './ClaudeCli.js';
+import { printUsage, printVersion } from './help.js';
+
+const { values } = parseArgs({
+  options: {
+    version: { type: 'boolean', short: 'v', default: false },
+    help: { type: 'boolean', short: 'h', default: false },
+  },
+  strict: false,
+});
+
+if (values.version) {
+  // biome-ignore lint/suspicious/noConsole: CLI --version output before app starts
+  printVersion(console.log);
+  process.exit(0);
+}
+
+if (values.help || process.argv.includes('-?')) {
+  // biome-ignore lint/suspicious/noConsole: CLI --help output before app starts
+  printUsage(console.log);
+  process.exit(0);
+}
 
 const cli = new ClaudeCli();
 await cli.start();


### PR DESCRIPTION
## Summary

- Switch build-version plugin from gitversion to git calculator
- Add --version/-v, --help/-h/-? CLI args via node:util parseArgs
- Add /version and /help in-session slash commands
- Extract shared printVersion, printUsage, printHelp functions

Co-Authored-By: Claude <noreply@anthropic.com>