### PR TITLE
Inject context usage and time into system prompt

### DIFF
--- a/src/UsageTracker.ts
+++ b/src/UsageTracker.ts
@@ -1,6 +1,7 @@
 import { closeSync, createReadStream, openSync, readSync, statSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import type { SDKMessage, SDKResultMessage } from '@anthropic-ai/claude-agent-sdk';
+import { OffsetDateTime } from '@js-joda/core';
 
 export interface ContextUsage {
   readonly used: number;
@@ -54,6 +55,7 @@ export class UsageTracker {
   private lastContextWindow = 0;
   private cumulativeCost = 0;
   private _lastAssistantUuid: string | undefined;
+  private _lastResultTime: OffsetDateTime | undefined;
 
   /** Load context usage from the tail of the audit file (sync, fast, 256KB). */
   public loadContextFromAudit(auditFile: string, sessionId: string): void {
@@ -145,6 +147,7 @@ export class UsageTracker {
   }
 
   public onResult(msg: SDKResultMessage): void {
+    this._lastResultTime = OffsetDateTime.now();
     this.cumulativeCost += msg.total_cost_usd;
 
     // Extract context window from modelUsage (use the largest, typically the primary model)
@@ -159,6 +162,10 @@ export class UsageTracker {
 
   public get sessionCost(): number {
     return this.cumulativeCost;
+  }
+
+  public get lastResultTime(): OffsetDateTime | undefined {
+    return this._lastResultTime;
   }
 
   public get lastAssistant(): LastAssistantInfo | undefined {

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,6 +15,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
   private aborted = false;
   private additionalDirs: string[] = [];
   public canUseTool: CanUseTool | undefined;
+  public systemPromptAppend: string | undefined;
 
   public get isActive(): boolean {
     return this.activeQuery !== undefined;
@@ -63,6 +64,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
       ...(this.resumeAt ? { resumeSessionAt: this.resumeAt } : {}),
       ...(this.canUseTool ? { canUseTool: this.canUseTool } : {}),
       ...(this.additionalDirs.length > 0 ? { additionalDirectories: this.additionalDirs } : {}),
+      ...(this.systemPromptAppend ? { systemPrompt: { type: 'preset' as const, preset: 'claude_code' as const, append: this.systemPromptAppend } } : {}),
     } satisfies Options;
 
     const q = query({ prompt: input, options });


### PR DESCRIPTION
## Summary

- Append context usage, current time, and session cost to the SDK system prompt each query
- Clear stale context data on compact_boundary messages
- Add time delta since last response to help detect stale tool output
- Use js-joda OffsetDateTime for time tracking

## Changes

- Add `buildSystemPromptAppend()` in ClaudeCli to construct dynamic system prompt metadata
- Pass `systemPrompt.append` to SDK options via `QuerySession.systemPromptAppend`
- Handle `compact_boundary` in `UsageTracker.onMessage()` to clear stale context
- Track `lastResultTime` as `OffsetDateTime` for time delta calculation

Co-Authored-By: Claude <noreply@anthropic.com>