### PR TITLE
Add attachment preview toggle in command mode

### DIFF
--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -382,6 +382,10 @@ export class ClaudeCli {
             this.attachmentStore.removeSelected();
             this.scheduleRedraw();
             break;
+          case 'preview':
+            this.commandMode.togglePreview();
+            this.scheduleRedraw();
+            break;
           case 'select-left':
             this.attachmentStore.selectLeft();
             this.scheduleRedraw();

--- a/src/CommandMode.ts
+++ b/src/CommandMode.ts
@@ -1,12 +1,17 @@
 import type { KeyAction } from './input.js';
 
-export type CommandAction = { type: 'none' } | { type: 'paste-image' } | { type: 'paste-text' } | { type: 'delete' } | { type: 'select-left' } | { type: 'select-right' } | { type: 'exit' };
+export type CommandAction = { type: 'none' } | { type: 'paste-image' } | { type: 'paste-text' } | { type: 'delete' } | { type: 'preview' } | { type: 'select-left' } | { type: 'select-right' } | { type: 'exit' };
 
 export class CommandMode {
   private _active = false;
+  private _previewActive = false;
 
   public get active(): boolean {
     return this._active;
+  }
+
+  public get previewActive(): boolean {
+    return this._previewActive;
   }
 
   public enter(): void {
@@ -15,6 +20,11 @@ export class CommandMode {
 
   public exit(): void {
     this._active = false;
+    this._previewActive = false;
+  }
+
+  public togglePreview(): void {
+    this._previewActive = !this._previewActive;
   }
 
   public toggle(): void {
@@ -35,6 +45,8 @@ export class CommandMode {
             return { type: 'paste-text' };
           case 'd':
             return { type: 'delete' };
+          case 'p':
+            return { type: 'preview' };
           default:
             return { type: 'none' };
         }

--- a/src/help.ts
+++ b/src/help.ts
@@ -48,6 +48,7 @@ export function printHelp(log: Log): void {
   log('  i                     Paste image from clipboard');
   log('  t                     Paste text from clipboard');
   log('  d                     Delete selected attachment');
+  log('  p                     Toggle attachment preview');
   log('  Left/Right            Select attachment');
   log('  Escape                Exit command mode');
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -176,10 +176,59 @@ export class Terminal {
       if (hasAtt) {
         b.text(' | ');
       }
-      b.text('i=image t=text d=delete \u2190\u2192=select ESC=exit');
+      b.text('i=image t=text d=delete ');
+      if (this.commandMode.previewActive) {
+        b.ansi(inverseOn);
+      }
+      b.text('p=preview');
+      if (this.commandMode.previewActive) {
+        b.ansi(inverseOff);
+      }
+      b.text(' \u2190\u2192=select ESC=exit');
     }
 
     return { line: b.output, screenLines: b.screenLines(columns) };
+  }
+
+  private buildPreviewLines(columns: number): { lines: string[]; screenLines: number } | null {
+    if (!this.commandMode.previewActive || !this.attachmentStore.hasAttachments) {
+      return null;
+    }
+    const idx = this.attachmentStore.selectedIndex;
+    if (idx < 0) {
+      return null;
+    }
+    const att = this.attachmentStore.attachments[idx];
+    const maxWidth = columns - 2;
+    const lines: string[] = [];
+
+    switch (att.kind) {
+      case 'text': {
+        const textLines = att.text.split('\n');
+        const showLines = textLines.slice(0, 3);
+        for (const line of showLines) {
+          const truncated = line.length > maxWidth ? `${line.slice(0, maxWidth - 1)}\u2026` : line;
+          lines.push(`  ${truncated}`);
+        }
+        const remaining = textLines.length - showLines.length;
+        if (remaining > 0) {
+          lines.push(`  \u2026 (${remaining} more line${remaining === 1 ? '' : 's'})`);
+        }
+        break;
+      }
+      case 'image': {
+        const sizeKB = Math.ceil(att.sizeBytes / 1024);
+        const hashPrefix = att.hash.slice(0, 8);
+        lines.push(`  image/png ${sizeKB}KB sha256:${hashPrefix}`);
+        break;
+      }
+    }
+
+    let screenLines = 0;
+    for (const line of lines) {
+      screenLines += Math.max(1, Math.ceil(line.length / columns));
+    }
+    return { lines, screenLines };
   }
 
   private buildSticky(): string {
@@ -205,6 +254,17 @@ export class Terminal {
       attachmentScreenLines = attachmentLine.screenLines;
     }
 
+    // Build preview lines
+    let previewScreenLines = 0;
+    const preview = this.buildPreviewLines(columns);
+    if (preview) {
+      for (const line of preview.lines) {
+        output += '\n';
+        output += clearLine + line;
+      }
+      previewScreenLines = preview.screenLines;
+    }
+
     // Build editor lines
     let editorScreenLines = 0;
     for (let i = 0; i < this.editorContent.lines.length; i++) {
@@ -227,7 +287,7 @@ export class Terminal {
     output += cursorTo(this.editorContent.cursorCol);
     output += this.cursorHidden ? hideCursorSeq : showCursor;
 
-    this.stickyLineCount = statusScreenLines + attachmentScreenLines + editorScreenLines;
+    this.stickyLineCount = statusScreenLines + attachmentScreenLines + previewScreenLines + editorScreenLines;
 
     return output;
   }


### PR DESCRIPTION
## Summary

- Add `p` toggle in command mode to preview the selected attachment
- Text attachments show first 3 lines with truncation
- Image attachments show media type, size, and hash prefix
- Highlight `p=preview` in instructions when preview is active

Co-Authored-By: Claude <noreply@anthropic.com>