### PR TITLE
Validate /add-dir paths and fix term.error rendering

### DIFF
--- a/schema/cli-config.schema.json
+++ b/schema/cli-config.schema.json
@@ -51,6 +51,11 @@
       "default": true,
       "description": "Auto-approve read-only tools (Read, Glob, Grep, LS, Skill) without prompting",
       "type": "boolean"
+    },
+    "expandTilde": {
+      "default": true,
+      "description": "Expand ~ to home directory in /add-dir paths",
+      "type": "boolean"
     }
   },
   "title": "Claude CLI Configuration",

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -13,6 +13,7 @@ const cliConfigSchema = z
     drowningThreshold: z.int().min(0).nullable().optional().default(15).catch(15).describe('Seconds remaining on permission timer before the drowning alert (flashing + beep). Set to null to disable.'),
     autoApproveEdits: z.boolean().optional().default(true).catch(true).describe('Auto-approve Edit and Write tools for files inside the working directory'),
     autoApproveReads: z.boolean().optional().default(true).catch(true).describe('Auto-approve read-only tools (Read, Glob, Grep, LS, Skill) without prompting'),
+    expandTilde: z.boolean().optional().default(true).catch(true).describe('Expand ~ to home directory in /add-dir paths'),
   })
   .meta({ title: 'Claude CLI Configuration', description: 'Configuration for @shellicar/claude-cli' });
 
@@ -92,6 +93,7 @@ export function initConfig(log: (msg: string) => void): void {
       drowningThreshold: defaults.drowningThreshold,
       autoApproveEdits: defaults.autoApproveEdits,
       autoApproveReads: defaults.autoApproveReads,
+      expandTilde: defaults.expandTilde,
     },
     null,
     2,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -207,6 +207,6 @@ export class Terminal {
   }
 
   public error(message: string): void {
-    process.stderr.write(`Error: ${message}\n`);
+    this.writeHistory(`\x1b[31mError: ${message}\x1b[0m`);
   }
 }

--- a/test/cli-config.spec.ts
+++ b/test/cli-config.spec.ts
@@ -13,6 +13,7 @@ describe('parseCliConfig', () => {
         drowningThreshold: 15,
         autoApproveEdits: true,
         autoApproveReads: true,
+        expandTilde: true,
       });
     });
 
@@ -55,6 +56,11 @@ describe('parseCliConfig', () => {
     it('overrides autoApproveReads', () => {
       const config = parseCliConfig({ autoApproveReads: false });
       expect(config.autoApproveReads).toBe(false);
+    });
+
+    it('overrides expandTilde', () => {
+      const config = parseCliConfig({ expandTilde: false });
+      expect(config.expandTilde).toBe(false);
     });
   });
 
@@ -114,6 +120,11 @@ describe('parseCliConfig', () => {
     it('falls back autoApproveReads on number', () => {
       const config = parseCliConfig({ autoApproveReads: 1 });
       expect(config.autoApproveReads).toBe(true);
+    });
+
+    it('falls back expandTilde on string', () => {
+      const config = parseCliConfig({ expandTilde: 'yes' });
+      expect(config.expandTilde).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Validate /add-dir paths exist and are directories
- Expand ~ to home directory in /add-dir paths (configurable)
- Fix errors not displaying in the terminal