### PR TITLE
Fix session context/cost loading

### DIFF
--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -40,6 +40,7 @@ export class ClaudeCli {
   private platform: Platform = 'unknown';
 
   private cliConfig!: ResolvedCliConfig;
+  private auditFile!: string;
   private term!: Terminal;
   private session!: QuerySession;
   private audit!: AuditWriter;
@@ -128,7 +129,18 @@ export class ClaudeCli {
     return `${color}context: ${ctx.used.toLocaleString()}/${ctx.window.toLocaleString()} (${ctx.percent.toFixed(1)}%)\x1b[0m`;
   }
 
-  private handleCommand(text: string): boolean {
+  private printContext(indent = 0): void {
+    const ctx = this.usage.context;
+    if (ctx) {
+      this.term.log(`${' '.repeat(indent)}${this.formatContext(ctx)}`);
+    }
+  }
+
+  private printSessionCost(indent = 0): void {
+    this.term.log(`${' '.repeat(indent)}session: $${this.usage.sessionCost.toFixed(4)}`);
+  }
+
+  private async handleCommand(text: string): Promise<boolean> {
     const trimmed = text.trim();
     if (trimmed === '/quit' || trimmed === '/exit') {
       this.cleanup();
@@ -153,8 +165,14 @@ export class ClaudeCli {
       const arg = trimmed.slice('/session'.length).trim();
       if (arg) {
         this.session.setSessionId(arg);
+        this.sessions.save(arg);
+        this.usage.reset();
+        this.usage.loadContextFromAudit(this.auditFile, arg);
+        await this.usage.loadCostFromAudit(this.auditFile, arg);
         this.term.sessionId = arg;
         this.term.info(`Switched to session: ${arg}`);
+        this.printContext();
+        this.printSessionCost();
       } else {
         this.term.info(`Session: ${this.session.currentSessionId ?? 'none'}`);
       }
@@ -225,7 +243,7 @@ export class ClaudeCli {
       this.term.log(`> ${text}`);
     }
 
-    if (this.handleCommand(text)) {
+    if (await this.handleCommand(text)) {
       this.redraw();
       return;
     }
@@ -330,11 +348,8 @@ export class ClaudeCli {
             }
           }
 
-          const ctx = this.usage.context;
-          if (ctx) {
-            this.term.log(`  ${this.formatContext(ctx)}`);
-          }
-          this.term.log(`  session: $${this.usage.sessionCost.toFixed(4)}`);
+          this.printContext(2);
+          this.printSessionCost(2);
           break;
         }
         case 'stream_event':
@@ -460,8 +475,11 @@ export class ClaudeCli {
           case 'session-clear':
             this.session.clearSessionId();
             this.sessions.clear();
+            this.usage.reset();
             this.term.sessionId = undefined;
             this.term.log('Session cleared');
+            this.printContext();
+            this.printSessionCost();
             this.commandMode.exit();
             this.scheduleRedraw();
             break;
@@ -699,6 +717,7 @@ export class ClaudeCli {
     this.session = new QuerySession(config.model, config.maxTurns, config.thinking, config.thinkingEffort);
 
     const paths = initFiles();
+    this.auditFile = paths.auditFile;
     this.audit = new AuditWriter(paths.auditFile);
     this.permissions = new PermissionManager(this.term, this.appState, config.permissionTimeoutMs, config.extendedPermissionTimeoutMs, config.drowningThreshold);
     this.prompts = new PromptManager(this.term, this.appState, config.questionTimeoutMs);
@@ -776,10 +795,7 @@ export class ClaudeCli {
       if (lastAssistant) {
         this.term.info(`\x1b[2mlast messageId: ${lastAssistant.uuid}\x1b[0m`);
       }
-      const ctx = this.usage.context;
-      if (ctx) {
-        this.term.info(this.formatContext(ctx));
-      }
+      this.printContext();
       await this.usage.loadCostFromAudit(paths.auditFile, savedSession);
       if (this.usage.sessionCost > 0) {
         this.term.info(`session: $${this.usage.sessionCost.toFixed(4)}`);

--- a/src/UsageTracker.ts
+++ b/src/UsageTracker.ts
@@ -49,6 +49,50 @@ function readTail(filePath: string, chunkSize = 256 * 1024): string[] {
   }
 }
 
+interface AuditContextScan {
+  readonly assistantUsage: AuditUsage | undefined;
+  readonly contextWindow: number;
+  readonly assistantUuid: string | undefined;
+}
+
+function scanContextFromLines(lines: string[], sessionId: string): AuditContextScan {
+  let assistantUsage: AuditUsage | undefined;
+  let contextWindow = 0;
+  let assistantUuid: string | undefined;
+  for (const line of lines) {
+    const entry = JSON.parse(line) as SDKMessage;
+    if (entry.session_id !== sessionId) {
+      continue;
+    }
+    if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+      break;
+    }
+    if (entry.type === 'result' && entry.subtype === 'success' && !contextWindow) {
+      const modelUsage = entry.modelUsage;
+      if (modelUsage) {
+        for (const mu of Object.values(modelUsage)) {
+          if (mu.contextWindow > contextWindow) {
+            contextWindow = mu.contextWindow;
+          }
+        }
+      }
+    }
+    if (entry.type === 'assistant' && !assistantUsage) {
+      const message = entry.message;
+      if (message?.usage) {
+        assistantUsage = message.usage;
+      }
+      if (!assistantUuid && typeof entry.uuid === 'string') {
+        assistantUuid = entry.uuid;
+      }
+    }
+    if (assistantUsage && contextWindow) {
+      break;
+    }
+  }
+  return { assistantUsage, contextWindow, assistantUuid };
+}
+
 export class UsageTracker {
   private processedMessageIds = new Set<string>();
   private lastAssistantUsage: AuditUsage | undefined;
@@ -61,42 +105,15 @@ export class UsageTracker {
   public loadContextFromAudit(auditFile: string, sessionId: string): void {
     try {
       const lines = readTail(auditFile);
-      for (const line of lines) {
-        const entry = JSON.parse(line) as Record<string, unknown>;
-        if (entry.session_id !== sessionId) {
-          continue;
-        }
-
-        // Compact boundary means everything before this is stale — stop looking
-        if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
-          break;
-        }
-
-        if (entry.type === 'result' && entry.subtype === 'success' && !this.lastContextWindow) {
-          const modelUsage = entry.modelUsage as Record<string, { contextWindow: number }> | undefined;
-          if (modelUsage) {
-            for (const mu of Object.values(modelUsage)) {
-              if (mu.contextWindow > this.lastContextWindow) {
-                this.lastContextWindow = mu.contextWindow;
-              }
-            }
-          }
-        }
-
-        if (entry.type === 'assistant' && !this.lastAssistantUsage) {
-          const message = entry.message as { usage?: AuditUsage } | undefined;
-          if (message?.usage) {
-            this.lastAssistantUsage = message.usage;
-          }
-          if (!this._lastAssistantUuid && typeof entry.uuid === 'string') {
-            this._lastAssistantUuid = entry.uuid;
-          }
-        }
-
-        // Once we have both, no need to continue
-        if (this.lastAssistantUsage && this.lastContextWindow) {
-          break;
-        }
+      const result = scanContextFromLines(lines, sessionId);
+      if (result.assistantUsage) {
+        this.lastAssistantUsage = result.assistantUsage;
+      }
+      if (result.contextWindow) {
+        this.lastContextWindow = result.contextWindow;
+      }
+      if (result.assistantUuid) {
+        this._lastAssistantUuid = result.assistantUuid;
       }
     } catch {
       // Audit file missing or corrupt — start fresh
@@ -118,7 +135,7 @@ export class UsageTracker {
 
     for await (const line of rl) {
       try {
-        const entry = JSON.parse(line) as Record<string, unknown>;
+        const entry = JSON.parse(line) as SDKMessage;
         if (entry.session_id !== sessionId) {
           continue;
         }
@@ -132,6 +149,14 @@ export class UsageTracker {
         // skip malformed lines
       }
     }
+  }
+
+  public reset(): void {
+    this.processedMessageIds.clear();
+    this.lastAssistantUsage = { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 };
+    this.cumulativeCost = 0;
+    this._lastAssistantUuid = undefined;
+    this._lastResultTime = undefined;
   }
 
   public onMessage(msg: SDKMessage): void {
@@ -185,7 +210,7 @@ export class UsageTracker {
       return undefined;
     }
     const u = this.lastAssistantUsage;
-    const used = (u.input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.output_tokens ?? 0);
+    const used = u.input_tokens + (u.cache_creation_input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + u.output_tokens;
     const window = this.lastContextWindow || 200_000;
     const percent = (used / window) * 100;
     return { used, window, percent };


### PR DESCRIPTION
## Summary

- Extract pure `scanContextFromLines` function to eliminate side-effect-based context loading
- Fix `reset()` to zero `lastAssistantUsage` instead of clearing it, so context returns `0/200,000` after session clear
- Fix `/session [id]` not saving to session file
- Fix `loadCostFromAudit` not being awaited in `handleCommand`, causing cost to show `$0.0000`
- Add `printContext(indent)` and `printSessionCost(indent)` helpers to eliminate repeated patterns