### PR TITLE
Add git SHA and configurable provider features

### DIFF
--- a/schema/cli-config.schema.json
+++ b/schema/cli-config.schema.json
@@ -56,6 +56,96 @@
       "default": true,
       "description": "Expand ~ to home directory in /add-dir paths",
       "type": "boolean"
+    },
+    "providers": {
+      "default": {
+        "git": {
+          "enabled": true,
+          "branch": true,
+          "status": true,
+          "sha": true
+        },
+        "usage": {
+          "enabled": true,
+          "time": true,
+          "context": true,
+          "cost": true
+        }
+      },
+      "description": "System prompt provider configuration",
+      "type": "object",
+      "properties": {
+        "git": {
+          "default": {
+            "enabled": true,
+            "branch": true,
+            "status": true,
+            "sha": true
+          },
+          "description": "Git provider configuration",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable the git provider",
+              "type": "boolean"
+            },
+            "branch": {
+              "default": true,
+              "description": "Show current branch name",
+              "type": "boolean"
+            },
+            "status": {
+              "default": true,
+              "description": "Show working tree status (dirty/clean)",
+              "type": "boolean"
+            },
+            "sha": {
+              "default": true,
+              "description": "Show short commit SHA with -dirty suffix",
+              "type": "boolean"
+            }
+          },
+          "required": ["enabled", "branch", "status", "sha"],
+          "additionalProperties": false
+        },
+        "usage": {
+          "default": {
+            "enabled": true,
+            "time": true,
+            "context": true,
+            "cost": true
+          },
+          "description": "Usage provider configuration",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable the usage provider",
+              "type": "boolean"
+            },
+            "time": {
+              "default": true,
+              "description": "Show current time and seconds since last response",
+              "type": "boolean"
+            },
+            "context": {
+              "default": true,
+              "description": "Show context usage percentage",
+              "type": "boolean"
+            },
+            "cost": {
+              "default": true,
+              "description": "Show session cost",
+              "type": "boolean"
+            }
+          },
+          "required": ["enabled", "time", "context", "cost"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["git", "usage"],
+      "additionalProperties": false
     }
   },
   "title": "Claude CLI Configuration",

--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -485,8 +485,12 @@ export class ClaudeCli {
 
     updateConfig({ autoApproveEdits: config.autoApproveEdits, autoApproveReads: config.autoApproveReads });
 
-    this.promptBuilder.add(new UsageProvider(this.usage));
-    this.promptBuilder.add(new GitProvider());
+    if (config.providers.usage.enabled) {
+      this.promptBuilder.add(new UsageProvider(this.usage, config.providers.usage));
+    }
+    if (config.providers.git.enabled) {
+      this.promptBuilder.add(new GitProvider(config.providers.git));
+    }
 
     this.session.canUseTool = (toolName, input, options) => {
       // Guard: if the query is no longer active, deny immediately.

--- a/src/SystemPromptBuilder.ts
+++ b/src/SystemPromptBuilder.ts
@@ -1,6 +1,5 @@
 export interface SystemPromptProvider {
   readonly name: string;
-  readonly enabled: boolean;
   getSections(): Promise<Array<string | undefined>>;
 }
 
@@ -12,12 +11,11 @@ export class SystemPromptBuilder {
   }
 
   public async build(): Promise<string | undefined> {
-    const enabled = this.providers.filter((p) => p.enabled);
-    if (enabled.length === 0) {
+    if (this.providers.length === 0) {
       return undefined;
     }
 
-    const results = await Promise.all(enabled.map((p) => p.getSections()));
+    const results = await Promise.all(this.providers.map((p) => p.getSections()));
     const parts = results.flat().filter((s): s is string => s !== undefined);
     return parts.length > 0 ? parts.join('\n\n') : undefined;
   }

--- a/src/providers/GitProvider.ts
+++ b/src/providers/GitProvider.ts
@@ -1,20 +1,14 @@
 import type { SystemPromptProvider } from '../SystemPromptBuilder';
-import { DEFAULT_GIT_FEATURES } from './consts';
 import { execFileAsync } from './execFileAsync';
 import type { GitFeatures } from './types';
 
 export class GitProvider implements SystemPromptProvider {
   public readonly name = 'git';
-  public readonly enabled: boolean;
-  private readonly features: GitFeatures;
 
-  public constructor(enabled = true, features: Partial<GitFeatures> = {}) {
-    this.enabled = enabled;
-    this.features = { ...DEFAULT_GIT_FEATURES, ...features };
-  }
+  public constructor(private readonly features: GitFeatures) {}
 
   public async getSections(): Promise<Array<string | undefined>> {
-    return [this.features.branch ? await this.buildBranch() : undefined, this.features.status ? await this.buildStatus() : undefined];
+    return [this.features.branch ? await this.buildBranch() : undefined, this.features.sha ? await this.buildSha() : undefined, this.features.status ? await this.buildStatus() : undefined];
   }
 
   private async buildBranch(): Promise<string | undefined> {
@@ -28,6 +22,23 @@ export class GitProvider implements SystemPromptProvider {
         return undefined;
       }
       return `# gitBranch\n${branch}`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async buildSha(): Promise<string | undefined> {
+    try {
+      const { stdout: sha } = await execFileAsync('git', ['rev-parse', '--short', 'HEAD'], {
+        timeout: 3000,
+        encoding: 'utf8',
+      });
+      const { stdout: status } = await execFileAsync('git', ['status', '--porcelain'], {
+        timeout: 3000,
+        encoding: 'utf8',
+      });
+      const dirty = status.trim().length > 0;
+      return `# gitSha\n${sha.trim()}${dirty ? '-dirty' : ''}`;
     } catch {
       return undefined;
     }

--- a/src/providers/UsageProvider.ts
+++ b/src/providers/UsageProvider.ts
@@ -1,22 +1,16 @@
 import { Duration, OffsetDateTime } from '@js-joda/core';
 import type { SystemPromptProvider } from '../SystemPromptBuilder';
 import type { UsageTracker } from '../UsageTracker';
-import { DEFAULT_USAGE_FEATURES, SYSTEM_TIME_FORMAT } from './consts';
+import { SYSTEM_TIME_FORMAT } from './consts';
 import type { UsageFeatures } from './types';
 
 export class UsageProvider implements SystemPromptProvider {
   public readonly name = 'usage';
-  public readonly enabled: boolean;
-  private readonly features: UsageFeatures;
 
   public constructor(
     private readonly usage: UsageTracker,
-    enabled = true,
-    features: Partial<UsageFeatures> = {},
-  ) {
-    this.enabled = enabled;
-    this.features = { ...DEFAULT_USAGE_FEATURES, ...features };
-  }
+    private readonly features: UsageFeatures,
+  ) {}
 
   public async getSections(): Promise<Array<string | undefined>> {
     return [this.features.time ? this.buildTime() : undefined, this.features.context ? this.buildContext() : undefined, this.features.cost ? this.buildCost() : undefined];

--- a/src/providers/consts.ts
+++ b/src/providers/consts.ts
@@ -1,15 +1,3 @@
 import { DateTimeFormatter } from '@js-joda/core';
-import type { GitFeatures, UsageFeatures } from './types';
 
 export const SYSTEM_TIME_FORMAT = DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss.SSS xxx');
-
-export const DEFAULT_USAGE_FEATURES: UsageFeatures = {
-  time: true,
-  context: true,
-  cost: true,
-} satisfies UsageFeatures;
-
-export const DEFAULT_GIT_FEATURES: GitFeatures = {
-  branch: true,
-  status: true,
-} satisfies GitFeatures;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -7,4 +7,5 @@ export interface UsageFeatures {
 export interface GitFeatures {
   readonly branch: boolean;
   readonly status: boolean;
+  readonly sha: boolean;
 }


### PR DESCRIPTION
## Summary

- Show short commit SHA with -dirty suffix in system prompt
- Make provider features configurable via cli-config.json
- Move enabled check to wiring site, simplify provider constructors

Co-Authored-By: Claude <noreply@anthropic.com>