### PR TITLE
Refactor system prompt into modular providers

### DIFF
--- a/src/SystemPromptBuilder.ts
+++ b/src/SystemPromptBuilder.ts
@@ -1,0 +1,24 @@
+export interface SystemPromptProvider {
+  readonly name: string;
+  readonly enabled: boolean;
+  getSections(): Promise<Array<string | undefined>>;
+}
+
+export class SystemPromptBuilder {
+  private readonly providers: SystemPromptProvider[] = [];
+
+  public add(provider: SystemPromptProvider): void {
+    this.providers.push(provider);
+  }
+
+  public async build(): Promise<string | undefined> {
+    const enabled = this.providers.filter((p) => p.enabled);
+    if (enabled.length === 0) {
+      return undefined;
+    }
+
+    const results = await Promise.all(enabled.map((p) => p.getSections()));
+    const parts = results.flat().filter((s): s is string => s !== undefined);
+    return parts.length > 0 ? parts.join('\n\n') : undefined;
+  }
+}

--- a/src/providers/GitProvider.ts
+++ b/src/providers/GitProvider.ts
@@ -1,0 +1,48 @@
+import type { SystemPromptProvider } from '../SystemPromptBuilder';
+import { DEFAULT_GIT_FEATURES } from './consts';
+import { execFileAsync } from './execFileAsync';
+import type { GitFeatures } from './types';
+
+export class GitProvider implements SystemPromptProvider {
+  public readonly name = 'git';
+  public readonly enabled: boolean;
+  private readonly features: GitFeatures;
+
+  public constructor(enabled = true, features: Partial<GitFeatures> = {}) {
+    this.enabled = enabled;
+    this.features = { ...DEFAULT_GIT_FEATURES, ...features };
+  }
+
+  public async getSections(): Promise<Array<string | undefined>> {
+    return [this.features.branch ? await this.buildBranch() : undefined, this.features.status ? await this.buildStatus() : undefined];
+  }
+
+  private async buildBranch(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+        timeout: 3000,
+        encoding: 'utf8',
+      });
+      const branch = stdout.trim();
+      if (!branch) {
+        return undefined;
+      }
+      return `# gitBranch\n${branch}`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async buildStatus(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
+        timeout: 3000,
+        encoding: 'utf8',
+      });
+      const dirty = stdout.trim().length > 0;
+      return `# gitStatus\nWorking tree: ${dirty ? 'dirty' : 'clean'}`;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/providers/UsageProvider.ts
+++ b/src/providers/UsageProvider.ts
@@ -1,0 +1,47 @@
+import { Duration, OffsetDateTime } from '@js-joda/core';
+import type { SystemPromptProvider } from '../SystemPromptBuilder';
+import type { UsageTracker } from '../UsageTracker';
+import { DEFAULT_USAGE_FEATURES, SYSTEM_TIME_FORMAT } from './consts';
+import type { UsageFeatures } from './types';
+
+export class UsageProvider implements SystemPromptProvider {
+  public readonly name = 'usage';
+  public readonly enabled: boolean;
+  private readonly features: UsageFeatures;
+
+  public constructor(
+    private readonly usage: UsageTracker,
+    enabled = true,
+    features: Partial<UsageFeatures> = {},
+  ) {
+    this.enabled = enabled;
+    this.features = { ...DEFAULT_USAGE_FEATURES, ...features };
+  }
+
+  public async getSections(): Promise<Array<string | undefined>> {
+    return [this.features.time ? this.buildTime() : undefined, this.features.context ? this.buildContext() : undefined, this.features.cost ? this.buildCost() : undefined];
+  }
+
+  private buildTime(): string {
+    const now = OffsetDateTime.now();
+    const lastResult = this.usage.lastResultTime;
+    const sinceLast = lastResult ? `${Duration.between(lastResult, now).seconds()}s since last response` : 'first message';
+    return `# currentTime\n${now.format(SYSTEM_TIME_FORMAT)} (${sinceLast})\nIf significant time has passed, re-read files and re-check state rather than relying on previous tool output.`;
+  }
+
+  private buildContext(): string | undefined {
+    const ctx = this.usage.context;
+    if (!ctx) {
+      return undefined;
+    }
+    return `# contextUsage\nContext: ${ctx.used}/${ctx.window}\nThis is updated every user message with the latest token count from the previous assistant response.`;
+  }
+
+  private buildCost(): string | undefined {
+    const cost = this.usage.sessionCost;
+    if (cost <= 0) {
+      return undefined;
+    }
+    return `# sessionCost\nSession: $${cost.toFixed(4)}`;
+  }
+}

--- a/src/providers/consts.ts
+++ b/src/providers/consts.ts
@@ -1,0 +1,15 @@
+import { DateTimeFormatter } from '@js-joda/core';
+import type { GitFeatures, UsageFeatures } from './types';
+
+export const SYSTEM_TIME_FORMAT = DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss.SSS xxx');
+
+export const DEFAULT_USAGE_FEATURES: UsageFeatures = {
+  time: true,
+  context: true,
+  cost: true,
+} satisfies UsageFeatures;
+
+export const DEFAULT_GIT_FEATURES: GitFeatures = {
+  branch: true,
+  status: true,
+} satisfies GitFeatures;

--- a/src/providers/execFileAsync.ts
+++ b/src/providers/execFileAsync.ts
@@ -1,0 +1,4 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+export const execFileAsync = promisify(execFile);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,10 @@
+export interface UsageFeatures {
+  readonly time: boolean;
+  readonly context: boolean;
+  readonly cost: boolean;
+}
+
+export interface GitFeatures {
+  readonly branch: boolean;
+  readonly status: boolean;
+}


### PR DESCRIPTION
## Summary

- Refactor hardcoded system prompt building into modular provider architecture
- Add SystemPromptProvider interface and SystemPromptBuilder for extensible prompt composition
- Extract usage tracking (time, context, cost) into UsageProvider with toggleable sub-features
- Add GitProvider to inject current branch and working tree status into system prompt
- Log system prompt append to terminal for debugging

Co-Authored-By: Claude <noreply@anthropic.com>