### PR TITLE
Add /add-dir command for session-scoped additional directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "author": "Stephen Hellicar",
   "contributors": [
+    "BananaBot9000 <bananabot9000@bananabot.dev>",
     "Claude (Anthropic) <noreply@anthropic.com>"
   ],
   "repository": {

--- a/src/help.ts
+++ b/src/help.ts
@@ -27,6 +27,7 @@ export function printHelp(log: Log): void {
   log('  /help                 Show available commands');
   log('  /session [id]         Show or switch session');
   log('  /compact-at <uuid>    Compact at a specific message');
+  log('  /add-dir <path>       Add an additional directory');
   log('  /quit, /exit          Exit the CLI');
   log('');
   log('Controls:');

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
   private abort: AbortController | undefined;
   private activeQuery: Query | undefined;
   private aborted = false;
+  private additionalDirs: string[] = [];
   public canUseTool: CanUseTool | undefined;
 
   public get isActive(): boolean {
@@ -35,6 +36,16 @@ export class QuerySession extends EventEmitter<SessionEvents> {
     this.resumeAt = uuid;
   }
 
+  public addDirectory(dir: string): void {
+    if (!this.additionalDirs.includes(dir)) {
+      this.additionalDirs.push(dir);
+    }
+  }
+
+  public getAdditionalDirectories(): readonly string[] {
+    return this.additionalDirs;
+  }
+
   public async send(input: string, onMessage: (msg: SDKMessage) => void): Promise<void> {
     this.aborted = false;
     const abort = new AbortController();
@@ -51,6 +62,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
       ...(this.sessionId ? { resume: this.sessionId } : {}),
       ...(this.resumeAt ? { resumeSessionAt: this.resumeAt } : {}),
       ...(this.canUseTool ? { canUseTool: this.canUseTool } : {}),
+      ...(this.additionalDirs.length > 0 ? { additionalDirectories: this.additionalDirs } : {}),
     } satisfies Options;
 
     const q = query({ prompt: input, options });


### PR DESCRIPTION
## Summary

- Add `/add-dir <path>` command to grant Claude access to directories outside the working directory
- Redundant path detection prevents adding directories already accessible under cwd or existing additional dirs
- Additional directories are passed to the SDK's `additionalDirectories` option on every query
- Update README with command mode design and additional directories documentation
- Add BananaBot9000 as a contributor

Co-Authored-By: Claude <noreply@anthropic.com>