### PR TITLE
Bump version to 1.0.0-alpha.71

### DIFF
--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -1,0 +1,55 @@
+name: Verify Commit Signatures
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify commit signatures
+        shell: sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FAILED=0
+          REPO="${{ github.repository }}"
+
+          for COMMIT in $(gh pr view "${{ github.event.pull_request.number }}" --repo "$REPO" --json commits --jq '.commits[].oid'); do
+            VERIFIED=$(gh api "repos/$REPO/commits/$COMMIT" --jq '.commit.verification.verified')
+            REASON=$(gh api "repos/$REPO/commits/$COMMIT" --jq '.commit.verification.reason')
+            COMMITTER=$(gh api "repos/$REPO/commits/$COMMIT" --jq '.commit.committer.email')
+            MESSAGE=$(gh api "repos/$REPO/commits/$COMMIT" --jq '.commit.message' | head -1)
+            SHORT=$(echo "$COMMIT" | cut -c1-7)
+
+            echo "---"
+            echo "Commit: $SHORT $MESSAGE"
+            echo "  Committer: $COMMITTER"
+            echo "  Verified:  $VERIFIED"
+            echo "  Reason:    $REASON"
+
+            if [ "$VERIFIED" != "true" ]; then
+              echo "  FAIL: Commit is not verified (reason: $REASON)"
+              FAILED=1
+            else
+              echo "  OK"
+            fi
+          done
+
+          echo ""
+          if [ "$FAILED" -eq 1 ]; then
+            echo "VERIFICATION FAILED: One or more commits are not verified."
+            echo "All commits must be GPG-signed and verified by GitHub."
+            exit 1
+          else
+            echo "All commits verified."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.71] - 2026-03-27
+
 ### Fixed
 
 - Exit with error when stdin is not a terminal (empty piped stdin no longer hangs)
 - Slash commands no longer discard pending file attachments
+- `session-clear` and `session-new` commands no longer exit command mode
+- Suppress unhandled rejection crash when aborting a query early
 
 ### Security
 
 - Fixed [CVE-2026-33672](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) (ReDoS) and [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p) (method injection) in picomatch
 - Fixed [CVE-2026-33532](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) (stack overflow) in yaml
 - Fixed [GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq) (DoS) in smol-toml
-
-### Fixed
-
-- `session-clear` and `session-new` commands no longer exit command mode
 
 ### Changed
 
@@ -120,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Patched CVE-2026-27903 and CVE-2026-27904 in minimatch
 
+[1.0.0-alpha.71]: https://github.com/shellicar/claude-cli/releases/tag/1.0.0-alpha.71
 [1.0.0-alpha.70]: https://github.com/shellicar/claude-cli/releases/tag/1.0.0-alpha.70
 [1.0.0-alpha.69]: https://github.com/shellicar/claude-cli/releases/tag/1.0.0-alpha.69
 [1.0.0-alpha.68]: https://github.com/shellicar/claude-cli/releases/tag/1.0.0-alpha.68

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-cli",
-  "version": "1.0.0-alpha.70",
+  "version": "1.0.0-alpha.71",
   "private": false,
   "type": "module",
   "description": "Interactive CLI for Claude AI with terminal UI",


### PR DESCRIPTION
## Summary

- Fix slash commands discarding pending file attachments (#89)
- Fix session-clear/session-new exiting command mode (#90)
- Exit with error when stdin is not a terminal (#107)
- Suppress unhandled rejection crash on early query abort (#122)
- Bump @shellicar/mcp-exec to 1.0.0-preview.6 (#123)
- Security: picomatch (CVE-2026-33672, GHSA-3v7f-55p6-f55p), yaml (CVE-2026-33532), smol-toml (GHSA-v3rj-xjv7-4jmq)
- Updated @anthropic-ai/claude-agent-sdk to 0.2.85, @anthropic-ai/sdk to 0.80.0
- Add verify-commit-signatures workflow

Co-authored-by: BananaBot9000 <bananabot9000@bananabot.dev>