### PR TITLE
Extract ToolApprovalState and renderToolApproval from AppLayout (step 5c)

### DIFF
--- a/.claude/sessions/2026-04-07.md
+++ b/.claude/sessions/2026-04-07.md
@@ -56,3 +56,45 @@ Started from main with PRs #194 (5a StatusState) and #195 (perf test fix) alread
 - Move `#buildApprovalRow` + `#buildExpandedRows` logic to `renderToolApproval(state, cols): string[]`
 - Risk: medium-high. The async approval flow (promise queue resolved by keyboard handler) must move together — splitting it would leave a broken intermediate state.
 - Tests: async approval flow, cancel flow, keyboard navigation (left/right cycle, space expand).
+
+
+---
+
+## Step 5c — Extract `ToolApprovalState` + `renderToolApproval` from `AppLayout` (PR #197)
+
+Continuation of the same session after context compaction.
+
+**New `ToolApprovalState.ts`** — pure state, no I/O:
+- `PendingTool` type moved here (was defined in AppLayout), to avoid circular dependency
+- Fields: `#pendingTools`, `#selectedTool`, `#toolExpanded`, `#pendingApprovals`
+- `addTool` / `removeTool` (returns bool, clamps selection) / `clearTools`
+- `requestApproval` returns a Promise that queues into `#pendingApprovals`
+- `resolveNextApproval(approved)` shifts from the queue and resolves; returns false if empty
+- `toggleExpanded` / `selectPrev` / `selectNext` (both collapse expanded) / `resetExpanded`
+- `hasPendingTools` and `hasPendingApprovals` getters
+
+**New `renderToolApproval.ts`** — pure renderer:
+- Returns `ToolApprovalRender = { approvalRow: string; expandedRows: string[] }`
+- `approvalRow`: tool name, navigation counter (← N/M →) for >1 tools, Allow prefix + [Y/N] when approval pending, expand/collapse hint
+- `expandedRows`: JSON.stringify of selected tool's input, wrapped to `cols`, capped at `maxRows`
+- Returns empty approvalRow and expandedRows when no tools
+
+**`AppLayout.ts` changes:**
+- Four old fields (`#pendingTools`, `#selectedTool`, `#toolExpanded`, `#pendingApprovals`) replaced by `#toolApprovalState = new ToolApprovalState()`
+- All methods delegate to `#toolApprovalState`
+- Dead methods `#buildApprovalRow` and old combined `#buildExpandedRows` removed (37 lines deleted)
+- `render()` calls `renderToolApproval(this.#toolApprovalState, cols, Math.floor(totalRows / 2))`
+- `PendingTool` re-exported via `export type { PendingTool } from './ToolApprovalState.js'` so `AgentMessageHandler.ts` import is unchanged
+- `#buildPreviewRows` kept for step 5d
+
+**Tests:** 29 new in `ToolApprovalState.spec.ts`, 16 in `renderToolApproval.spec.ts`. Total: 276 (up from 231).
+
+## Decisions
+
+**`PendingTool` moved to `ToolApprovalState.ts`:** AppLayout imports ToolApprovalState, so if PendingTool stayed in AppLayout, ToolApprovalState would import from AppLayout — circular. Re-exporting from AppLayout keeps external consumers unaffected.
+
+**Object return `{ approvalRow, expandedRows }` from `renderToolApproval`:** The two pieces go in different positions in the layout assembly, and `expandedRows.length` is needed for height calculation before `approvalRow` is placed. A flat array would require encoding the structure implicitly.
+
+**`requestApproval` split:** Promise creation moves into `ToolApprovalState.requestApproval()`. `this.render()` stays in `AppLayout.requestApproval()` since rendering is AppLayout's responsibility, not state's.
+
+**`#cancelFn` stays in AppLayout:** It's an agent lifecycle concern (set by `runAgent`, triggered by Escape), not tool approval state. Not extracted here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,34 @@ Run `pnpm type-check` and `pnpm build` before committing to verify types and com
 ## System Prompt
 
 The CLI injects a system prompt append before each SDK query. This is built by `SystemPromptBuilder` using modular `SystemPromptProvider` implementations in `src/providers/`. The system prompt should NOT be built or sent for local commands (e.g. `/compact`, `/help`) that don't invoke the SDK.
+
+
+## Current State
+
+Refactoring `AppLayout.ts` into focused, testable units (milestone 1.0 prerequisite).
+
+| Step | Status | PR |
+|------|--------|----|
+| 1a Conversation split | ✅ Done | #183 |
+| 1b History replay | ✅ Done | #186 |
+| 2 RequestBuilder | ✅ Done | #187 |
+| 3a EditorState (fields) | ✅ Done | #189 |
+| 3b EditorState.handleKey | ✅ Done | #190 |
+| 3c renderEditor | ✅ Done | #191 |
+| 4a AgentMessageHandler stateless | ✅ Done | #192 |
+| 4b AgentMessageHandler stateful | ✅ Done | #193 |
+| 5a StatusState + renderStatus | ✅ Done | #194 |
+| 5b ConversationState + renderConversation | ✅ Done | #196 |
+| 5c ToolApprovalState + renderToolApproval | ✅ Done | #197 |
+| 5d CommandModeState + renderCommandMode | ⏳ Next | — |
+| 5e ScreenCoordinator cleanup | — | — |
+
+Test count: 276 across 11 spec files.
+
+## Recent Decisions
+
+**`PendingTool` moved to `ToolApprovalState.ts`** (step 5c): AppLayout imports ToolApprovalState; keeping PendingTool in AppLayout would create a circular dependency. AppLayout re-exports it so external consumers (AgentMessageHandler) are unaffected.
+
+**`renderToolApproval` returns `{ approvalRow, expandedRows }`**: The two pieces occupy different fixed positions in the layout assembly; `expandedRows.length` is needed for the content-area height calculation before `approvalRow` is placed.
+
+**`#cancelFn` stays in AppLayout**: Agent lifecycle concern, not tool approval state. Extraction deferred to step 5e ScreenCoordinator cleanup.

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -17,13 +17,12 @@ import { logger } from './logger.js';
 import { buildDivider, renderBlocksToString, renderConversation } from './renderConversation.js';
 import { renderEditor } from './renderEditor.js';
 import { renderStatus } from './renderStatus.js';
+import { renderToolApproval } from './renderToolApproval.js';
 import { StatusState } from './StatusState.js';
+import type { PendingTool } from './ToolApprovalState.js';
+import { ToolApprovalState } from './ToolApprovalState.js';
 
-export type PendingTool = {
-  requestId: string;
-  name: string;
-  input: Record<string, unknown>;
-};
+export type { PendingTool } from './ToolApprovalState.js';
 
 type Mode = 'editor' | 'streaming';
 
@@ -51,16 +50,13 @@ export class AppLayout implements Disposable {
   #editorState = new EditorState();
   #renderPending = false;
 
-  #pendingTools: PendingTool[] = [];
-  #selectedTool = 0;
-  #toolExpanded = false;
+  #toolApprovalState = new ToolApprovalState();
 
   #commandMode = false;
   #previewMode = false;
   #attachments = new AttachmentStore();
 
   #editorResolve: ((value: string) => void) | null = null;
-  #pendingApprovals: Array<(approved: boolean) => void> = [];
   #cancelFn: (() => void) | null = null;
 
   #statusState = new StatusState();
@@ -128,7 +124,7 @@ export class AppLayout implements Disposable {
   /** Seal the completed response block and return to editor mode. */
   public completeStreaming(): void {
     this.#conversationState.completeActive();
-    this.#pendingTools = [];
+    this.#toolApprovalState.clearTools();
     this.#mode = 'editor';
     this.#commandMode = false;
     this.#previewMode = false;
@@ -139,20 +135,14 @@ export class AppLayout implements Disposable {
   }
 
   public addPendingTool(tool: PendingTool): void {
-    this.#pendingTools.push(tool);
-    if (this.#pendingTools.length === 1) {
-      this.#selectedTool = 0;
-    }
+    this.#toolApprovalState.addTool(tool);
     this.render();
   }
 
   public removePendingTool(requestId: string): void {
-    const idx = this.#pendingTools.findIndex((t) => t.requestId === requestId);
-    if (idx < 0) {
+    if (!this.#toolApprovalState.removeTool(requestId)) {
       return;
     }
-    this.#pendingTools.splice(idx, 1);
-    this.#selectedTool = Math.min(this.#selectedTool, Math.max(0, this.#pendingTools.length - 1));
     this.render();
   }
 
@@ -191,7 +181,7 @@ export class AppLayout implements Disposable {
   public waitForInput(): Promise<string> {
     this.#mode = 'editor';
     this.#editorState.reset();
-    this.#toolExpanded = false;
+    this.#toolApprovalState.resetExpanded();
     this.render();
     return new Promise((resolve) => {
       this.#editorResolve = resolve;
@@ -204,10 +194,9 @@ export class AppLayout implements Disposable {
    * Multiple calls queue up; Y/N resolves them in FIFO order.
    */
   public requestApproval(): Promise<boolean> {
-    return new Promise((resolve) => {
-      this.#pendingApprovals.push(resolve);
-      this.render();
-    });
+    const promise = this.#toolApprovalState.requestApproval();
+    this.render();
+    return promise;
   }
 
   /** Debounced render for key events — batches rapid input (paste) into one repaint. */
@@ -247,32 +236,29 @@ export class AppLayout implements Disposable {
     }
 
     // Y/N resolves the first queued approval
-    if (this.#pendingApprovals.length > 0 && key.type === 'char') {
+    if (this.#toolApprovalState.hasPendingApprovals && key.type === 'char') {
       const ch = key.value.toUpperCase();
       if (ch === 'Y' || ch === 'N') {
-        const resolve = this.#pendingApprovals.shift();
-        resolve?.(ch === 'Y');
+        this.#toolApprovalState.resolveNextApproval(ch === 'Y');
         this.render();
         return;
       }
     }
 
     // Tool navigation: left/right to cycle, space to expand/collapse
-    if (this.#pendingTools.length > 0) {
+    if (this.#toolApprovalState.hasPendingTools) {
       if (key.type === 'char' && key.value === ' ') {
-        this.#toolExpanded = !this.#toolExpanded;
+        this.#toolApprovalState.toggleExpanded();
         this.render();
         return;
       }
       if (key.type === 'left') {
-        this.#selectedTool = Math.max(0, this.#selectedTool - 1);
-        this.#toolExpanded = false;
+        this.#toolApprovalState.selectPrev();
         this.render();
         return;
       }
       if (key.type === 'right') {
-        this.#selectedTool = Math.min(this.#pendingTools.length - 1, this.#selectedTool + 1);
-        this.#toolExpanded = false;
+        this.#toolApprovalState.selectNext();
         this.render();
         return;
       }
@@ -355,7 +341,9 @@ export class AppLayout implements Disposable {
     const cols = this.#screen.columns;
     const totalRows = this.#screen.rows;
 
-    const expandedRows = this.#buildExpandedRows(cols);
+    const { approvalRow, expandedRows: toolRows } = renderToolApproval(this.#toolApprovalState, cols, Math.floor(totalRows / 2));
+    const previewRows = this.#previewMode && this.#commandMode ? this.#buildPreviewRows(cols) : [];
+    const expandedRows = [...toolRows, ...previewRows];
     const commandRow = this.#buildCommandRow(cols);
     // Fixed status bar: separator (1) + status line (1) + approval row (1) + command row (always 1) + optional expanded rows
     const statusBarHeight = 4 + expandedRows.length;
@@ -375,7 +363,6 @@ export class AppLayout implements Disposable {
 
     const separator = buildDivider(null, cols);
     const statusLine = this.#buildStatusLine(cols);
-    const approvalRow = this.#buildApprovalRow(cols);
     const allRows = [...visibleRows, separator, statusLine, approvalRow, commandRow, ...expandedRows];
 
     let out = syncStart + hideCursor;
@@ -526,43 +513,6 @@ export class AppLayout implements Disposable {
 
   #buildStatusLine(cols: number): string {
     return renderStatus(this.#statusState, cols);
-  }
-
-  #buildApprovalRow(_cols: number): string {
-    if (this.#pendingTools.length === 0) {
-      return '';
-    }
-    const tool = this.#pendingTools[this.#selectedTool];
-    if (!tool) {
-      return '';
-    }
-
-    const idx = this.#selectedTool + 1;
-    const total = this.#pendingTools.length;
-    const nav = total > 1 ? ` \u2190 ${idx}/${total} \u2192` : '';
-    const needsApproval = this.#pendingApprovals.length > 0;
-    const prefix = needsApproval ? 'Allow ' : '';
-    const approval = needsApproval ? '  [Y/N]' : '';
-    const expand = this.#toolExpanded ? ' [space: collapse]' : ' [space: expand]';
-    return ` ${prefix}Tool: ${tool.name}${nav}${approval}${expand}`;
-  }
-
-  #buildExpandedRows(cols: number): string[] {
-    if (this.#toolExpanded && this.#pendingTools.length > 0) {
-      const tool = this.#pendingTools[this.#selectedTool];
-      if (tool) {
-        const rows: string[] = [];
-        for (const line of JSON.stringify(tool.input, null, 2).split('\n')) {
-          rows.push(...wrapLine(CONTENT_INDENT + line, cols));
-        }
-        // Cap at half the screen height to leave room for content
-        return rows.slice(0, Math.floor(this.#screen.rows / 2));
-      }
-    }
-    if (this.#previewMode && this.#commandMode) {
-      return this.#buildPreviewRows(cols);
-    }
-    return [];
   }
 
   #buildPreviewRows(cols: number): string[] {

--- a/apps/claude-sdk-cli/src/ToolApprovalState.ts
+++ b/apps/claude-sdk-cli/src/ToolApprovalState.ts
@@ -1,0 +1,109 @@
+export type PendingTool = {
+  requestId: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+/**
+ * Pure state for the tool approval UI: pending tools, selection, expand/collapse,
+ * and the promise queue that connects the async approval flow to keyboard input.
+ *
+ * No rendering, no I/O. The approval queue holds live resolver functions — addTool,
+ * removeTool, requestApproval, and resolveNextApproval must all live here so the
+ * queue never splits across two objects.
+ */
+export class ToolApprovalState {
+  #pendingTools: PendingTool[] = [];
+  #selectedTool = 0;
+  #toolExpanded = false;
+  #pendingApprovals: Array<(approved: boolean) => void> = [];
+
+  public get pendingTools(): ReadonlyArray<PendingTool> {
+    return this.#pendingTools;
+  }
+
+  public get selectedTool(): number {
+    return this.#selectedTool;
+  }
+
+  public get toolExpanded(): boolean {
+    return this.#toolExpanded;
+  }
+
+  public get hasPendingTools(): boolean {
+    return this.#pendingTools.length > 0;
+  }
+
+  public get hasPendingApprovals(): boolean {
+    return this.#pendingApprovals.length > 0;
+  }
+
+  /** Add a tool to the pending list. First tool resets selection to 0. */
+  public addTool(tool: PendingTool): void {
+    this.#pendingTools.push(tool);
+    if (this.#pendingTools.length === 1) {
+      this.#selectedTool = 0;
+    }
+  }
+
+  /** Remove a tool by requestId and clamp selection to the new length. */
+  public removeTool(requestId: string): boolean {
+    const idx = this.#pendingTools.findIndex((t) => t.requestId === requestId);
+    if (idx < 0) {
+      return false;
+    }
+    this.#pendingTools.splice(idx, 1);
+    this.#selectedTool = Math.min(this.#selectedTool, Math.max(0, this.#pendingTools.length - 1));
+    return true;
+  }
+
+  /** Clear all pending tools (called when streaming completes). */
+  public clearTools(): void {
+    this.#pendingTools = [];
+  }
+
+  /**
+   * Queue an approval request. Returns a promise that resolves when the user
+   * presses Y or N (via resolveNextApproval). Multiple calls queue in FIFO order.
+   */
+  public requestApproval(): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.#pendingApprovals.push(resolve);
+    });
+  }
+
+  /**
+   * Resolve the next queued approval with the given answer.
+   * Returns true if there was a pending approval, false if the queue was empty.
+   */
+  public resolveNextApproval(approved: boolean): boolean {
+    const resolve = this.#pendingApprovals.shift();
+    if (!resolve) {
+      return false;
+    }
+    resolve(approved);
+    return true;
+  }
+
+  /** Toggle the expanded/collapsed state of the selected tool's input. */
+  public toggleExpanded(): void {
+    this.#toolExpanded = !this.#toolExpanded;
+  }
+
+  /** Select the previous tool, collapsing any expansion. */
+  public selectPrev(): void {
+    this.#selectedTool = Math.max(0, this.#selectedTool - 1);
+    this.#toolExpanded = false;
+  }
+
+  /** Select the next tool, collapsing any expansion. */
+  public selectNext(): void {
+    this.#selectedTool = Math.min(this.#pendingTools.length - 1, this.#selectedTool + 1);
+    this.#toolExpanded = false;
+  }
+
+  /** Collapse the expanded view (called when returning to editor mode). */
+  public resetExpanded(): void {
+    this.#toolExpanded = false;
+  }
+}

--- a/apps/claude-sdk-cli/src/renderToolApproval.ts
+++ b/apps/claude-sdk-cli/src/renderToolApproval.ts
@@ -1,0 +1,48 @@
+import { wrapLine } from '@shellicar/claude-core/reflow';
+import type { ToolApprovalState } from './ToolApprovalState.js';
+
+const CONTENT_INDENT = '   ';
+
+export type ToolApprovalRender = {
+  approvalRow: string;
+  expandedRows: string[];
+};
+
+/**
+ * Render the tool approval UI from pure state.
+ *
+ * Returns two separate pieces because they occupy different fixed positions in
+ * the layout: approvalRow sits between the status line and command row;
+ * expandedRows are appended below the command row and their count affects the
+ * content area height calculation.
+ *
+ * maxRows caps the expanded JSON display at half the screen height — the caller
+ * computes Math.floor(totalRows / 2) and passes it in so this function stays
+ * free of any screen reference.
+ */
+export function renderToolApproval(state: ToolApprovalState, cols: number, maxRows: number): ToolApprovalRender {
+  const tool = state.pendingTools[state.selectedTool];
+
+  // --- approval row ---
+  let approvalRow = '';
+  if (tool) {
+    const total = state.pendingTools.length;
+    const nav = total > 1 ? ` \u2190 ${state.selectedTool + 1}/${total} \u2192` : '';
+    const prefix = state.hasPendingApprovals ? 'Allow ' : '';
+    const approval = state.hasPendingApprovals ? '  [Y/N]' : '';
+    const expand = state.toolExpanded ? ' [space: collapse]' : ' [space: expand]';
+    approvalRow = ` ${prefix}Tool: ${tool.name}${nav}${approval}${expand}`;
+  }
+
+  // --- expanded rows ---
+  let expandedRows: string[] = [];
+  if (state.toolExpanded && tool) {
+    const rows: string[] = [];
+    for (const line of JSON.stringify(tool.input, null, 2).split('\n')) {
+      rows.push(...wrapLine(CONTENT_INDENT + line, cols));
+    }
+    expandedRows = rows.slice(0, maxRows);
+  }
+
+  return { approvalRow, expandedRows };
+}

--- a/apps/claude-sdk-cli/test/ToolApprovalState.spec.ts
+++ b/apps/claude-sdk-cli/test/ToolApprovalState.spec.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import { ToolApprovalState } from '../src/ToolApprovalState.js';
+
+const toolA = { requestId: 'a', name: 'read_file', input: { path: '/tmp/foo' } };
+const toolB = { requestId: 'b', name: 'write_file', input: { path: '/tmp/bar', content: 'hi' } };
+
+describe('ToolApprovalState — initial state', () => {
+  it('pendingTools starts empty', () => {
+    const state = new ToolApprovalState();
+    const expected = 0;
+    const actual = state.pendingTools.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectedTool starts at 0', () => {
+    const state = new ToolApprovalState();
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('toolExpanded starts false', () => {
+    const state = new ToolApprovalState();
+    const expected = false;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+
+  it('hasPendingTools is false when empty', () => {
+    const state = new ToolApprovalState();
+    const expected = false;
+    const actual = state.hasPendingTools;
+    expect(actual).toBe(expected);
+  });
+
+  it('hasPendingApprovals is false when empty', () => {
+    const state = new ToolApprovalState();
+    const expected = false;
+    const actual = state.hasPendingApprovals;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ToolApprovalState — addTool', () => {
+  it('adds a tool to pendingTools', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    const expected = 1;
+    const actual = state.pendingTools.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('first tool resets selection to 0', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('second tool does not change selection', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('hasPendingTools becomes true after addTool', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    const expected = true;
+    const actual = state.hasPendingTools;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ToolApprovalState — removeTool', () => {
+  it('returns true when requestId is found', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    const expected = true;
+    const actual = state.removeTool('a');
+    expect(actual).toBe(expected);
+  });
+
+  it('removes the tool from pendingTools', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.removeTool('a');
+    const expected = 0;
+    const actual = state.pendingTools.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns false when requestId is not found', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    const expected = false;
+    const actual = state.removeTool('z');
+    expect(actual).toBe(expected);
+  });
+
+  it('clamps selectedTool when removing selected last tool', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.selectNext(); // selectedTool = 1
+    state.removeTool('b');
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ToolApprovalState — clearTools', () => {
+  it('empties pendingTools', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.clearTools();
+    const expected = 0;
+    const actual = state.pendingTools.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ToolApprovalState — requestApproval / resolveNextApproval', () => {
+  it('resolveNextApproval with empty queue returns false', () => {
+    const state = new ToolApprovalState();
+    const expected = false;
+    const actual = state.resolveNextApproval(true);
+    expect(actual).toBe(expected);
+  });
+
+  it('requestApproval resolves with true when Y pressed', async () => {
+    const state = new ToolApprovalState();
+    const promise = state.requestApproval();
+    state.resolveNextApproval(true);
+    const expected = true;
+    const actual = await promise;
+    expect(actual).toBe(expected);
+  });
+
+  it('requestApproval resolves with false when N pressed', async () => {
+    const state = new ToolApprovalState();
+    const promise = state.requestApproval();
+    state.resolveNextApproval(false);
+    const expected = false;
+    const actual = await promise;
+    expect(actual).toBe(expected);
+  });
+
+  it('resolveNextApproval returns true when a pending approval exists', () => {
+    const state = new ToolApprovalState();
+    state.requestApproval();
+    const expected = true;
+    const actual = state.resolveNextApproval(true);
+    expect(actual).toBe(expected);
+  });
+
+  it('hasPendingApprovals is true after requestApproval', () => {
+    const state = new ToolApprovalState();
+    state.requestApproval();
+    const expected = true;
+    const actual = state.hasPendingApprovals;
+    expect(actual).toBe(expected);
+  });
+
+  it('multiple approvals resolve in FIFO order', async () => {
+    const state = new ToolApprovalState();
+    const p1 = state.requestApproval();
+    const p2 = state.requestApproval();
+    state.resolveNextApproval(true);
+    state.resolveNextApproval(false);
+    const results = await Promise.all([p1, p2]);
+    const expected = [true, false];
+    const actual = results;
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('ToolApprovalState — navigation', () => {
+  it('toggleExpanded flips toolExpanded from false to true', () => {
+    const state = new ToolApprovalState();
+    state.toggleExpanded();
+    const expected = true;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+
+  it('toggleExpanded flips toolExpanded from true to false', () => {
+    const state = new ToolApprovalState();
+    state.toggleExpanded();
+    state.toggleExpanded();
+    const expected = false;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectPrev decrements selectedTool', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.selectNext(); // 0 -> 1
+    state.selectPrev(); // 1 -> 0
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectPrev does not go below 0', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.selectPrev();
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectPrev collapses expanded view', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.selectNext();
+    state.toggleExpanded();
+    state.selectPrev();
+    const expected = false;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectNext increments selectedTool', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.selectNext();
+    const expected = 1;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectNext does not exceed last index', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.selectNext();
+    const expected = 0;
+    const actual = state.selectedTool;
+    expect(actual).toBe(expected);
+  });
+
+  it('selectNext collapses expanded view', () => {
+    const state = new ToolApprovalState();
+    state.addTool(toolA);
+    state.addTool(toolB);
+    state.toggleExpanded();
+    state.selectNext();
+    const expected = false;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+
+  it('resetExpanded sets toolExpanded to false', () => {
+    const state = new ToolApprovalState();
+    state.toggleExpanded();
+    state.resetExpanded();
+    const expected = false;
+    const actual = state.toolExpanded;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/renderToolApproval.spec.ts
+++ b/apps/claude-sdk-cli/test/renderToolApproval.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { renderToolApproval } from '../src/renderToolApproval.js';
+import { ToolApprovalState } from '../src/ToolApprovalState.js';
+
+const COLS = 120;
+const MAX_ROWS = 10;
+
+function emptyState(): ToolApprovalState {
+  return new ToolApprovalState();
+}
+
+function stateWithTool(name = 'read_file', input: Record<string, unknown> = { path: '/tmp/foo' }): ToolApprovalState {
+  const state = new ToolApprovalState();
+  state.addTool({ requestId: 'a', name, input });
+  return state;
+}
+
+function stateWithTwoTools(): ToolApprovalState {
+  const state = new ToolApprovalState();
+  state.addTool({ requestId: 'a', name: 'read_file', input: { path: '/tmp/foo' } });
+  state.addTool({ requestId: 'b', name: 'write_file', input: { path: '/tmp/bar' } });
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// No tools
+// ---------------------------------------------------------------------------
+
+describe('renderToolApproval — no tools', () => {
+  it('approvalRow is empty string when no tools', () => {
+    const expected = '';
+    const actual = renderToolApproval(emptyState(), COLS, MAX_ROWS).approvalRow;
+    expect(actual).toBe(expected);
+  });
+
+  it('expandedRows is empty when no tools', () => {
+    const expected = 0;
+    const actual = renderToolApproval(emptyState(), COLS, MAX_ROWS).expandedRows.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single tool, no approval pending
+// ---------------------------------------------------------------------------
+
+describe('renderToolApproval — single tool, no approval', () => {
+  it('approvalRow includes tool name', () => {
+    const expected = true;
+    const actual = renderToolApproval(stateWithTool('read_file'), COLS, MAX_ROWS).approvalRow.includes('read_file');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow does not include [Y/N] when no approval pending', () => {
+    const expected = false;
+    const actual = renderToolApproval(stateWithTool(), COLS, MAX_ROWS).approvalRow.includes('[Y/N]');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow does not include "Allow" when no approval pending', () => {
+    const expected = false;
+    const actual = renderToolApproval(stateWithTool(), COLS, MAX_ROWS).approvalRow.includes('Allow');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow includes expand hint when not expanded', () => {
+    const expected = true;
+    const actual = renderToolApproval(stateWithTool(), COLS, MAX_ROWS).approvalRow.includes('[space: expand]');
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single tool, approval pending
+// ---------------------------------------------------------------------------
+
+describe('renderToolApproval — approval pending', () => {
+  it('approvalRow includes [Y/N] when approval is pending', () => {
+    const state = stateWithTool();
+    state.requestApproval();
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, MAX_ROWS).approvalRow.includes('[Y/N]');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow includes "Allow" when approval is pending', () => {
+    const state = stateWithTool();
+    state.requestApproval();
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, MAX_ROWS).approvalRow.includes('Allow');
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple tools — navigation counter
+// ---------------------------------------------------------------------------
+
+describe('renderToolApproval — multiple tools', () => {
+  it('approvalRow includes 1/2 counter for first of two tools', () => {
+    const expected = true;
+    const actual = renderToolApproval(stateWithTwoTools(), COLS, MAX_ROWS).approvalRow.includes('1/2');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow includes 2/2 counter after selectNext', () => {
+    const state = stateWithTwoTools();
+    state.selectNext();
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, MAX_ROWS).approvalRow.includes('2/2');
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow does not include counter for single tool', () => {
+    const expected = false;
+    const actual = renderToolApproval(stateWithTool(), COLS, MAX_ROWS).approvalRow.includes('1/1');
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expand / collapse
+// ---------------------------------------------------------------------------
+
+describe('renderToolApproval — expanded', () => {
+  it('expandedRows is empty when not expanded', () => {
+    const expected = 0;
+    const actual = renderToolApproval(stateWithTool(), COLS, MAX_ROWS).expandedRows.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('expandedRows is non-empty when expanded', () => {
+    const state = stateWithTool();
+    state.toggleExpanded();
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, MAX_ROWS).expandedRows.length > 0;
+    expect(actual).toBe(expected);
+  });
+
+  it('approvalRow includes [space: collapse] when expanded', () => {
+    const state = stateWithTool();
+    state.toggleExpanded();
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, MAX_ROWS).approvalRow.includes('[space: collapse]');
+    expect(actual).toBe(expected);
+  });
+
+  it('expandedRows contains JSON content from tool input', () => {
+    const state = stateWithTool('read_file', { path: '/tmp/unique-path-xyz' });
+    state.toggleExpanded();
+    const rows = renderToolApproval(state, COLS, MAX_ROWS).expandedRows;
+    const expected = true;
+    const actual = rows.some((r) => r.includes('unique-path-xyz'));
+    expect(actual).toBe(expected);
+  });
+
+  it('expandedRows is capped at maxRows', () => {
+    // Large input that would produce more rows than the cap
+    const bigInput: Record<string, unknown> = {};
+    for (let i = 0; i < 100; i++) {
+      bigInput[`key${i}`] = `value${i}`;
+    }
+    const state = stateWithTool('heavy_tool', bigInput);
+    state.toggleExpanded();
+    const cap = 3;
+    const expected = true;
+    const actual = renderToolApproval(state, COLS, cap).expandedRows.length <= cap;
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
Part of the AppLayout refactor series.

## What

- New `ToolApprovalState.ts` — pure state for tool approval UI (pending tools list, selection, expand/collapse, promise queue for Y/N input)
- New `renderToolApproval.ts` — pure renderer returning `{ approvalRow, expandedRows }`
- `PendingTool` type moved from `AppLayout.ts` to `ToolApprovalState.ts`; re-exported from AppLayout so existing consumers are unaffected
- Dead methods `#buildApprovalRow` and `#buildExpandedRows` removed from AppLayout (37 lines)
- 29 new tests in `ToolApprovalState.spec.ts`, 16 in `renderToolApproval.spec.ts`

## Why the object return

`renderToolApproval` returns `{ approvalRow, expandedRows }` rather than a flat array because the two pieces go in different fixed positions in the layout — `expandedRows.length` determines the content-area height before `approvalRow` is positioned.

## Why PendingTool moved

AppLayout imports ToolApprovalState. If PendingTool stayed in AppLayout, ToolApprovalState would need to import from AppLayout — circular. Re-exporting from AppLayout keeps the public interface stable.

## Test count
276 across 11 files (up from 231).