### PR TITLE
Fix emoji and multi-byte Unicode input

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -141,8 +141,8 @@ export function translateKey(ch: string | undefined, key: NodeKey | undefined): 
       return { type: 'escape' };
   }
 
-  // Regular printable character
-  if (ch && ch.length === 1 && ch >= ' ') {
+  // Regular printable character (supports multi-byte Unicode like emoji)
+  if (ch && [...ch].length === 1 && ch >= ' ') {
     return { type: 'char', value: ch };
   }
 


### PR DESCRIPTION
## Summary

- Fix ch.length check to use codepoint count instead of UTF-16 length
- Emoji and other multi-byte Unicode characters were silently dropped

Co-Authored-By: Claude <noreply@anthropic.com>