### PR TITLE
Move key handling into EditorState.handleKey (step 3b)

### DIFF
--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -333,30 +333,6 @@ export class AppLayout implements Disposable {
     }
   }
 
-  /** Returns the column index of the start of the word to the left of col. */
-  #wordStartLeft(line: string, col: number): number {
-    let c = col;
-    while (c > 0 && line[c - 1] === ' ') {
-      c--;
-    }
-    while (c > 0 && line[c - 1] !== ' ') {
-      c--;
-    }
-    return c;
-  }
-
-  /** Returns the column index of the end of the word to the right of col. */
-  #wordEndRight(line: string, col: number): number {
-    let c = col;
-    while (c < line.length && line[c] === ' ') {
-      c++;
-    }
-    while (c < line.length && line[c] !== ' ') {
-      c++;
-    }
-    return c;
-  }
-
   public handleKey(key: KeyAction): void {
     if (key.type === 'ctrl+c') {
       this.exit();
@@ -424,229 +400,53 @@ export class AppLayout implements Disposable {
       return;
     }
 
-    switch (key.type) {
-      case 'enter': {
-        // Split current line at cursor
-        const cur = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        const before = cur.slice(0, this.#editorState.cursorCol);
-        const after = cur.slice(this.#editorState.cursorCol);
-        this.#editorState.lines[this.#editorState.cursorLine] = before;
-        this.#editorState.lines.splice(this.#editorState.cursorLine + 1, 0, after);
-        this.#editorState.cursorLine++;
-        this.#editorState.cursorCol = 0;
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+enter': {
-        const text = this.#editorState.lines.join('\n').trim();
-        if (!text && !this.#attachments.hasAttachments) {
-          break;
+    if (this.#editorState.handleKey(key)) {
+      this.#scheduleRender();
+      return;
+    }
+
+    if (key.type !== 'ctrl+enter') {
+      return;
+    }
+    const text = this.#editorState.text.trim();
+    if (!text && !this.#attachments.hasAttachments) {
+      return;
+    }
+    if (!this.#editorResolve) {
+      return;
+    }
+    const attachments = this.#attachments.takeAttachments();
+    const parts: string[] = [text];
+    if (attachments) {
+      for (let n = 0; n < attachments.length; n++) {
+        const att = attachments[n];
+        if (!att) {
+          continue;
         }
-        if (!this.#editorResolve) {
-          break;
-        }
-        const attachments = this.#attachments.takeAttachments();
-        const parts: string[] = [text];
-        if (attachments) {
-          for (let n = 0; n < attachments.length; n++) {
-            const att = attachments[n];
-            if (!att) {
-              continue;
-            }
-            if (att.kind === 'text') {
-              const showSize = att.sizeBytes >= 1024 ? `${(att.sizeBytes / 1024).toFixed(1)}KB` : `${att.sizeBytes}B`;
-              const fullSize = att.fullSizeBytes >= 1024 ? `${(att.fullSizeBytes / 1024).toFixed(1)}KB` : `${att.fullSizeBytes}B`;
-              const truncPrefix = att.truncated ? `// showing ${showSize} of ${fullSize} (truncated)\n` : '';
-              parts.push(`\n\n[attachment #${n + 1}]\n${truncPrefix}${att.text}\n[/attachment]`);
-            } else {
-              const lines: string[] = [`path: ${att.path}`];
-              if (att.fileType === 'missing') {
-                lines.push('// not found');
-              } else {
-                lines.push(`type: ${att.fileType}`);
-                if (att.fileType === 'file' && att.sizeBytes !== undefined) {
-                  const sz = att.sizeBytes;
-                  const sizeStr = sz >= 1024 ? `${(sz / 1024).toFixed(1)}KB` : `${sz}B`;
-                  lines.push(`size: ${sizeStr}`);
-                }
-              }
-              parts.push(`\n\n[attachment #${n + 1}]\n${lines.join('\n')}\n[/attachment]`);
+        if (att.kind === 'text') {
+          const showSize = att.sizeBytes >= 1024 ? `${(att.sizeBytes / 1024).toFixed(1)}KB` : `${att.sizeBytes}B`;
+          const fullSize = att.fullSizeBytes >= 1024 ? `${(att.fullSizeBytes / 1024).toFixed(1)}KB` : `${att.fullSizeBytes}B`;
+          const truncPrefix = att.truncated ? `// showing ${showSize} of ${fullSize} (truncated)\n` : '';
+          parts.push(`\n\n[attachment #${n + 1}]\n${truncPrefix}${att.text}\n[/attachment]`);
+        } else {
+          const lines: string[] = [`path: ${att.path}`];
+          if (att.fileType === 'missing') {
+            lines.push('// not found');
+          } else {
+            lines.push(`type: ${att.fileType}`);
+            if (att.fileType === 'file' && att.sizeBytes !== undefined) {
+              const sz = att.sizeBytes;
+              const sizeStr = sz >= 1024 ? `${(sz / 1024).toFixed(1)}KB` : `${sz}B`;
+              lines.push(`size: ${sizeStr}`);
             }
           }
+          parts.push(`\n\n[attachment #${n + 1}]\n${lines.join('\n')}\n[/attachment]`);
         }
-        const resolveInput = this.#editorResolve;
-        this.#editorResolve = null;
-        resolveInput(parts.join(''));
-        break;
-      }
-      case 'backspace': {
-        if (this.#editorState.cursorCol > 0) {
-          const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-          this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, this.#editorState.cursorCol - 1) + line.slice(this.#editorState.cursorCol);
-          this.#editorState.cursorCol--;
-        } else if (this.#editorState.cursorLine > 0) {
-          // Join with previous line
-          const prev = this.#editorState.lines[this.#editorState.cursorLine - 1] ?? '';
-          const curr = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-          this.#editorState.lines.splice(this.#editorState.cursorLine, 1);
-          this.#editorState.cursorLine--;
-          this.#editorState.cursorCol = prev.length;
-          this.#editorState.lines[this.#editorState.cursorLine] = prev + curr;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'delete': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        if (this.#editorState.cursorCol < line.length) {
-          this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, this.#editorState.cursorCol) + line.slice(this.#editorState.cursorCol + 1);
-        } else if (this.#editorState.cursorLine < this.#editorState.lines.length - 1) {
-          // Join with next line
-          const next = this.#editorState.lines[this.#editorState.cursorLine + 1] ?? '';
-          this.#editorState.lines.splice(this.#editorState.cursorLine + 1, 1);
-          this.#editorState.lines[this.#editorState.cursorLine] = line + next;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+backspace': {
-        if (this.#editorState.cursorCol === 0) {
-          // At start of line: cross the newline boundary, same as plain backspace
-          if (this.#editorState.cursorLine > 0) {
-            const prev = this.#editorState.lines[this.#editorState.cursorLine - 1] ?? '';
-            const curr = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-            this.#editorState.lines.splice(this.#editorState.cursorLine, 1);
-            this.#editorState.cursorLine--;
-            this.#editorState.cursorCol = prev.length;
-            this.#editorState.lines[this.#editorState.cursorLine] = prev + curr;
-          }
-        } else {
-          const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-          const newCol = this.#wordStartLeft(line, this.#editorState.cursorCol);
-          this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, newCol) + line.slice(this.#editorState.cursorCol);
-          this.#editorState.cursorCol = newCol;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+delete': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        if (this.#editorState.cursorCol === line.length) {
-          // At EOL: cross the newline boundary, same as plain delete
-          if (this.#editorState.cursorLine < this.#editorState.lines.length - 1) {
-            const next = this.#editorState.lines[this.#editorState.cursorLine + 1] ?? '';
-            this.#editorState.lines.splice(this.#editorState.cursorLine + 1, 1);
-            this.#editorState.lines[this.#editorState.cursorLine] = line + next;
-          }
-        } else {
-          const newCol = this.#wordEndRight(line, this.#editorState.cursorCol);
-          this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, this.#editorState.cursorCol) + line.slice(newCol);
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+k': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        if (this.#editorState.cursorCol < line.length) {
-          // Kill to end of line
-          this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, this.#editorState.cursorCol);
-        } else if (this.#editorState.cursorLine < this.#editorState.lines.length - 1) {
-          // At EOL: join with next line
-          const next = this.#editorState.lines[this.#editorState.cursorLine + 1] ?? '';
-          this.#editorState.lines.splice(this.#editorState.cursorLine + 1, 1);
-          this.#editorState.lines[this.#editorState.cursorLine] = line + next;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+u': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        this.#editorState.lines[this.#editorState.cursorLine] = line.slice(this.#editorState.cursorCol);
-        this.#editorState.cursorCol = 0;
-        this.#scheduleRender();
-        break;
-      }
-      case 'left': {
-        if (this.#editorState.cursorCol > 0) {
-          this.#editorState.cursorCol--;
-        } else if (this.#editorState.cursorLine > 0) {
-          this.#editorState.cursorLine--;
-          this.#editorState.cursorCol = (this.#editorState.lines[this.#editorState.cursorLine] ?? '').length;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'right': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        if (this.#editorState.cursorCol < line.length) {
-          this.#editorState.cursorCol++;
-        } else if (this.#editorState.cursorLine < this.#editorState.lines.length - 1) {
-          this.#editorState.cursorLine++;
-          this.#editorState.cursorCol = 0;
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'up': {
-        if (this.#editorState.cursorLine > 0) {
-          this.#editorState.cursorLine--;
-          const newLine = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-          this.#editorState.cursorCol = Math.min(this.#editorState.cursorCol, newLine.length);
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'down': {
-        if (this.#editorState.cursorLine < this.#editorState.lines.length - 1) {
-          this.#editorState.cursorLine++;
-          const newLine = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-          this.#editorState.cursorCol = Math.min(this.#editorState.cursorCol, newLine.length);
-        }
-        this.#scheduleRender();
-        break;
-      }
-      case 'home': {
-        this.#editorState.cursorCol = 0;
-        this.#scheduleRender();
-        break;
-      }
-      case 'end': {
-        this.#editorState.cursorCol = (this.#editorState.lines[this.#editorState.cursorLine] ?? '').length;
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+home': {
-        this.#editorState.cursorLine = 0;
-        this.#editorState.cursorCol = 0;
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+end': {
-        this.#editorState.cursorLine = this.#editorState.lines.length - 1;
-        this.#editorState.cursorCol = (this.#editorState.lines[this.#editorState.cursorLine] ?? '').length;
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+left': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        this.#editorState.cursorCol = this.#wordStartLeft(line, this.#editorState.cursorCol);
-        this.#scheduleRender();
-        break;
-      }
-      case 'ctrl+right': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        this.#editorState.cursorCol = this.#wordEndRight(line, this.#editorState.cursorCol);
-        this.#scheduleRender();
-        break;
-      }
-      case 'char': {
-        const line = this.#editorState.lines[this.#editorState.cursorLine] ?? '';
-        this.#editorState.lines[this.#editorState.cursorLine] = line.slice(0, this.#editorState.cursorCol) + key.value + line.slice(this.#editorState.cursorCol);
-        this.#editorState.cursorCol += key.value.length;
-        this.#scheduleRender();
-        break;
       }
     }
+    const resolveInput = this.#editorResolve;
+    this.#editorResolve = null;
+    resolveInput(parts.join(''));
   }
 
   #flushToScroll(): void {

--- a/apps/claude-sdk-cli/src/EditorState.ts
+++ b/apps/claude-sdk-cli/src/EditorState.ts
@@ -1,11 +1,12 @@
+import type { KeyAction } from '@shellicar/claude-core/input';
+
 /**
  * Pure editor state — lines of text and cursor position.
- * No rendering, no key handling, no I/O.
+ * No rendering, no I/O.
  *
- * AppLayout holds an instance and reads from it directly. Key handling
- * will move here in step 3b; rendering will be extracted in step 3c.
- * Until 3b lands, AppLayout mutates the lines array and cursor position
- * directly through the exposed getters/setters.
+ * `handleKey` owns all text-editing transitions. `ctrl+enter` (submit) is
+ * intentionally absent — it involves attachments and a promise resolve that
+ * live in AppLayout.
  */
 export class EditorState {
   #lines: string[] = [''];
@@ -13,10 +14,10 @@ export class EditorState {
   #cursorCol = 0;
 
   /**
-   * The lines array. Direct mutation (index assignment, splice) is
-   * intentional here — key handling still lives in AppLayout until step 3b.
+   * The lines of text. Read-only: all mutations go through `handleKey` or
+   * `reset`. AppLayout uses this for rendering only.
    */
-  public get lines(): string[] {
+  public get lines(): readonly string[] {
     return this.#lines;
   }
 
@@ -24,16 +25,8 @@ export class EditorState {
     return this.#cursorLine;
   }
 
-  public set cursorLine(n: number) {
-    this.#cursorLine = n;
-  }
-
   public get cursorCol(): number {
     return this.#cursorCol;
-  }
-
-  public set cursorCol(n: number) {
-    this.#cursorCol = n;
   }
 
   /** Full text content — all lines joined by newline. */
@@ -46,5 +39,195 @@ export class EditorState {
     this.#lines = [''];
     this.#cursorLine = 0;
     this.#cursorCol = 0;
+  }
+
+  /**
+   * Handle an editor key. Returns true if the key was consumed (caller should
+   * schedule a re-render). Returns false for `ctrl+enter` and any key not
+   * recognised here — the caller handles those itself.
+   */
+  public handleKey(key: KeyAction): boolean {
+    switch (key.type) {
+      case 'enter': {
+        const cur = this.#lines[this.#cursorLine] ?? '';
+        const before = cur.slice(0, this.#cursorCol);
+        const after = cur.slice(this.#cursorCol);
+        this.#lines[this.#cursorLine] = before;
+        this.#lines.splice(this.#cursorLine + 1, 0, after);
+        this.#cursorLine++;
+        this.#cursorCol = 0;
+        return true;
+      }
+      case 'backspace': {
+        if (this.#cursorCol > 0) {
+          const line = this.#lines[this.#cursorLine] ?? '';
+          this.#lines[this.#cursorLine] = line.slice(0, this.#cursorCol - 1) + line.slice(this.#cursorCol);
+          this.#cursorCol--;
+        } else if (this.#cursorLine > 0) {
+          const prev = this.#lines[this.#cursorLine - 1] ?? '';
+          const curr = this.#lines[this.#cursorLine] ?? '';
+          this.#lines.splice(this.#cursorLine, 1);
+          this.#cursorLine--;
+          this.#cursorCol = prev.length;
+          this.#lines[this.#cursorLine] = prev + curr;
+        }
+        return true;
+      }
+      case 'delete': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        if (this.#cursorCol < line.length) {
+          this.#lines[this.#cursorLine] = line.slice(0, this.#cursorCol) + line.slice(this.#cursorCol + 1);
+        } else if (this.#cursorLine < this.#lines.length - 1) {
+          const next = this.#lines[this.#cursorLine + 1] ?? '';
+          this.#lines.splice(this.#cursorLine + 1, 1);
+          this.#lines[this.#cursorLine] = line + next;
+        }
+        return true;
+      }
+      case 'ctrl+backspace': {
+        if (this.#cursorCol === 0) {
+          if (this.#cursorLine > 0) {
+            const prev = this.#lines[this.#cursorLine - 1] ?? '';
+            const curr = this.#lines[this.#cursorLine] ?? '';
+            this.#lines.splice(this.#cursorLine, 1);
+            this.#cursorLine--;
+            this.#cursorCol = prev.length;
+            this.#lines[this.#cursorLine] = prev + curr;
+          }
+        } else {
+          const line = this.#lines[this.#cursorLine] ?? '';
+          const newCol = this.#wordStartLeft(line, this.#cursorCol);
+          this.#lines[this.#cursorLine] = line.slice(0, newCol) + line.slice(this.#cursorCol);
+          this.#cursorCol = newCol;
+        }
+        return true;
+      }
+      case 'ctrl+delete': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        if (this.#cursorCol === line.length) {
+          if (this.#cursorLine < this.#lines.length - 1) {
+            const next = this.#lines[this.#cursorLine + 1] ?? '';
+            this.#lines.splice(this.#cursorLine + 1, 1);
+            this.#lines[this.#cursorLine] = line + next;
+          }
+        } else {
+          const newCol = this.#wordEndRight(line, this.#cursorCol);
+          this.#lines[this.#cursorLine] = line.slice(0, this.#cursorCol) + line.slice(newCol);
+        }
+        return true;
+      }
+      case 'ctrl+k': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        if (this.#cursorCol < line.length) {
+          this.#lines[this.#cursorLine] = line.slice(0, this.#cursorCol);
+        } else if (this.#cursorLine < this.#lines.length - 1) {
+          const next = this.#lines[this.#cursorLine + 1] ?? '';
+          this.#lines.splice(this.#cursorLine + 1, 1);
+          this.#lines[this.#cursorLine] = line + next;
+        }
+        return true;
+      }
+      case 'ctrl+u': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        this.#lines[this.#cursorLine] = line.slice(this.#cursorCol);
+        this.#cursorCol = 0;
+        return true;
+      }
+      case 'left': {
+        if (this.#cursorCol > 0) {
+          this.#cursorCol--;
+        } else if (this.#cursorLine > 0) {
+          this.#cursorLine--;
+          this.#cursorCol = (this.#lines[this.#cursorLine] ?? '').length;
+        }
+        return true;
+      }
+      case 'right': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        if (this.#cursorCol < line.length) {
+          this.#cursorCol++;
+        } else if (this.#cursorLine < this.#lines.length - 1) {
+          this.#cursorLine++;
+          this.#cursorCol = 0;
+        }
+        return true;
+      }
+      case 'up': {
+        if (this.#cursorLine > 0) {
+          this.#cursorLine--;
+          const newLine = this.#lines[this.#cursorLine] ?? '';
+          this.#cursorCol = Math.min(this.#cursorCol, newLine.length);
+        }
+        return true;
+      }
+      case 'down': {
+        if (this.#cursorLine < this.#lines.length - 1) {
+          this.#cursorLine++;
+          const newLine = this.#lines[this.#cursorLine] ?? '';
+          this.#cursorCol = Math.min(this.#cursorCol, newLine.length);
+        }
+        return true;
+      }
+      case 'home': {
+        this.#cursorCol = 0;
+        return true;
+      }
+      case 'end': {
+        this.#cursorCol = (this.#lines[this.#cursorLine] ?? '').length;
+        return true;
+      }
+      case 'ctrl+home': {
+        this.#cursorLine = 0;
+        this.#cursorCol = 0;
+        return true;
+      }
+      case 'ctrl+end': {
+        this.#cursorLine = this.#lines.length - 1;
+        this.#cursorCol = (this.#lines[this.#cursorLine] ?? '').length;
+        return true;
+      }
+      case 'ctrl+left': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        this.#cursorCol = this.#wordStartLeft(line, this.#cursorCol);
+        return true;
+      }
+      case 'ctrl+right': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        this.#cursorCol = this.#wordEndRight(line, this.#cursorCol);
+        return true;
+      }
+      case 'char': {
+        const line = this.#lines[this.#cursorLine] ?? '';
+        this.#lines[this.#cursorLine] = line.slice(0, this.#cursorCol) + key.value + line.slice(this.#cursorCol);
+        this.#cursorCol += key.value.length;
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  /** Returns the column index of the start of the word to the left of col. */
+  #wordStartLeft(line: string, col: number): number {
+    let c = col;
+    while (c > 0 && line[c - 1] === ' ') {
+      c--;
+    }
+    while (c > 0 && line[c - 1] !== ' ') {
+      c--;
+    }
+    return c;
+  }
+
+  /** Returns the column index of the end of the word to the right of col. */
+  #wordEndRight(line: string, col: number): number {
+    let c = col;
+    while (c < line.length && line[c] === ' ') {
+      c++;
+    }
+    while (c < line.length && line[c] !== ' ') {
+      c++;
+    }
+    return c;
   }
 }

--- a/apps/claude-sdk-cli/test/EditorState.spec.ts
+++ b/apps/claude-sdk-cli/test/EditorState.spec.ts
@@ -1,0 +1,667 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '../src/EditorState.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const key = (type: string, value = '') => ({ type, value }) as Parameters<EditorState['handleKey']>[0];
+
+const char = (value: string) => key('char', value);
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe('EditorState — initial state', () => {
+  it('starts with one empty line', () => {
+    const expected = 1;
+    const actual = new EditorState().lines.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('starts with cursor at line 0', () => {
+    const expected = 0;
+    const actual = new EditorState().cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('starts with cursor at col 0', () => {
+    const expected = 0;
+    const actual = new EditorState().cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset
+// ---------------------------------------------------------------------------
+
+describe('EditorState — reset', () => {
+  it('clears lines back to one empty line', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.reset();
+    const expected = 1;
+    const actual = s.lines.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('resets cursor line to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('enter'));
+    s.reset();
+    const expected = 0;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('resets cursor col to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.reset();
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// char — insert
+// ---------------------------------------------------------------------------
+
+describe('EditorState — char', () => {
+  it('inserts a character at the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('a'));
+    const expected = 'a';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('advances cursor col by the length of the value', () => {
+    const s = new EditorState();
+    s.handleKey(char('hi'));
+    const expected = 2;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('inserts at cursor mid-line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ac'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right'));
+    s.handleKey(char('b'));
+    const expected = 'abc';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('returns true', () => {
+    const expected = true;
+    const actual = new EditorState().handleKey(char('x'));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enter — line split
+// ---------------------------------------------------------------------------
+
+describe('EditorState — enter', () => {
+  it('increases line count by one', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    const expected = 2;
+    const actual = s.lines.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('splits line content at the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right')); // cursor after 'a'
+    s.handleKey(key('enter'));
+    const expected = 'a';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('puts the text after the cursor on the new line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right')); // cursor after 'a'
+    s.handleKey(key('enter'));
+    const expected = 'b';
+    const actual = s.lines[1];
+    expect(actual).toBe(expected);
+  });
+
+  it('moves cursor to line 1', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    const expected = 1;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('resets cursor col to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backspace
+// ---------------------------------------------------------------------------
+
+describe('EditorState — backspace', () => {
+  it('deletes the character before the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('backspace'));
+    const expected = 'a';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('moves cursor col back by one', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('backspace'));
+    const expected = 1;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 joins with previous line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('home'));
+    s.handleKey(key('backspace'));
+    const expected = 'abcd';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 reduces line count by one', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('backspace'));
+    const expected = 1;
+    const actual = s.lines.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 sets cursor col to length of previous line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('backspace'));
+    const expected = 2;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 on line 0 does nothing', () => {
+    const s = new EditorState();
+    s.handleKey(key('backspace'));
+    const expected = 1;
+    const actual = s.lines.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+describe('EditorState — delete', () => {
+  it('deletes the character under the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('home'));
+    s.handleKey(key('delete'));
+    const expected = 'b';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL joins with next line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('delete'));
+    const expected = 'abcd';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL of last line does nothing', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('delete'));
+    const expected = 'ab';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+backspace — delete word left
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+backspace', () => {
+  it('deletes the word to the left of the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello world'));
+    s.handleKey(key('ctrl+backspace'));
+    const expected = 'hello ';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 joins with previous line', () => {
+    const s = new EditorState();
+    s.handleKey(char('first'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('ctrl+backspace'));
+    const expected = 'first';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+delete — delete word right
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+delete', () => {
+  it('deletes the word to the right of the cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello world'));
+    s.handleKey(key('home'));
+    s.handleKey(key('ctrl+delete'));
+    const expected = ' world';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL joins with next line', () => {
+    const s = new EditorState();
+    s.handleKey(char('first'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('second'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('ctrl+delete'));
+    const expected = 'firstsecond';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+k — kill to end of line
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+k', () => {
+  it('kills from cursor to end of line', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right'));
+    s.handleKey(key('ctrl+k'));
+    const expected = 'h';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL joins with next line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('ctrl+k'));
+    const expected = 'abcd';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+u — kill to start of line
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+u', () => {
+  it('kills from line start to cursor', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right'));
+    s.handleKey(key('right'));
+    s.handleKey(key('ctrl+u'));
+    const expected = 'llo';
+    const actual = s.lines[0];
+    expect(actual).toBe(expected);
+  });
+
+  it('resets cursor col to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('ctrl+u'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// left / right
+// ---------------------------------------------------------------------------
+
+describe('EditorState — left', () => {
+  it('moves cursor col left', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('left'));
+    const expected = 1;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 wraps to end of previous line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('left'));
+    const expected = 2;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at col 0 on line 0 does nothing', () => {
+    const s = new EditorState();
+    s.handleKey(key('left'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — right', () => {
+  it('moves cursor col right', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right'));
+    const expected = 1;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL wraps to start of next line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('right'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at EOL wraps to next line index', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('right'));
+    const expected = 1;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// up / down with col clamping
+// ---------------------------------------------------------------------------
+
+describe('EditorState — up', () => {
+  it('moves cursor line up', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('up'));
+    const expected = 0;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('clamps cursor col to shorter line length', () => {
+    const s = new EditorState();
+    s.handleKey(char('a'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('abc'));
+    s.handleKey(key('up'));
+    const expected = 1;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('at line 0 does not change line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('up'));
+    const expected = 0;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('at line 0 returns true', () => {
+    const expected = true;
+    const actual = new EditorState().handleKey(key('up'));
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — down', () => {
+  it('moves cursor line down', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(key('up'));
+    s.handleKey(key('down'));
+    const expected = 1;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('clamps cursor col to shorter line length', () => {
+    const s = new EditorState();
+    s.handleKey(char('abc'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('a'));
+    s.handleKey(key('up'));
+    s.handleKey(key('end'));
+    s.handleKey(key('down'));
+    const expected = 1;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// home / end / ctrl+home / ctrl+end
+// ---------------------------------------------------------------------------
+
+describe('EditorState — home', () => {
+  it('moves cursor col to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('home'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — end', () => {
+  it('moves cursor col to end of line', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello'));
+    s.handleKey(key('home'));
+    s.handleKey(key('end'));
+    const expected = 5;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — ctrl+home', () => {
+  it('moves cursor to line 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('ctrl+home'));
+    const expected = 0;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('moves cursor col to 0', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('ctrl+home'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — ctrl+end', () => {
+  it('moves cursor to last line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('ctrl+home'));
+    s.handleKey(key('ctrl+end'));
+    const expected = 1;
+    const actual = s.cursorLine;
+    expect(actual).toBe(expected);
+  });
+
+  it('moves cursor col to end of last line', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    s.handleKey(key('ctrl+home'));
+    s.handleKey(key('ctrl+end'));
+    const expected = 2;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+left / ctrl+right — word navigation
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+left', () => {
+  it('jumps to start of current word', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello world'));
+    s.handleKey(key('ctrl+left'));
+    const expected = 6;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('skips trailing spaces before jumping over the preceding word', () => {
+    const s = new EditorState();
+    // Three trailing spaces — cursor lands after them at col 8.
+    // ctrl+left skips the spaces (c: 8→5), then skips 'hello' (c: 5→0).
+    s.handleKey(char('hello   '));
+    s.handleKey(key('ctrl+left'));
+    const expected = 0;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('EditorState — ctrl+right', () => {
+  it('jumps to end of current word', () => {
+    const s = new EditorState();
+    s.handleKey(char('hello world'));
+    s.handleKey(key('home'));
+    s.handleKey(key('ctrl+right'));
+    const expected = 5;
+    const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ctrl+enter — not handled by EditorState
+// ---------------------------------------------------------------------------
+
+describe('EditorState — ctrl+enter', () => {
+  it('returns false', () => {
+    const expected = false;
+    const actual = new EditorState().handleKey(key('ctrl+enter'));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unknown key
+// ---------------------------------------------------------------------------
+
+describe('EditorState — unknown key', () => {
+  it('returns false', () => {
+    const expected = false;
+    const actual = new EditorState().handleKey(key('f1'));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// text getter
+// ---------------------------------------------------------------------------
+
+describe('EditorState — text', () => {
+  it('joins lines with newline', () => {
+    const s = new EditorState();
+    s.handleKey(char('ab'));
+    s.handleKey(key('enter'));
+    s.handleKey(char('cd'));
+    const expected = 'ab\ncd';
+    const actual = s.text;
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## What

All editor key transitions move from `AppLayout` into `EditorState.handleKey`.

## Changes

- `EditorState.handleKey(key: KeyAction): boolean` — handles every editing key; returns `true` when consumed so the caller schedules a re-render, `false` for `ctrl+enter` and unknown keys
- `#wordStartLeft` / `#wordEndRight` move from `AppLayout` into `EditorState` as private helpers
- `lines` getter now returns `readonly string[]` — enforces that AppLayout only reads for rendering
- `AppLayout.handleKey` collapses from a 220-line switch to four lines: delegate to `handleKey`, schedule render, then handle `ctrl+enter` inline
- `ctrl+enter` stays in `AppLayout`: it reads `#attachments` and resolves `#editorResolve`, which are not editor state

## Testing

56 unit tests in `EditorState.spec.ts` cover every key case as pure state assertions — no ANSI, no rendering, no terminal.