### PR TITLE
Fix stale context percentage after compaction

### DIFF
--- a/src/UsageTracker.ts
+++ b/src/UsageTracker.ts
@@ -67,6 +67,11 @@ export class UsageTracker {
           continue;
         }
 
+        // Compact boundary means everything before this is stale — stop looking
+        if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+          break;
+        }
+
         if (entry.type === 'result' && entry.subtype === 'success' && !this.lastContextWindow) {
           const modelUsage = entry.modelUsage as Record<string, { contextWindow: number }> | undefined;
           if (modelUsage) {


### PR DESCRIPTION
## Summary

- Stop reading audit entries before a compact boundary when loading context usage at startup
- Prevents showing inflated context percentage from pre-compaction data
- Matches existing runtime behaviour where compact_boundary clears assistant usage