### PR TITLE
Add session clear via command mode (Ctrl+/ s c)

### DIFF
--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -153,6 +153,7 @@ export class ClaudeCli {
       const arg = trimmed.slice('/session'.length).trim();
       if (arg) {
         this.session.setSessionId(arg);
+        this.term.sessionId = arg;
         this.term.info(`Switched to session: ${arg}`);
       } else {
         this.term.info(`Session: ${this.session.currentSessionId ?? 'none'}`);
@@ -368,6 +369,7 @@ export class ClaudeCli {
       this.appState.idle();
       if (this.session.currentSessionId) {
         this.sessions.save(this.session.currentSessionId);
+        this.term.sessionId = this.session.currentSessionId;
       }
       const elapsed = Math.floor((Date.now() - startTime) / 1000);
       this.term.log(`Done after ${elapsed}s`);
@@ -455,11 +457,20 @@ export class ClaudeCli {
             this.attachmentStore.selectRight();
             this.scheduleRedraw();
             break;
+          case 'session-clear':
+            this.session.clearSessionId();
+            this.sessions.clear();
+            this.term.sessionId = undefined;
+            this.term.log('Session cleared');
+            this.commandMode.exit();
+            this.scheduleRedraw();
+            break;
           case 'exit':
             this.commandMode.exit();
             this.scheduleRedraw();
             break;
           case 'none':
+            this.scheduleRedraw();
             break;
         }
       }
@@ -758,6 +769,7 @@ export class ClaudeCli {
     const savedSession = this.sessions.load((msg) => this.term.info(msg));
     if (savedSession) {
       this.session.setSessionId(savedSession);
+      this.term.sessionId = savedSession;
       this.term.info(`Resuming session: ${savedSession}`);
       this.usage.loadContextFromAudit(paths.auditFile, savedSession);
       const lastAssistant = this.usage.lastAssistant;

--- a/src/CommandMode.ts
+++ b/src/CommandMode.ts
@@ -1,10 +1,13 @@
 import type { KeyAction } from './input.js';
 
-export type CommandAction = { type: 'none' } | { type: 'paste-image' } | { type: 'paste-text' } | { type: 'delete' } | { type: 'preview' } | { type: 'select-left' } | { type: 'select-right' } | { type: 'exit' };
+export type CommandAction = { type: 'none' } | { type: 'paste-image' } | { type: 'paste-text' } | { type: 'delete' } | { type: 'preview' } | { type: 'select-left' } | { type: 'select-right' } | { type: 'exit' } | { type: 'session-clear' };
+
+type CommandContext = 'root' | 'session';
 
 export class CommandMode {
   private _active = false;
   private _previewActive = false;
+  private _context: CommandContext = 'root';
 
   public get active(): boolean {
     return this._active;
@@ -14,6 +17,10 @@ export class CommandMode {
     return this._previewActive;
   }
 
+  public get context(): CommandContext {
+    return this._context;
+  }
+
   public enter(): void {
     this._active = true;
   }
@@ -21,6 +28,7 @@ export class CommandMode {
   public exit(): void {
     this._active = false;
     this._previewActive = false;
+    this._context = 'root';
   }
 
   public togglePreview(): void {
@@ -29,11 +37,31 @@ export class CommandMode {
 
   public toggle(): void {
     this._active = !this._active;
+    if (!this._active) {
+      this._context = 'root';
+    }
   }
 
   public handleKey(key: KeyAction): CommandAction | null {
     if (!this._active) {
       return null;
+    }
+
+    if (this._context === 'session') {
+      switch (key.type) {
+        case 'char':
+          if (key.value === 'c') {
+            this._context = 'root';
+            return { type: 'session-clear' };
+          }
+          if (key.value === '/') {
+            this._context = 'root';
+            return { type: 'none' };
+          }
+          return { type: 'none' };
+        default:
+          return { type: 'none' };
+      }
     }
 
     switch (key.type) {
@@ -47,6 +75,9 @@ export class CommandMode {
             return { type: 'delete' };
           case 'p':
             return { type: 'preview' };
+          case 's':
+            this._context = 'session';
+            return { type: 'none' };
           default:
             return { type: 'none' };
         }

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -25,4 +25,8 @@ export class SessionManager {
   public save(id: string): void {
     writeFileSync(this.filePath, id);
   }
+
+  public clear(): void {
+    writeFileSync(this.filePath, '');
+  }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -50,6 +50,10 @@ export class QuerySession extends EventEmitter<SessionEvents> {
     this.sessionId = id;
   }
 
+  public clearSessionId(): void {
+    this.sessionId = undefined;
+  }
+
   public setResumeAt(uuid: string | undefined): void {
     this.resumeAt = uuid;
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -29,6 +29,8 @@ export class Terminal {
   private cursorHidden = false;
   private _paused = false;
   private pauseBuffer: string[] = [];
+  public sessionId: string | undefined;
+
   public constructor(
     private readonly appState: AppState,
     private drowningThreshold: number | null,
@@ -187,15 +189,20 @@ export class Terminal {
       if (hasAtt) {
         b.text(' | ');
       }
-      b.text('i=image t=text d=delete ');
-      if (this.commandMode.previewActive) {
-        b.ansi(inverseOn);
+      if (this.commandMode.context === 'session') {
+        const id = this.sessionId ?? 'none';
+        b.text(`session: ${id} | c=clear /=back`);
+      } else {
+        b.text('i=image t=text d=delete ');
+        if (this.commandMode.previewActive) {
+          b.ansi(inverseOn);
+        }
+        b.text('p=preview');
+        if (this.commandMode.previewActive) {
+          b.ansi(inverseOff);
+        }
+        b.text(' \u2190\u2192=select s=session ESC=exit');
       }
-      b.text('p=preview');
-      if (this.commandMode.previewActive) {
-        b.ansi(inverseOff);
-      }
-      b.text(' \u2190\u2192=select ESC=exit');
     }
 
     return { line: b.output, screenLines: b.screenLines(columns) };


### PR DESCRIPTION
## Summary

- Add session submenu to command mode via `s` key
- `c` clears the current session ID and session file
- Instruction line shows current session UUID (or none) when submenu is open
- `/` returns to root menu without closing command mode
- Keep `term.sessionId` in sync on startup, after queries, and on session commands

Co-Authored-By: Claude <noreply@anthropic.com>