### PR TITLE
Auto-approve Skill tool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 
 /** Tools that are always safe to auto-approve (via SDK allowedTools) */
-export const READ_ONLY_TOOLS = ['Read', 'Glob', 'Grep', 'LS'];
+export const READ_ONLY_TOOLS = ['Read', 'Glob', 'Grep', 'LS', 'Skill'];
 
 export interface Config {
   /** Auto-approve Edit and Write tools for files inside cwd */


### PR DESCRIPTION
## Summary

- Add `Skill` to `READ_ONLY_TOOLS` so the SDK auto-approves it without prompting
- Skills only load text content and are safe to run without user confirmation
- Eliminates unnecessary permission prompts when Claude invokes skills