### PR TITLE
Fix sharp dependency error and catch unsupported BMP

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -29,7 +29,7 @@ const ctx = await esbuild.context({
   treeShaking: true,
   dropLabels: ['DEBUG'],
   tsconfig: 'tsconfig.json',
-  external: ['@anthropic-ai/claude-agent-sdk'],
+  external: ['@anthropic-ai/claude-agent-sdk', 'sharp'],
 });
 
 if (watch) {

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -78,6 +78,9 @@ function bmpToPng(buf: Buffer): Promise<Buffer> {
   const width = buf.readUInt32LE(18);
   let height = buf.readInt32LE(22);
   const bpp = buf.readUInt16LE(28);
+  if (bpp !== 24 && bpp !== 32) {
+    throw new Error(`Unsupported BMP bit depth: ${bpp}bpp (only 24/32 supported)`);
+  }
 
   const bottomUp = height > 0;
   height = Math.abs(height);


### PR DESCRIPTION
## Summary

- Fix sharp not loading when running from bundled dist output
- Reject unsupported BMP bit depths instead of producing garbage

Co-Authored-By: Claude <noreply@anthropic.com>