### PR TITLE
Add auto-merge requirement to PR checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Every PR must include:
 - **Reviewer**: `bananabot9000`
 - **Assignee**: `shellicar`
 - **Label**: one of `bug`, `enhancement`, or `documentation` (pick the most appropriate)
+- **Auto-merge**: enable with `gh pr merge --auto --squash`
 
 ## Branch Naming
 


### PR DESCRIPTION
## Summary

- Add auto-merge with squash as a required step in the PR checklist
- Ensures the github-pr workflow preference is captured directly in project instructions

Co-Authored-By: Claude <noreply@anthropic.com>