### PR TITLE
Skip system prompt for /compact command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Use the following prefixes:
 
 ## Build
 
-Run `pnpm build` before committing to verify the project compiles.
+Run `pnpm type-check` and `pnpm build` before committing to verify types and compilation.
 
 ## System Prompt
 

--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -240,9 +240,14 @@ export class ClaudeCli {
 
     try {
       this.redraw();
-      this.session.systemPromptAppend = await this.promptBuilder.build();
-      if (this.session.systemPromptAppend) {
-        this.term.log('systemPromptAppend: ' + this.session.systemPromptAppend.replaceAll('\n', '\\n'));
+      const isCompact = text === '/compact';
+      if (isCompact) {
+        this.session.systemPromptAppend = undefined;
+      } else {
+        this.session.systemPromptAppend = await this.promptBuilder.build();
+        if (this.session.systemPromptAppend) {
+          this.term.log('systemPromptAppend: ' + this.session.systemPromptAppend.replaceAll('\n', '\\n'));
+        }
       }
       await this.session.send(text, onMessage);
     } catch (err) {


### PR DESCRIPTION
## Summary

- Skip building system prompt append when sending /compact to the SDK
- Update CLAUDE.md build section to require both type-check and build

Co-Authored-By: Claude <noreply@anthropic.com>