### PR TITLE
Fix cursor skipping through emoji and special characters

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,6 +3,8 @@
  * No I/O — just data manipulation.
  */
 
+const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
 export interface CursorPosition {
   row: number;
   col: number;
@@ -123,7 +125,11 @@ export function deleteWordBackward(state: EditorState): EditorState {
 export function moveLeft(state: EditorState): EditorState {
   const { lines, cursor } = state;
   if (cursor.col > 0) {
-    return { lines, cursor: { row: cursor.row, col: cursor.col - 1 } };
+    const before = lines[cursor.row].slice(0, cursor.col);
+    const segments = [...segmenter.segment(before)];
+    const lastSeg = segments[segments.length - 1];
+    const retreat = lastSeg?.segment.length ?? 1;
+    return { lines, cursor: { row: cursor.row, col: cursor.col - retreat } };
   }
   if (cursor.row > 0) {
     return { lines, cursor: { row: cursor.row - 1, col: lines[cursor.row - 1].length } };
@@ -133,8 +139,11 @@ export function moveLeft(state: EditorState): EditorState {
 
 export function moveRight(state: EditorState): EditorState {
   const { lines, cursor } = state;
-  if (cursor.col < lines[cursor.row].length) {
-    return { lines, cursor: { row: cursor.row, col: cursor.col + 1 } };
+  const line = lines[cursor.row];
+  if (cursor.col < line.length) {
+    const segments = [...segmenter.segment(line.slice(cursor.col))];
+    const advance = segments[0]?.segment.length ?? 1;
+    return { lines, cursor: { row: cursor.row, col: cursor.col + advance } };
   }
   if (cursor.row < lines.length - 1) {
     return { lines, cursor: { row: cursor.row + 1, col: 0 } };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -24,7 +24,8 @@ export function prepareEditor(editor: EditorState, prompt: string): EditorRender
   }
 
   const cursorPrefix = editor.cursor.row === 0 ? prompt : CONTINUATION;
-  const cursorCol = stringWidth(cursorPrefix) + editor.cursor.col;
+  const textBeforeCursor = editor.lines[editor.cursor.row].slice(0, editor.cursor.col);
+  const cursorCol = stringWidth(cursorPrefix) + stringWidth(textBeforeCursor);
 
   let cursorRow = 0;
   for (let i = 0; i < editor.cursor.row; i++) {


### PR DESCRIPTION
## Summary

- Cursor moves by visible character, not internal code position
- Arrow keys correctly cross emoji and multi-part characters in a single keypress

Closes #138