### PR TITLE
Add per-tool permission timeouts

### DIFF
--- a/src/PermissionManager.ts
+++ b/src/PermissionManager.ts
@@ -15,7 +15,15 @@ interface Waiter {
   resolve: (result: PermissionResult) => void;
 }
 
-const PERMISSION_TIMEOUT_MS = 60_000;
+function getTimeoutMs(toolName: string): number {
+  switch (toolName) {
+    case 'ExitPlanMode':
+    case 'EnterPlanMode':
+      return 120_000;
+    default:
+      return 30_000;
+  }
+}
 
 export class PermissionManager {
   private queue: PendingPermission[] = [];
@@ -176,7 +184,7 @@ export class PermissionManager {
     if (!current) {
       return;
     }
-    let remaining = Math.ceil(PERMISSION_TIMEOUT_MS / 1000);
+    let remaining = Math.ceil(getTimeoutMs(current.toolName) / 1000);
     const prefix = this.queue.length > 1 ? `[${this.currentIndex + 1}/${this.queue.length}] ` : '';
     this.appState.prompting(`${prefix}Allow? ${current.label} (y/n) [${remaining}s]`);
     this.timer = setInterval(() => {


### PR DESCRIPTION
## Summary

- Replace flat 60s permission timeout with per-tool timeout function
- ExitPlanMode and EnterPlanMode get 120s to allow reading plan content
- All other tools default to 30s

Co-Authored-By: Claude <noreply@anthropic.com>