### PR TITLE
Split README into focused docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,39 @@
-# claude-cli
+# @shellicar/claude-cli
 
-A terminal-friendly Claude Code CLI built on the Claude Agent SDK — without React Ink.
+> A terminal-friendly Claude Code CLI built on the Claude Agent SDK — without React Ink.
 
-## Why
+The official Claude Code CLI uses React Ink for its TUI, which re-renders the entire terminal on every state change. In tmux (especially on WSL2), this floods the PTY with escape sequences and can deadlock the kernel write lock. This CLI uses the SDK directly with plain terminal I/O.
 
-The official Claude Code CLI uses React Ink for its TUI, which re-renders the entire terminal on every state change. In tmux (especially on WSL2), this floods the PTY with escape sequences and can deadlock the kernel write lock, freezing not just the session but the entire tmux server and sometimes the whole system.
+## Installation
 
-This CLI uses the SDK directly with plain terminal I/O. No virtual DOM, no full re-renders, no PTY flooding.
-
-## Status
-
-Proof of concept — functional and actively used for development.
+```sh
+pnpm add -g @shellicar/claude-cli
+```
 
 ## Features
 
-### Working
+- Multiline editor with word-level editing, Home/End, Ctrl+Home/End
+- Session resumption and auto-resume across restarts
+- Portable sessions — resume sessions from the official CLI or VS Code extension
+- Configurable auto-approve tiers (reads, edits in cwd)
+- Permission queue with configurable timeouts and drowning alert
+- Coloured diff display for Edit tool calls
+- Cost, context usage, and elapsed time tracking
+- System prompt providers (git branch/status, context %, session cost, current time)
+- Command mode (Ctrl+/) with clipboard image/text paste, attachment preview
+- Interactive question prompts with configurable timeout
+- Audit log for debugging (`.claude/audit.jsonl`)
+- Skills and hooks support via `settingSources`
 
-- Send messages to Claude via the Agent SDK
-- Stream responses to stdout
-- Multiline input — Enter inserts newline, Ctrl+Enter sends
-- Word-level editing — Ctrl+Backspace/Delete, Ctrl+Left/Right
-- Home/End, Ctrl+Home/End cursor navigation
-- Waiting indicator with elapsed time during SDK calls
-- Session resumption (`/session` to view, `/session <id>` to switch)
-- Auto-resume — persists session ID to `.claude/cli-session`, automatically resumes on restart
-- Session portability — sessions created by the official CLI or VS Code extension can be resumed (same cwd required)
-- `/quit` / `/exit`
-- Auto-approve edits — Edit/Write tools for files inside `cwd` are auto-approved, files outside prompt for confirmation
-- Coloured diff display — Edit tool calls show a unified diff instead of raw JSON
-- Permission queue with timeout — concurrent tool permission requests are queued, 5 minute timeout per prompt
-- Audit log — all SDK events written to `.claude/audit.jsonl` for debugging (`tail -f .claude/audit.jsonl` in another tmux pane)
-- Cost/turns/duration display on result messages
-- System prompt append — modular provider system injects context into Claude's system prompt per query:
-  - **Current time** with elapsed seconds since last response
-  - **Context usage** (percentage of context window used)
-  - **Session cost** (cumulative USD)
-  - **Git branch** (current branch name)
-  - **Git status** (dirty/clean working tree)
-- Per-tool permission timeouts — configurable timeout per tool type
+## Terminal Setup
 
-### Terminal Setup
-
-Ctrl+Enter requires custom keybindings in your terminal — most terminals send the same byte (`\r`) for both Enter and Ctrl+Enter.
+Ctrl+Enter requires a custom keybinding. Most terminals send the same byte for Enter and Ctrl+Enter.
 
 **Windows Terminal** — add to `settings.json`:
 
 ```json
 {
-    "command": { "action": "sendInput", "input": "\u001b[13;5u" },
+    "command": { "action": "sendInput", "input": "\\u001b[13;5u" },
     "id": "User.sendInput.CTRL_ENTER"
 }
 ```
@@ -62,334 +48,32 @@ Ctrl+Enter requires custom keybindings in your terminal — most terminals send 
 {
     "key": "ctrl+enter",
     "command": "workbench.action.terminal.sendSequence",
-    "args": { "text": "\u001b[13;5u" },
+    "args": { "text": "\\u001b[13;5u" },
     "when": "terminalFocus"
 }
 ```
 
-### Planned
+## Configuration
 
-#### Core
+Config file at `~/.claude/cli-config.json`. Run `claude-cli --init-config` to create defaults.
 
-- [x] Cost tracking — cumulative session cost from SDK result messages, displayed on each result and on startup
-- [x] Context window usage — token count/percentage on result messages and on startup, colour-coded (green <50%, yellow 50-80%, red >80%)
-- [x] Startup cost loading — streams full audit file via `readline` to sum all session costs (handles files of any size). Context uses a fast 256KB tail read (only needs the last assistant message).
-- [ ] Configurable auto-compact threshold (official CLI uses 80%)
-- [ ] Model selection — configure which Claude model to use
-- [x] Escape to cancel — interrupt in-progress SDK operations
-- [ ] Capture SDK stderr — the SDK process can exit with code 1 and no event data. Capture stderr for real error messages (already implemented in simple-claude-bot, can reference)
-- [ ] Extra directories — `/add-dir` command to add additional directories to the session context
-- [x] `/compact-at <uuid>` — compact at a specific message boundary by UUID, for recovering from context overflow
-- [x] Context usage display — shows token count and percentage of context window on result messages. Formula (proven exact match with official CLI): `input_tokens + cache_creation_input_tokens + cache_read_input_tokens + output_tokens` from the last assistant message, deduped by message `id`. Context window from `modelUsage[model].contextWindow`.
-- [x] Skip `stream_event` from audit log — prevents audit.jsonl blowout (was ~50% of all entries)
+Key options: `model`, `maxTurns`, `permissionTimeoutMs`, `extendedPermissionTimeoutMs`, `questionTimeoutMs`, `drowningThreshold`, `autoApproveEdits`, `autoApproveReads`, `providers`.
 
-#### System Prompt Providers
-
-The system prompt append uses a modular provider architecture (`SystemPromptProvider` interface + `SystemPromptBuilder`). Each provider can contribute multiple sections and be independently enabled/disabled with feature toggles. Providers run in parallel via `Promise.all`.
-
-Future provider ideas:
-- [x] Context usage threshold warning — when context exceeds 80%, appends a mandatory compact preparation warning instructing Claude to finish micro-tasks, write out what to preserve, and suggest compaction. Non-optional directive rather than a soft nudge
-- [ ] Configurable context thresholds — make the 80% threshold configurable, potentially with multiple tiers (50%, 80%) and different messages
-- [ ] Runtime toggling — `/toggle git` to enable/disable providers without recompiling
-- [ ] Provider latency tracking — log how long each provider takes to build its sections
-- [ ] `NodeProvider` — node version, package name/version from `package.json`
-- [ ] `EnvProvider` — OS, shell, platform info
-- [ ] User-configurable providers — define custom providers via config file
-
-#### Stream Events & Status
-
-The SDK emits `stream_event` messages containing Anthropic API streaming events (`message_start`, `content_block_start`, `content_block_delta`, etc.) and `system` messages with subtypes like `compacting`. Currently silenced and excluded from audit, but useful for:
-
-- [ ] **Activity indicators** — use `stream_event` deltas for real-time "thinking..." / typing animation / spinner, via `includePartialMessages` SDK option
-- [ ] **System status display** — surface `system` subtypes (`compacting`, `init`, etc.) in the status zone so you can see what the SDK is doing internally
-- [ ] **Streaming text preview** — optionally show partial assistant text as it arrives (before the full `assistant` message)
-- [ ] **Mid-response cost updates** — the official CLI updates the cost display during streaming (from `stream_event` usage data). Currently, cost only updates after each complete result. Processing `stream_event` messages would enable live cost tracking, but these are not currently written to the audit log (`AuditWriter` skips `stream_event` to prevent file blowout). Would need either selective auditing of usage-bearing stream events, or in-memory-only processing.
-
-#### Audit Log as Context Transfer
-
-The audit log (`.claude/audit.jsonl`) is a complete record of all SDK events — assistant messages, tool calls, tool results, system events. This makes it useful beyond debugging:
-
-- Paste relevant entries to another Claude for instant context on what happened
-- Replay/review sessions after the fact
-- Feed into dashboards or analytics
-
-#### Permissions & Settings
-
-Auto-approve tiers for tool calls:
-
-- [x] **Auto-approve reads** — Read/Glob/Grep/WebSearch/LS auto-approved without prompting
-- [x] **Auto-approve in cwd** — Edit/Write inside cwd auto-approved
-- [ ] **Bash safety — normalise, match, decide** (see below)
-- [ ] Auto-generated system prompt — generate a prompt snippet from config/safe lists so Claude knows what's auto-approved, what's blocked, and doesn't use unnecessary flags (e.g. `git -C` when already in the right cwd)
-- [x] Hooks support — enabled via `settingSources`, `PreToolUse` hooks fire from settings.json (e.g. block_dangerous_commands.sh)
-- [x] Skills support — enabled via `settingSources`, skills load and are invokable (e.g. `/git-commit`)
-- [ ] Persisted config file — back `config.ts` with a file (e.g. `~/.claude-cli/config.json`)
-- [x] `allowedTools` SDK option — Read/Glob/Grep/LS auto-approved at SDK level (bypasses `canUseTool` entirely)
-
-#### `AskUserQuestion` Tool
-
-The SDK's `AskUserQuestion` tool presents interactive questions with selectable options. Key findings:
-
-- `allowedTools` has **no effect** — the tool always goes through `canUseTool` regardless
-- Without a handler in `canUseTool`, it hits the raw permission prompt (`Allow? y/n`)
-- Denying returns `"User denied"` as the tool result
-- Approving returns an empty response (no interactive UI to capture the selection)
-- **Blocker for skills** that use `AskUserQuestion` (e.g. `git-commit` skill asks to confirm staging/commit message)
-
-To properly support this:
-
-- [x] Auto-approve `AskUserQuestion` in `canUseTool`
-- [x] Render questions and options as an interactive terminal prompt
-- [x] Capture user selection and return it as the tool result
-- [x] "Other" free-text option with inline text editing
-- [ ] Handle `multiSelect` mode (checkboxes vs radio)
-
-#### Background Task Permission Handling
-
-When Claude runs a Bash command with `run_in_background: true`, the SDK spawns a background task. If the task completes (or fails) after the current query's `result` message, the SDK emits a `task_notification` system message and automatically starts a new internal turn. During this auto-triggered turn, Claude may call tools — but the original query stream has already ended and our `canUseTool` handler is in a stale state.
-
-**Symptom**: `Error: Stream closed` on repeated tool permission requests, causing Claude to retry the same tool call multiple times before giving up.
-
-**Current mitigations** (error handling):
-- [x] Guard in `canUseTool` — checks `session.isActive` before processing; if inactive, denies immediately with a warning log
-- [x] Already-aborted signal check in `PermissionManager.resolve()` — if the abort signal is already fired, denies immediately instead of creating an orphaned waiter
-
-**Root cause fix** (not yet implemented):
-- [ ] Keep the query stream open while background tasks are still running — the `for await` loop in `session.ts` currently ends after the first `result` message, but the SDK may still need `canUseTool` for task_notification turns. Need to investigate whether the SDK stream stays open for these turns or if `canUseTool` is called from a separate context after the stream closes.
-
-#### Skill-Aware Auto-Approve
-
-When a skill workflow is active (e.g. `/git-commit`), user decisions made via `AskUserQuestion` can be used to auto-approve subsequent tool calls — building a trust chain from user intent through to execution.
-
-**Example: git-commit workflow**
-
-1. User approves staging files → auto-approve `git add` for those exact files
-2. User approves commit message "XYZ" → auto-approve `git commit -m "XYZ"` (exact match only)
-3. Workflow reaches push step → auto-approve `git push` (no force flags)
-
-Each auto-approve is derived from a previous user decision, not blind trust. Anything outside the expected workflow still prompts normally.
-
-**Implementation needs:**
-
-- [ ] Workflow context tracker — active skill, current step, accumulated user decisions
-- [ ] Expected-next-command matcher in `canUseTool` — compare incoming tool call against what the workflow predicts
-- [ ] Skills declare step sequences (or the CLI infers them from the tool call pattern)
-- [ ] Safety constraints — only auto-approve non-destructive variants (e.g. `git push` but never `git push --force`)
-
-#### Bash Safety (`bash-safety.ts`)
-
-Approving every Bash command is actually less safe than smart auto-approve — approval fatigue means you stop reading and just mash `y`. The goal is reducing noise so you only need to pay attention to genuinely ambiguous commands.
-
-**Flow: Normalise → Match → Decide**
-
-1. **Normalise** — resolve cwd-override flags before matching:
-   - `git -C /path status` → normalise to `git status` (with adjusted cwd)
-   - `pnpm --dir /path install` → normalise to `pnpm install`
-   - Strip cosmetic flags: `--color=always`, `--no-pager`, etc.
-2. **Match** against three tiers:
-   - **Green (auto-approve)** — read-only commands (delegated to SDK `permissions.allow` from `settings.json` via `settingSources`)
-   - **Red (auto-deny)** — destructive commands: `rm -rf`, `git push --force`, `git checkout .`, `git reset --hard`, `git clean`, `find...-delete`, `chmod -R`, etc.
-   - **Yellow (prompt)** — everything else, user decides
-3. **Chain detection** — commands with `&&`, `||`, `;`, `|` are either split and each part matched individually, or the whole thing goes to prompt. Prevents bypass like `git log; rm -rf /`.
-
-This handles ~95% of cases. The remaining 5% get prompted, but now you're actually reading those prompts because there are only a few per session.
-
-#### Smart Auto-Compact
-
-Automatic compaction at a configurable context window threshold (default ~80%), with three modes:
-
-- [ ] **Default** — standard SDK compaction behaviour
-- [ ] **Custom prompt** — user provides instructions for what to preserve
-- [ ] **Claude-generated prompt** — ask the active Claude to generate the compaction summary (best results, since it knows the conversation context)
-- [ ] `/compact` — manual compact command
-
-Remembers the last selected mode. Prevents the "forgot to compact and ran out of context" problem.
-
-#### Command Mode
-
-**Problem**: Currently, any input starting with `/` gets intercepted by `handleCommand`. This creates the same ambiguity the official CLI has — typing `/hello` in a message to Claude triggers command handling, and there's no way to distinguish "I want to run a local command" from "I want to invoke a skill" from "I typed a `/` in my message". Invalid commands get silently swallowed or sent to the SDK with unpredictable results.
-
-**Solution**: A dedicated command mode that is context-aware, with validation and autocomplete. Commands are never accidentally triggered from normal chat input.
-
-**Command types**:
-- **Local commands** — executed immediately by the CLI, never sent to SDK: `quit`, `exit`, `session`, `add-dir`, `version`, `help`, `compact-at`, `compact`
-- **Skill commands** — forwarded to the SDK as skill invocations: `git-commit`, `github-pr`, etc. The CLI knows which skills are available (from the skill registry loaded via `settingSources`) and provides autocomplete
-- **Unknown commands** — rejected with an error, never sent anywhere
-
-**Interaction model** (TBD — trigger mechanism):
-- `/` prefix enters command mode inline (current behaviour, but with validation)
-- Or a key combo (like tmux `Ctrl+B`) switches the input context entirely
-- Or `:` prefix (vim-style) for local commands, `/` for skills
-
-**Key requirements**:
-- [ ] Command validation — only known commands are accepted, unknown input is rejected with feedback
-- [ ] Skill-aware autocomplete — `/skill git-` shows `git-commit`, `git-cleanup`, etc. The skill list comes from the SDK's loaded skills
-- [ ] Skill shorthand — `/skill git-commit <args>` translates to `/git-commit <args>` sent to the SDK, or skills can be invoked directly by name if unambiguous
-- [ ] Tab completion / filtering with typeahead
-- [ ] Prompt buffer preserved — entering command mode doesn't lose your in-progress message
-- [ ] Local command registry — explicit list of commands the CLI handles locally
-- [ ] Skill registry — populated from `settingSources` skill loading, provides the list of available skills for autocomplete and validation
-
-#### Session Management
-
-- [x] View current session ID
-- [x] Switch sessions
-- [ ] List recent sessions
-
-#### Global Session Dashboard
-
-Central view of all Claude sessions across projects. Session data lives in `~/.claude/projects/` as `.jsonl` files — this feature would parse and present them.
-
-- [ ] List all sessions across all projects
-- [ ] Show session metadata — working directory, duration, context size, model, cost
-- [ ] Filter/search by project, date, or session content
-- [ ] Quick switch — resume any session from the dashboard
-- [ ] Session health — identify sessions nearing context limits
-- [ ] Prune/archive old sessions
-
-#### Terminal Rendering Zones
-
-The terminal needs three independent rendering zones to prevent output from clobbering prompts:
-
-1. **History zone** (top, scrollable) — logged messages, tool results, assistant text, diffs. Permanent and append-only.
-2. **Status/prompt zone** (bottom, fixed) — permission prompts ("Allow? y/n"), waiting indicators, progress. Always visible, replaces itself. Must stay at the bottom even when history updates above it.
-3. **Input zone** (very bottom, fixed) — the user's text editor area.
-
-Currently everything is dumped sequentially to stdout, so when parallel tool calls come in, the permission prompt gets buried under tool results and you can't tell what you're approving. This is the core rendering problem to solve.
-
-Scrolling is handled by the terminal/tmux — the CLI doesn't need to manage it. History is just appended to stdout normally. The key is: after writing to history, redraw the fixed status/input area at the bottom.
-
-Approach: ANSI cursor positioning — save/restore cursor, write history, then redraw status + input at the bottom. Core escape sequences: `\x1B[s`/`\x1B[u` (save/restore), `\x1B[<n>A`/`\x1B[<n>B` (move up/down), `\x1B[2K` (clear line). Could use `ansi-escapes` npm package as a clean wrapper, or just raw sequences — the logic is more important than the abstraction. No heavy TUI framework (blessed, terminal-kit are both unmaintained).
-
-- [ ] Implement zone-based rendering with fixed status/prompt area
-- [ ] Ensure permission prompt is always the latest visible line
-- [ ] Multi-line paste support — currently pastes corrupt the editor state/line management
-- [ ] Escape during permission prompt — pressing Escape returns to the input prompt but the permission callback remains pending, leaving the session in an inconsistent state. Escape should either deny the pending permission or cancel the entire query.
-
-#### Input & UX
-
-- [ ] Type-ahead — write the next message while Claude is still responding, send on completion (separate from message queueing)
-- [ ] Message queueing — queue multiple messages, execute sequentially
-- [ ] Tmux pane title integration — send status to tmux via `\033]2;...\033\\` escape sequences (similar to existing dotfiles `.prompt` pattern: `?` for pending, `O` for success, `X` for failure)
-- [ ] Configurable settings (persisted)
-- [ ] `/help` or `?` command listing
-
-#### Refactoring
-
-- [ ] Extract message rendering — the `switch` block in the message handler is growing, move to its own module
-- [ ] Extract permission handling — queue, timer, and `canUseTool` logic into `permissions.ts`
-- [ ] Slim down `index.ts` — currently handles editor, permissions, rendering, session management, keyboard, and startup
-
-## SDK vs CLI Findings
-
-Through testing, we discovered the boundary between what the Claude Agent SDK handles vs what the official CLI handles on top.
-
-### `settingSources` option
-
-Adding `settingSources: ['local', 'project', 'user']` to SDK options enables:
-
-- ✅ Skills loaded and invokable (git-commit, github-pr, etc.)
-- ✅ `PreToolUse` hooks firing (block_dangerous_commands.sh)
-- ✅ Settings.json being read
-- ✅ File change notifications (system reminders)
-- ✅ `permissions.deny` rules — confirmed working! Adding `"Bash"` and `"Edit"` to deny gives explicit `Error: No such tool available` when Claude tries to use them. Tools not in deny still work normally. (Clean retest with no `tools` option in code.)
-- ✅ Plugins loaded — audit log confirms `typescript-lsp` and `agent-sdk-dev` plugins are loaded in the init event, though LSP tool not directly observed
-- ❓ CLAUDE.md — SDK docs say `'project'` is required (which we have), but injection not confirmed. May be loading but not obvious without the protocol skills being invoked.
-- ❓ `permissionMode` from settings.json — audit log shows `"permissionMode": "default"` even though settings.json has `"defaultMode": "acceptEdits"`. The SDK option `permissionMode` must be passed explicitly in code; it does not read `defaultMode` from settings.json.
-
-**Important**: `allowedTools`, `tools`, and `disallowedTools` are different SDK options:
-- `allowedTools: ['Edit']` — Edit auto-approves without prompting (all tools still available)
-- `tools: ['Bash', 'Read']` — whitelist: ONLY Bash and Read exist (restricts available tools)
-- `tools: []` — SDK init confirms `"tools": []`, Claude still sees tools in system prompt but cannot call any (silent failure — turns end immediately with no tool calls). Different from deny which gives explicit error.
-- `disallowedTools: ['Bash']` — blacklist: removes specific tools from model context entirely, cannot be used even if otherwise allowed. Use for blocking dangerous tools.
-
-### SDK Options discovered (from `sdk.d.ts`)
-
-Key options available but not yet fully utilised:
-
-- **`permissionMode`** — `'acceptEdits'`, `'dontAsk'`, `'bypassPermissions'`, etc. SDK-level permission mode (we implement our own hybrid via `canUseTool`)
-- **`allowedTools`** — array of tool names that auto-allow without prompting
-- **`disallowedTools`** — array of tool names to remove from model context entirely (blacklist)
-- **`includePartialMessages`** — when true, emits `SDKPartialAssistantMessage` events during streaming. Useful for activity indicators even if content isn't shown.
-- **`stderr`** — callback `(data: string) => void` for capturing SDK process errors. Solves "exited with code 1 with no info" problem
-- **`systemPrompt`** — supports `{ type: 'preset', preset: 'claude_code', append: '...' }` to keep default prompt and add custom context
-- **`hooks`** — programmatic hook callbacks (not just from settings.json)
-- **`agents`** — define custom subagents programmatically for the Task tool
-- **`plugins`** — `[{ type: 'local', path: './my-plugin' }]`
-- **`debug` / `debugFile`** — built-in debug logging
-- **`enableFileCheckpointing`** — track and rewind file changes
-- **`thinking`** — `{ type: 'adaptive' }` for Opus 4.6 adaptive thinking
-- **`effort`** — `'low'` | `'medium'` | `'high'` | `'max'` for thinking depth
-- **`maxBudgetUsd`** — cost cap per query
-- **`betas`** — `'context-1m-2025-08-07'` for 1M context window (Sonnet 4/4.5)
-
-### SDK handles
-
-- Tool definitions (what tools are available)
-- JSON schema validation on `settings.json` edits (prevents invalid JSON)
-- Some built-in auto-approvals for safe read-only commands (e.g. `git show`, `git log`, `pwd`)
-- Skills loading and invocation (via `settingSources`)
-- Hooks execution (via `settingSources`)
-
-### Requires `settingSources` (not loaded by default)
-
-- `permissions.deny` — removes tools entirely with explicit error
-- `permissions.allow` — pattern matching (untested, likely works)
-- Skills, hooks, plugins, file change notifications
-
-### CLI-only (not available via SDK)
-
-- `defaultMode` from settings.json (SDK has its own `permissionMode` option which must be passed in code)
-- UI features (spinnerVerbs, statusLine, promptSuggestions, etc.)
-
-### Implications
-
-The `canUseTool` callback is your **entire** permission system when using the SDK directly. The SDK hands you every tool call and you decide. Our hybrid approach: SDK handles hooks, settings, and bash permissions via `settingSources`, while `canUseTool` provides auto-approve tiers (reads, edits in cwd) with manual prompt as fallback.
-
-Sessions are keyed by `sessionId + cwd`. A session created from one directory cannot be resumed from another, even with the same session ID.
-
-### Additional Directories (`/add-dir`)
-
-The official CLI supports `/add-dir` to register extra directories beyond the working directory. The SDK accepts these via the `additionalDirectories` option on each `query()` call (array of absolute paths).
-
-**Persistence**: When the user chooses "and remember" (vs "for this session"), the official CLI persists the directories to `.claude/settings.local.json` inside the project directory:
-
-```json
-{
-  "permissions": {
-    "additionalDirectories": [
-      "/home/user/other-project",
-      "/home/user/shared-lib"
-    ]
-  }
-}
-```
-
-**Write method**: Atomic write via temp file + rename (`settings.local.json.tmp.<pid>.<timestamp>` → `settings.local.json`). A backup of `~/.claude.json` is also written on each update.
-
-**Discovery method**: Confirmed via `strace -f -e trace=openat -p <PID>` on the Claude Code process, filtering for `O_WRONLY|O_RDWR`.
-
-**Implementation for claude-cli**:
-1. Read `additionalDirectories` from `<cwd>/.claude/settings.local.json` on startup
-2. Pass them to `query()` via the `additionalDirectories` option on every call
-3. Implement `/add-dir <path>` command with "this session" (in-memory only) and "remember" (persist to `settings.local.json`) modes
-4. Use the same atomic temp file + rename write pattern
-
-## Architecture
-
-- **Node.js + TypeScript** — required for the Claude Agent SDK
-- **Raw stdin** — no TUI framework, plain escape sequence rendering
-- **`@anthropic-ai/claude-agent-sdk`** — session management, tool orchestration, compaction
-- **`.claude/audit.jsonl`** — all SDK events logged for debugging, viewable via `tail -f` in a separate pane
-- **`config.ts`** — in-memory config with `autoApproveEdits` and `autoApproveReads` (to be backed by a file later)
-- **`SystemPromptBuilder`** — modular provider system for composing the system prompt append. Providers implement `SystemPromptProvider` and contribute sections per query
-- **`providers/`** — `UsageProvider` (time, context, cost) and `GitProvider` (branch, status) with toggleable sub-features
+See [`schema/cli-config.schema.json`](schema/cli-config.schema.json) for the full schema.
 
 ## Development
 
-```bash
+```sh
 pnpm install
 pnpm dev        # Run with tsx
 pnpm build      # Bundle with esbuild
 pnpm start      # Run built bundle
+pnpm test       # Run tests
+pnpm type-check # TypeScript type checking
 ```
+
+## Documentation
+
+- [Architecture](docs/architecture.md)
+- [SDK Findings](docs/sdk-findings.md)
+- [Roadmap](docs/roadmap.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture
+
+## Overview
+
+Node.js + TypeScript CLI built on the Claude Agent SDK. Uses raw stdin with plain ANSI escape sequences — no TUI framework (React Ink, blessed, terminal-kit).
+
+## Core Components
+
+- **`ClaudeCli`** — main entry point, orchestrates session lifecycle
+- **`AppState`** — phase management (`idle`, `sending`, `thinking`, `prompting`, `asking`)
+- **`Terminal`** — ANSI rendering with status line, sticky prompt area, coloured output
+- **`PromptManager`** — handles `AskUserQuestion` tool with interactive selection and configurable timeout
+- **`PermissionManager`** — tool permission queue with configurable timeouts and drowning alert
+- **`SystemPromptBuilder`** — modular provider system for composing the system prompt append per query
+- **`AuditWriter`** — all SDK events logged to `.claude/audit.jsonl` for debugging
+- **`AttachmentStore`** — unified store for image and text attachments
+
+## System Prompt Providers
+
+The system prompt append uses a modular provider architecture (`SystemPromptProvider` interface + `SystemPromptBuilder`). Each provider contributes sections and can be independently enabled/disabled. Providers run in parallel via `Promise.all`.
+
+Current providers:
+- **`UsageProvider`** — current time, elapsed since last response, context usage %, session cost
+- **`GitProvider`** — current branch, working tree dirty/clean status
+
+## Terminal Rendering
+
+Three logical zones:
+1. **History zone** (top, scrollable) — logged messages, tool results, assistant text, diffs. Append-only.
+2. **Status/prompt zone** (bottom, fixed) — permission prompts, waiting indicators, progress. Always visible.
+3. **Input zone** (very bottom, fixed) — the user's text editor area.
+
+Uses ANSI cursor positioning — save/restore cursor, write history, then redraw status + input at the bottom. No heavy TUI framework.
+
+## Permission System
+
+The `canUseTool` callback is the entire permission system when using the SDK directly. The SDK hands every tool call and the CLI decides.
+
+Hybrid approach:
+- SDK handles hooks, settings, and bash permissions via `settingSources`
+- `canUseTool` provides auto-approve tiers (reads, edits in cwd) with manual prompt as fallback
+- `allowedTools` SDK option auto-approves Read/Glob/Grep/LS at SDK level
+
+## Session Management
+
+- Sessions keyed by `sessionId + cwd` — a session from one directory cannot be resumed from another
+- Auto-resume via `.claude/cli-session` file
+- Portable sessions — can resume sessions from the official CLI or VS Code extension
+
+## Command Mode
+
+Activated via `Ctrl+/`. Provides key-driven actions without text-based `/commands`:
+- Clipboard paste (image `i`, text `t`)
+- Attachment management (delete `d`, preview `p`, navigate `←→`)
+- Preserves editor buffer while active
+
+## Audit Log
+
+All SDK events written to `.claude/audit.jsonl`. Useful for:
+- Debugging SDK interactions (`tail -f .claude/audit.jsonl`)
+- Context transfer — paste entries to another Claude for instant context
+- Session replay and review

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,75 @@
+# Roadmap
+
+Tracking toward the **1.0.0** milestone.
+
+## In Progress
+
+### Command Mode Menu
+Hierarchical key menus (vim/roguelikes style). `Ctrl+/` enters command mode, keys navigate submenus, `Esc` goes back.
+
+Proposed layout:
+- **Top-level (flat)**: `i`=image, `t`=text, `f`=file paths, `d`=delete, `p`=preview, `←→`=navigate attachments
+- `s` = Session submenu (`c`=compact, `s`=show, `r`=resume-at)
+- `k` = sKills (type-to-filter with autocomplete)
+- `a` = Add directory
+- `c` = Config
+- `v` = Version
+- `h` = Help
+- `q` = Quit
+
+### Monorepo Setup
+Move to a monorepo structure.
+
+## Planned
+
+### Core Features
+- Configurable auto-compact threshold
+- Capture SDK stderr for real error messages
+- `multiSelect` mode for AskUserQuestion
+
+### Bash Safety
+Normalise → Match → Decide flow for Bash commands:
+1. **Normalise** — resolve cwd-override flags before matching
+2. **Match** against green (auto-approve), red (auto-deny), yellow (prompt) tiers
+3. **Chain detection** — split `&&`/`||`/`;`/`|` and match each part
+
+### Skill-Aware Auto-Approve
+When a skill workflow is active, user decisions via `AskUserQuestion` auto-approve subsequent matching tool calls — building a trust chain from user intent through to execution.
+
+### System Prompt Providers
+- Configurable context thresholds with multiple tiers
+- Runtime toggling (`/toggle git`)
+- Provider latency tracking
+- `NodeProvider`, `EnvProvider`
+- User-configurable custom providers
+
+### Stream Events
+- Activity indicators from streaming deltas
+- System status display (compacting, init, etc.)
+- Streaming text preview
+- Mid-response cost updates
+
+### Smart Auto-Compact
+Automatic compaction at configurable threshold with modes: default, custom prompt, Claude-generated prompt.
+
+### Terminal Rendering
+- Zone-based rendering with fixed status/prompt area
+- Multi-line paste support
+- Escape during permission prompt handling
+
+### Input & UX
+- Type-ahead while Claude is responding
+- Message queueing
+- Tmux pane title integration
+- Skill mode with type-to-filter autocomplete
+- Multiple editors / tabs
+
+### Paste from File
+Read file paths from clipboard. PowerShell `GetFileDropList()` works from WSL2 (returns UNC paths for WSL files, Windows paths for `C:\`). On native Linux/macOS, `text/uri-list` MIME type.
+
+### Session Dashboard
+Central view of all Claude sessions across projects — list, filter, search, quick switch, health monitoring.
+
+## Known Bugs
+- **Cursor off by 1 line** — occasional mismatch between calculated `stickyLineCount` and actual rendered lines. No reliable repro.
+- **Permission prompt readability** — tool permission prompts output raw JSON most of the time. Only plan mode prompts are formatted.

--- a/docs/sdk-findings.md
+++ b/docs/sdk-findings.md
@@ -1,0 +1,71 @@
+# SDK Findings
+
+Discoveries about the boundary between the Claude Agent SDK and the official CLI.
+
+## `settingSources` Option
+
+Adding `settingSources: ['local', 'project', 'user']` to SDK options enables:
+
+- Skills loaded and invokable (git-commit, github-pr, etc.)
+- `PreToolUse` hooks firing (block_dangerous_commands.sh)
+- Settings.json being read
+- File change notifications (system reminders)
+- `permissions.deny` rules — removes tools entirely with explicit error
+- Plugins loaded (typescript-lsp, agent-sdk-dev confirmed in audit)
+
+**Not loaded by default** — skills, hooks, plugins, file change notifications all require `settingSources`.
+
+## SDK Options
+
+Key options from `sdk.d.ts`:
+
+| Option | Description |
+|--------|-------------|
+| `permissionMode` | `'acceptEdits'`, `'dontAsk'`, `'bypassPermissions'`, etc. |
+| `allowedTools` | Array of tool names that auto-allow without prompting |
+| `disallowedTools` | Array of tool names to remove from model context entirely |
+| `tools` | Whitelist — ONLY these tools exist (restricts available tools) |
+| `includePartialMessages` | Emits streaming events for activity indicators |
+| `stderr` | Callback for capturing SDK process errors |
+| `systemPrompt` | Supports `{ type: 'preset', preset: 'claude_code', append: '...' }` |
+| `hooks` | Programmatic hook callbacks |
+| `agents` | Define custom subagents for the Task tool |
+| `plugins` | `[{ type: 'local', path: './my-plugin' }]` |
+| `debug` / `debugFile` | Built-in debug logging |
+| `enableFileCheckpointing` | Track and rewind file changes |
+| `thinking` | `{ type: 'adaptive' }` for Opus 4.6 adaptive thinking |
+| `effort` | `'low'` / `'medium'` / `'high'` / `'max'` thinking depth |
+| `maxBudgetUsd` | Cost cap per query |
+| `betas` | `'context-1m-2025-08-07'` for 1M context (Sonnet 4/4.5) |
+
+## Tool Options Distinction
+
+- `allowedTools: ['Edit']` — Edit auto-approves without prompting (all tools still available)
+- `tools: ['Bash', 'Read']` — whitelist: ONLY Bash and Read exist
+- `tools: []` — Claude sees tools in system prompt but cannot call any (silent failure)
+- `disallowedTools: ['Bash']` — removes from model context entirely
+
+## `AskUserQuestion` Tool
+
+- `allowedTools` has **no effect** — always goes through `canUseTool`
+- Without a handler, hits the raw permission prompt
+- Denying returns `"User denied"` as the tool result
+- Approving without a handler returns an empty response
+
+## `defaultMode` from Settings
+
+`permissionMode` must be passed explicitly in SDK options. The SDK does not read `defaultMode` from settings.json.
+
+## Additional Directories
+
+The official CLI supports `/add-dir` via the `additionalDirectories` option on each `query()` call.
+
+Persistence: stored in `<cwd>/.claude/settings.local.json` under `permissions.additionalDirectories`. Written atomically via temp file + rename.
+
+## Background Tasks
+
+When Claude runs `run_in_background: true`, the task may complete after the query's `result` message. The SDK emits a `task_notification` and starts a new internal turn, but the original `canUseTool` handler may be stale.
+
+**Symptom**: `Error: Stream closed` on repeated tool permission requests.
+
+**Mitigations**: Guard in `canUseTool` checks `session.isActive`, and `PermissionManager.resolve()` checks abort signal before creating waiters.


### PR DESCRIPTION
## Summary

- Condense 395-line README to ~80 lines focused on install, features, config, and dev setup
- Split architecture, SDK findings, and roadmap into separate docs files
- Match @shellicar repo README pattern (title, tagline, install, features, docs links)

Co-Authored-By: Claude <noreply@anthropic.com>