### PR TITLE
Bump version to 1.0.0-alpha.61

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,16 @@ jobs:
       - run: pnpm audit
       - run: pnpm i --frozen-lockfile
       - run: pnpm run build
+      - name: Verify build version
+        run: |
+          EXPECTED=$(gitversion -showvariable SemVer)
+          ACTUAL=$(node dist/main.js --version)
+          echo "Expected: $EXPECTED"
+          echo "Actual:   $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "Version mismatch!"
+            exit 1
+          fi
       - run: pnpm run type-check
       - run: pnpm run ci:fix
       - name: Verify release tag matches package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-cli",
-  "version": "1.0.0-alpha.60",
+  "version": "1.0.0-alpha.61",
   "private": false,
   "type": "module",
   "description": "Interactive CLI for Claude AI with terminal UI",


### PR DESCRIPTION
## Summary

- Bump version to 1.0.0-alpha.61
- Add build version verification to publish workflow

Co-Authored-By: Claude <noreply@anthropic.com>