### PR TITLE
Preserve session ID across aborts

### DIFF
--- a/docs/sdk-findings.md
+++ b/docs/sdk-findings.md
@@ -82,7 +82,7 @@ There is no dedicated "resume notification" message. `SDKSystemMessage` has exac
 
 To detect whether a resume succeeded: compare `init.session_id` with the value passed to `Options.resume`. If they match, the session was successfully resumed. If they differ, the SDK started a new session (e.g., because the session ID was not found).
 
-The current CLI captures the session ID from `init` on every query (`pendingSessionId = msg.session_id`). This is correct — it works for both new sessions and resumes, and re-captures a new ID if the resume silently fails.
+The current CLI commits the session ID to `this.sessionId` immediately on `init` (`this.sessionId = msg.session_id`). This works for both new sessions and resumes, and re-captures a new ID if the resume silently fails. Committing on `init` (rather than on `result`) ensures the session ID is preserved even if the query is aborted before a `result` message arrives.
 
 ### `session_id` on `SDKUserMessage`
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -168,8 +168,6 @@ export class QuerySession extends EventEmitter<SessionEvents> {
     this.activeQuery = q;
     this.emit('activeChanged', true);
 
-    let pendingSessionId: string | undefined;
-
     this.on('message', onMessage);
     try {
       for await (const msg of q) {
@@ -180,10 +178,7 @@ export class QuerySession extends EventEmitter<SessionEvents> {
           appendFileSync('/tmp/claude-cli-messages.log', `${new Date().toISOString()} | yield ${msg.type}${subtype}\n`);
         }
         if (msg.type === 'system' && msg.subtype === 'init') {
-          pendingSessionId = msg.session_id;
-        }
-        if (msg.type === 'result' && pendingSessionId) {
-          this.sessionId = pendingSessionId;
+          this.sessionId = msg.session_id;
         }
         this.emit('message', msg);
       }


### PR DESCRIPTION
## Summary

- Session ID now persisted before waiting for user input, not after query completion
- Aborted prompts no longer lose the session, allowing resume on next query

## Related Issues

Fixes #108

Co-Authored-By: Claude <noreply@anthropic.com>