### PR TITLE
Add local config merge support

### DIFF
--- a/src/ClaudeCli.ts
+++ b/src/ClaudeCli.ts
@@ -6,7 +6,7 @@ import { AppState } from './AppState.js';
 import { AttachmentStore } from './AttachmentStore.js';
 import { AuditWriter } from './AuditWriter.js';
 import { CommandMode } from './CommandMode.js';
-import { CONFIG_PATH } from './cli-config/consts.js';
+import { CONFIG_PATH, LOCAL_CONFIG_PATH } from './cli-config/consts.js';
 import { diffConfig } from './cli-config/diffConfig.js';
 import { loadCliConfig } from './cli-config/loadCliConfig.js';
 import type { ResolvedCliConfig } from './cli-config/types.js';
@@ -54,7 +54,7 @@ export class ClaudeCli {
   private resizeTimer: ReturnType<typeof setTimeout> | undefined;
   private redrawScheduled = false;
   private savedEditor: EditorState | undefined;
-  private configWatcher: FSWatcher | undefined;
+  private configWatchers: FSWatcher[] = [];
   private configDebounce: ReturnType<typeof setTimeout> | undefined;
   private pendingConfigReload = false;
 
@@ -68,15 +68,17 @@ export class ClaudeCli {
       return;
     }
     this.pendingConfigReload = false;
-    const { config: newConfig, warnings } = loadCliConfig();
+    const { config: newConfig, warnings, paths } = loadCliConfig();
 
-    try {
-      const raw = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-      for (const w of validateRawConfig(raw)) {
-        this.term.info(`\x1b[33mconfig warning: ${w}\x1b[0m`);
+    for (const p of paths) {
+      try {
+        const raw = JSON.parse(readFileSync(p, 'utf8'));
+        for (const w of validateRawConfig(raw)) {
+          this.term.info(`\x1b[33mconfig warning: ${w}\x1b[0m`);
+        }
+      } catch {
+        // parse error already covered by loadCliConfig warnings
       }
-    } catch {
-      // parse error already covered by loadCliConfig warnings
     }
 
     for (const w of warnings) {
@@ -712,7 +714,9 @@ export class ClaudeCli {
       process.stdin.setRawMode(false);
     }
     this.cleanupKeypress?.();
-    this.configWatcher?.close();
+    for (const w of this.configWatchers) {
+      w.close();
+    }
     clearTimeout(this.configDebounce);
     process.stdout.removeListener('resize', this.redrawCallback);
     process.stdin.pause();
@@ -721,12 +725,12 @@ export class ClaudeCli {
   public async start(): Promise<void> {
     this.platform = detectPlatform();
 
-    const { config, warnings, path: configPath } = loadCliConfig();
+    const { config, warnings, paths: configPaths } = loadCliConfig();
     this.cliConfig = config;
 
-    if (configPath) {
+    for (const p of configPaths) {
       try {
-        const raw = JSON.parse(readFileSync(configPath, 'utf8'));
+        const raw = JSON.parse(readFileSync(p, 'utf8'));
         for (const w of validateRawConfig(raw)) {
           warnings.push(w);
         }
@@ -796,8 +800,8 @@ export class ClaudeCli {
     };
 
     printVersionInfo((msg) => this.term.info(msg));
-    if (configPath) {
-      this.term.info(`config: ${configPath}`);
+    for (const p of configPaths) {
+      this.term.info(`config: ${p}`);
     }
     for (const warning of warnings) {
       this.term.info(`\x1b[33mconfig warning: ${warning}\x1b[0m`);
@@ -859,13 +863,16 @@ export class ClaudeCli {
       this.redraw();
     });
 
-    try {
-      this.configWatcher = watch(CONFIG_PATH, () => {
-        clearTimeout(this.configDebounce);
-        this.configDebounce = setTimeout(() => this.checkConfigReload(), 100);
-      });
-    } catch {
-      // Config file might not exist yet
+    const reloadHandler = () => {
+      clearTimeout(this.configDebounce);
+      this.configDebounce = setTimeout(() => this.checkConfigReload(), 100);
+    };
+    for (const p of [CONFIG_PATH, LOCAL_CONFIG_PATH]) {
+      try {
+        this.configWatchers.push(watch(p, reloadHandler));
+      } catch {
+        // Config file might not exist yet
+      }
     }
 
     this.showSkills();

--- a/src/cli-config/consts.ts
+++ b/src/cli-config/consts.ts
@@ -5,5 +5,6 @@ export const GIT_PROVIDER_DEFAULTS = { enabled: true, branch: true, status: true
 export const USAGE_PROVIDER_DEFAULTS = { enabled: true, time: true, context: true, cost: true };
 export const PROVIDERS_DEFAULTS = { git: GIT_PROVIDER_DEFAULTS, usage: USAGE_PROVIDER_DEFAULTS };
 export const CONFIG_PATH = resolve(homedir(), '.claude', 'cli-config.json');
+export const LOCAL_CONFIG_PATH = resolve(process.cwd(), '.claude', 'cli-config.json');
 
 export const SCHEMA_URL = 'https://raw.githubusercontent.com/shellicar/claude-cli/main/schema/cli-config.schema.json';

--- a/src/cli-config/loadCliConfig.ts
+++ b/src/cli-config/loadCliConfig.ts
@@ -1,20 +1,63 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { CONFIG_PATH } from './consts';
+import { CONFIG_PATH, LOCAL_CONFIG_PATH } from './consts';
 import { cliConfigSchema } from './schema';
 import type { ResolvedCliConfig } from './types';
 
-export function loadCliConfig(): { config: ResolvedCliConfig; warnings: string[]; path: string | null } {
-  const defaults = cliConfigSchema.parse({});
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
 
-  if (!existsSync(CONFIG_PATH)) {
-    return { config: defaults, warnings: [], path: null };
+/** @private Exported for testing only. */
+export function mergeRawConfigs(home: Record<string, unknown>, local: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...home };
+
+  for (const [key, value] of Object.entries(local)) {
+    if (value === null) {
+      delete merged[key];
+    } else if (isPlainObject(value) && isPlainObject(merged[key])) {
+      const mergedSub: Record<string, unknown> = { ...(merged[key] as Record<string, unknown>) };
+      for (const [sk, sv] of Object.entries(value)) {
+        if (sv === null) {
+          delete mergedSub[sk];
+        } else {
+          mergedSub[sk] = sv;
+        }
+      }
+      merged[key] = mergedSub;
+    } else {
+      merged[key] = value;
+    }
   }
 
+  return merged;
+}
+
+function readRaw(path: string, warnings: string[]): Record<string, unknown> {
   try {
-    const raw = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-    const config = cliConfigSchema.parse(raw);
-    return { config, warnings: [], path: CONFIG_PATH };
+    return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
   } catch {
-    return { config: defaults, warnings: [`Failed to parse ${CONFIG_PATH}`], path: CONFIG_PATH };
+    warnings.push(`Failed to parse ${path}`);
+    return {};
   }
+}
+
+export function loadCliConfig(): { config: ResolvedCliConfig; warnings: string[]; paths: string[] } {
+  const warnings: string[] = [];
+  const paths: string[] = [];
+
+  let homeRaw: Record<string, unknown> = {};
+  if (existsSync(CONFIG_PATH)) {
+    paths.push(CONFIG_PATH);
+    homeRaw = readRaw(CONFIG_PATH, warnings);
+  }
+
+  let localRaw: Record<string, unknown> = {};
+  if (existsSync(LOCAL_CONFIG_PATH)) {
+    paths.push(LOCAL_CONFIG_PATH);
+    localRaw = readRaw(LOCAL_CONFIG_PATH, warnings);
+  }
+
+  const merged = mergeRawConfigs(homeRaw, localRaw);
+  const config = cliConfigSchema.parse(merged);
+  return { config, warnings, paths };
 }

--- a/test/cli-config.spec.ts
+++ b/test/cli-config.spec.ts
@@ -1,7 +1,58 @@
 import { describe, expect, it } from 'vitest';
 import { diffConfig } from '../src/cli-config/diffConfig.js';
+import { mergeRawConfigs } from '../src/cli-config/loadCliConfig.js';
 import { parseCliConfig } from '../src/cli-config/parseCliConfig.js';
 import { validateRawConfig } from '../src/cli-config/validateRawConfig.js';
+
+describe('mergeRawConfigs', () => {
+  it('local value overrides home value', () => {
+    const result = mergeRawConfigs({ model: 'haiku' }, { model: 'opus' });
+    expect(result.model).toBe('opus');
+  });
+
+  it('absent local key keeps home value', () => {
+    const result = mergeRawConfigs({ model: 'haiku', maxTurns: 50 }, {});
+    expect(result.model).toBe('haiku');
+    expect(result.maxTurns).toBe(50);
+  });
+
+  it('null in local deletes the key', () => {
+    const result = mergeRawConfigs({ model: 'haiku' }, { model: null });
+    expect('model' in result).toBe(false);
+  });
+
+  it('merges nested object 1 level deep — replaces sub-key, preserves others', () => {
+    const home = { providers: { git: { enabled: false, branch: true }, usage: { enabled: true } } };
+    const local = { providers: { git: { branch: false } } };
+    const result = mergeRawConfigs(home, local);
+    // git replaced entirely by local value; usage preserved from home
+    expect(result.providers).toEqual({ git: { branch: false }, usage: { enabled: true } });
+  });
+
+  it('null in nested object deletes the sub-key', () => {
+    const home = { providers: { git: { enabled: true, branch: true }, usage: { enabled: true } } };
+    const local = { providers: { git: null } };
+    const result = mergeRawConfigs(home, local);
+    // null deletes git from providers; usage preserved
+    expect((result.providers as Record<string, unknown>).git).toBeUndefined();
+    expect((result.providers as Record<string, unknown>).usage).toEqual({ enabled: true });
+  });
+
+  it('local nested object replaces home scalar', () => {
+    const result = mergeRawConfigs({ model: 'haiku' }, { model: { nested: true } });
+    expect(result.model).toEqual({ nested: true });
+  });
+
+  it('empty home uses local values', () => {
+    const result = mergeRawConfigs({}, { model: 'opus', maxTurns: 10 });
+    expect(result).toEqual({ model: 'opus', maxTurns: 10 });
+  });
+
+  it('empty local returns home unchanged', () => {
+    const result = mergeRawConfigs({ model: 'haiku', maxTurns: 50 }, {});
+    expect(result).toEqual({ model: 'haiku', maxTurns: 50 });
+  });
+});
 
 describe('parseCliConfig', () => {
   describe('defaults', () => {
@@ -9,6 +60,7 @@ describe('parseCliConfig', () => {
       const config = parseCliConfig({});
       expect(config).toEqual({
         model: 'claude-opus-4-6',
+        compactModel: 'claude-haiku-4-5-20251001',
         maxTurns: 100,
         permissionTimeoutMs: 30_000,
         extendedPermissionTimeoutMs: 120_000,
@@ -17,6 +69,8 @@ describe('parseCliConfig', () => {
         autoApproveEdits: true,
         autoApproveReads: true,
         expandTilde: true,
+        thinking: true,
+        thinkingEffort: 'high',
         providers: {
           git: { enabled: true, branch: true, status: true, sha: true },
           usage: { enabled: true, time: true, context: true, cost: true },


### PR DESCRIPTION
## Summary

- Reads both `~/.claude/cli-config.json` (home) and `./.claude/cli-config.json` (local)
- Local config merged onto home: `null` deletes a key, absent keys ignored, values override
- Nested objects (e.g. `providers`) merged one level deep
- Watches both config files for live reload
- Adds `mergeRawConfigs` tests; fixes missing defaults in `parseCliConfig` snapshot test

Co-Authored-By: Claude <noreply@anthropic.com>