### PR TITLE
Add project CLAUDE.md with shellicar-oss conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Claude CLI — Project Instructions
+
+## Convention
+
+This repository uses `shellicar-oss` conventions.
+
+## Milestone
+
+All work is tracking toward the `1.0.0` milestone.
+
+## Pull Requests
+
+Every PR must include:
+
+- **Milestone**: `1.0.0`
+- **Reviewer**: `bananabot9000`
+- **Assignee**: `shellicar`
+- **Label**: one of `bug`, `enhancement`, or `documentation` (pick the most appropriate)
+
+## Branch Naming
+
+Use the following prefixes:
+
+- `feature/` — new functionality
+- `fix/` — bug fixes
+- `docs/` — documentation-only changes
+
+## Build
+
+Run `pnpm build` before committing to verify the project compiles.
+
+## System Prompt
+
+The CLI injects a system prompt append before each SDK query. This is built by `SystemPromptBuilder` using modular `SystemPromptProvider` implementations in `src/providers/`. The system prompt should NOT be built or sent for local commands (e.g. `/compact`, `/help`) that don't invoke the SDK.


### PR DESCRIPTION
## Summary

- Adds project-level `CLAUDE.md` with instructions for Claude Code
- Switches convention from `shellicar` to `shellicar-oss` to match the new `@shellicar/` directory location
- Documents PR requirements (milestone, reviewer, assignee, label), branch naming, build checks, and system prompt architecture

## Changes

- New `CLAUDE.md` with project instructions including convention, milestone tracking, PR requirements, branch naming, build verification, and system prompt documentation

Co-Authored-By: Claude <noreply@anthropic.com>