### PR TITLE
Add ConversationSession: persistent conversation identity and n key

### DIFF
--- a/.claude/testament/2026-04-12.md
+++ b/.claude/testament/2026-04-12.md
@@ -47,3 +47,27 @@ The tsconfig has `verbatimModuleSyntax: true`. `IFileSystem` and `Conversation` 
 ### History serialisation
 
 The history file format isn't pinned by the tests -- they only check that what was saved can be round-tripped through `Conversation.setHistory()`. One message per line as JSON (matching the existing `saveHistory` in `main.ts`) is the natural choice and keeps the format consistent with the old `.sdk-history.jsonl`.
+
+
+
+# 11:02
+
+## Phase 2: ConversationSession implementation
+
+Branch: `feature/conversation-identity`. Four files staged, no commit yet.
+
+### Biome requires `public` on all class members
+
+The prompt's stub didn't include `public` modifiers. Biome's `useConsistentMemberAccessibility` rule rejects them without it. Add `public` to the constructor, `get id()`, `load()`, `save()`, and `createNew()`. `pnpm ci:fix` will catch this but not auto-fix it — you have to add them manually.
+
+### `pnpm ci:fix` exits 1 by design here
+
+The only remaining error after fixing our files is the pre-existing control character in `packages/claude-core/src/reflow.ts`. It is an unsafe fix; biome cannot auto-fix it. Exit code 1 is expected and not ours.
+
+### JSON.parse satisfies `BetaMessageParam[]` without a cast
+
+`JSON.parse` returns `any`. `any[]` is assignable to `BetaMessageParam[]`, so `setHistory(messages)` compiles without an explicit cast or an `Anthropic` import. Don't add one.
+
+### `conversation` must be created before `layout` in main.ts
+
+The `ConversationSession` constructor takes the `Conversation` instance directly. `session.load()` must be awaited before `AppLayout` is constructed, because `load()` populates the conversation that `historyReplay` then reads. The order in `main.ts` is: `conversation` → `session` → `await session.load()` → `layout`.

--- a/.claude/testament/2026-04-12.md
+++ b/.claude/testament/2026-04-12.md
@@ -17,3 +17,33 @@ Branch: `feature/extract-status-state`
 - `packages/claude-sdk-tools/test/Find.spec.ts`
 
 These are pre-existing formatting issues that biome auto-fixed as a side effect. When staging for commit, only stage the four files listed in the prompt -- leave those two out.
+
+
+# 10:52
+
+## Phase 1: ConversationSession stub and red tests
+
+Branch: `feature/conversation-identity`. Three files staged, no commit yet.
+
+### The renderCommandMode failures are expected and mechanical
+
+The spec now passes `conversationId` as the second argument, shifting `cols` to position 3. The implementation hasn't changed yet. `buildCommandRow` happens not to use `cols`, so those tests still pass. `buildPreviewRows` does use `cols` for `wrapLine`, so the three tests that exercise preview content now receive `''` as their width and break. These will fix themselves automatically when Phase 2 updates the signature. Don't touch them.
+
+### Clearing the conversation in createNew
+
+`Conversation` has no `clear()` method. The way to reset it is `this.#conversation.setHistory([])`.
+
+### File paths the implementation must use
+
+- Marker (cwd-relative): `{fs.cwd()}/.claude/.sdk-conversation-id`
+- History (home-relative): `{fs.homedir()}/.claude/conversations/{id}.jsonl`
+
+These are what the tests assume. The tests pre-populate `MemoryFileSystem` at these paths to simulate a previous run.
+
+### import type is required for the stub
+
+The tsconfig has `verbatimModuleSyntax: true`. `IFileSystem` and `Conversation` are only used as type annotations in the stub, so both must be `import type`. The tests import `Conversation` as a value (`new Conversation()`) so they use a regular import.
+
+### History serialisation
+
+The history file format isn't pinned by the tests -- they only check that what was saved can be round-tripped through `Conversation.setHistory()`. One message per line as JSON (matching the existing `saveHistory` in `main.ts`) is the natural choice and keeps the format consistent with the old `.sdk-history.jsonl`.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -1,3 +1,4 @@
 {"description":"Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns","category":"fixed"}
 {"description":"Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)","category":"fixed"}
 {"description":"Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement","category":"changed"}
+{"description":"Add ConversationSession: persistent conversation identity and n key to start new conversation","category":"added"}

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -9,6 +9,7 @@ import { readClipboardPath, readClipboardText } from './clipboard.js';
 import { logger } from './logger.js';
 import { buildSubmitText } from './model/buildSubmitText.js';
 import { CommandModeState } from './model/CommandModeState.js';
+import type { ConversationSession } from './model/ConversationSession.js';
 import type { Block, BlockType } from './model/ConversationState.js';
 import { ConversationState } from './model/ConversationState.js';
 import { EditorState } from './model/EditorState.js';
@@ -55,9 +56,11 @@ export class AppLayout implements Disposable {
   #cancelFn: (() => void) | null = null;
 
   readonly #statusState: StatusState;
+  readonly #session: ConversationSession;
 
-  public constructor(statusState: StatusState) {
+  public constructor(statusState: StatusState, session: ConversationSession) {
     this.#statusState = statusState;
+    this.#session = session;
     this.#screen = new StdoutScreen();
     this.#cleanupResize = this.#screen.onResize(() => {
       this.#resizing = true;
@@ -313,7 +316,7 @@ export class AppLayout implements Disposable {
     const totalRows = this.#screen.rows;
 
     const { approvalRow, expandedRows: toolRows } = renderToolApproval(this.#toolApprovalState, cols, Math.floor(totalRows / 2));
-    const { commandRow, previewRows } = renderCommandMode(this.#commandModeState, cols, Math.max(1, Math.floor(totalRows / 3)), Math.floor(totalRows / 2));
+    const { commandRow, previewRows } = renderCommandMode(this.#commandModeState, this.#session.id, cols, Math.max(1, Math.floor(totalRows / 3)), Math.floor(totalRows / 2));
     const expandedRows = [...toolRows, ...previewRows];
     // Fixed status bar: separator (1) + model line (1) + status line (1) + approval row (1) + command row (always 1) + optional expanded rows
     const statusBarHeight = 5 + expandedRows.length;
@@ -407,6 +410,18 @@ export class AppLayout implements Disposable {
           this.#commandModeState.togglePreview();
           this.render();
           return;
+        case 'n': {
+          this.#session
+            .createNew()
+            .then(() => {
+              this.#clearConversation();
+              this.render();
+            })
+            .catch(() => {
+              this.render();
+            });
+          return;
+        }
       }
     }
     if (key.type === 'left') {
@@ -420,5 +435,10 @@ export class AppLayout implements Disposable {
       return;
     }
     // All other keys silently consumed
+  }
+
+  #clearConversation(): void {
+    this.#conversationState = new ConversationState();
+    this.#editorState.reset();
   }
 }

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -1,6 +1,4 @@
-import { readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
-import type { Anthropic } from '@anthropic-ai/sdk';
 import { AnthropicAuth, AnthropicBeta, AnthropicClient, type AnyToolDefinition, ApprovalCoordinator, CacheTtl, ControlChannel, Conversation, type DurableConfig, QueryRunner, type SdkMessage, StreamProcessor, ToolRegistry, TurnRunner } from '@shellicar/claude-sdk';
 import { CreateFile } from '@shellicar/claude-sdk-tools/CreateFile';
 import { DeleteDirectory } from '@shellicar/claude-sdk-tools/DeleteDirectory';
@@ -27,6 +25,7 @@ import { AgentMessageHandler } from '../controller/AgentMessageHandler.js';
 import { GitStateMonitor } from '../GitStateMonitor.js';
 import { printUsage, printVersion, printVersionInfo, startupBannerText } from '../help.js';
 import { logger } from '../logger.js';
+import { ConversationSession } from '../model/ConversationSession.js';
 import { StatusState } from '../model/StatusState.js';
 import { ReadLine } from '../ReadLine.js';
 import { replayHistory } from '../replayHistory.js';
@@ -72,26 +71,6 @@ if (!process.stdin.isTTY) {
   process.exit(1);
 }
 
-const HISTORY_FILE = '.sdk-history.jsonl';
-
-function loadHistory(file: string): Anthropic.Beta.Messages.BetaMessageParam[] {
-  try {
-    const raw = readFileSync(file, 'utf-8');
-    return raw
-      .split('\n')
-      .filter((line) => line.length > 0)
-      .map((line) => JSON.parse(line) as Anthropic.Beta.Messages.BetaMessageParam);
-  } catch {
-    return [];
-  }
-}
-
-function saveHistory(conversation: Conversation, file: string): void {
-  const tmp = `${file}.tmp`;
-  writeFileSync(tmp, conversation.messages.map((msg) => JSON.stringify(msg)).join('\n'));
-  renameSync(tmp, file);
-}
-
 const main = async () => {
   const auth = new AnthropicAuth({ redirect: 'local' });
   await auth.getCredentials();
@@ -102,7 +81,10 @@ const main = async () => {
 
   using rl = new ReadLine();
   const statusState = new StatusState();
-  const layout = new AppLayout(statusState);
+  const conversation = new Conversation();
+  const session = new ConversationSession(nodeFs, conversation);
+  await session.load();
+  const layout = new AppLayout(statusState, session);
 
   let turnInProgress = false;
   const watcher = new SdkConfigWatcher((config) => {
@@ -127,7 +109,6 @@ const main = async () => {
   // --- SDK blocks (constructed once, reused for every query) ---
 
   const client = new AnthropicClient({ authToken, logger });
-  const conversation = new Conversation();
   const processor = new StreamProcessor(logger);
   const approval = new ApprovalCoordinator();
 
@@ -209,13 +190,6 @@ const main = async () => {
     handler.handle(msg);
   });
 
-  // --- History ---
-
-  const savedHistory = loadHistory(HISTORY_FILE);
-  if (savedHistory.length > 0) {
-    conversation.setHistory(savedHistory);
-  }
-
   if (watcher.config.historyReplay.enabled) {
     const history = conversation.messages;
     if (history.length > 0) {
@@ -254,7 +228,7 @@ const main = async () => {
     currentAbortController = null;
     statusState.setModel(watcher.config.model);
     layout.render();
-    saveHistory(conversation, HISTORY_FILE);
+    await session.save();
   }
 };
 await main();

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -1,21 +1,54 @@
+import { randomUUID } from 'node:crypto';
 import type { Conversation } from '@shellicar/claude-sdk';
 import type { IFileSystem } from '@shellicar/claude-sdk-tools/fs';
 
 export class ConversationSession {
   readonly #fs: IFileSystem;
   readonly #conversation: Conversation;
-  #id: string = '';
+  #id = '';
 
-  constructor(fs: IFileSystem, conversation: Conversation) {
+  public constructor(fs: IFileSystem, conversation: Conversation) {
     this.#fs = fs;
     this.#conversation = conversation;
   }
 
-  get id(): string {
+  public get id(): string {
     return this.#id;
   }
 
-  async load(): Promise<void> {}
-  async save(): Promise<void> {}
-  async createNew(): Promise<void> {}
+  public async load(): Promise<void> {
+    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
+    const markerExists = await this.#fs.exists(markerPath);
+    if (markerExists) {
+      const savedId = await this.#fs.readFile(markerPath);
+      this.#id = savedId.trim();
+      const historyPath = `${this.#fs.homedir()}/.claude/conversations/${this.#id}.jsonl`;
+      const historyExists = await this.#fs.exists(historyPath);
+      if (historyExists) {
+        const raw = await this.#fs.readFile(historyPath);
+        const messages = raw
+          .split('\n')
+          .filter((line) => line.length > 0)
+          .map((line) => JSON.parse(line));
+        this.#conversation.setHistory(messages);
+      }
+    } else {
+      this.#id = randomUUID();
+      await this.#fs.writeFile(markerPath, this.#id);
+    }
+  }
+
+  public async save(): Promise<void> {
+    const historyPath = `${this.#fs.homedir()}/.claude/conversations/${this.#id}.jsonl`;
+    const content = this.#conversation.messages.map((msg) => JSON.stringify(msg)).join('\n');
+    await this.#fs.writeFile(historyPath, content);
+  }
+
+  public async createNew(): Promise<void> {
+    await this.save();
+    this.#id = randomUUID();
+    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
+    await this.#fs.writeFile(markerPath, this.#id);
+    this.#conversation.setHistory([]);
+  }
 }

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -1,0 +1,21 @@
+import type { Conversation } from '@shellicar/claude-sdk';
+import type { IFileSystem } from '@shellicar/claude-sdk-tools/fs';
+
+export class ConversationSession {
+  readonly #fs: IFileSystem;
+  readonly #conversation: Conversation;
+  #id: string = '';
+
+  constructor(fs: IFileSystem, conversation: Conversation) {
+    this.#fs = fs;
+    this.#conversation = conversation;
+  }
+
+  get id(): string {
+    return this.#id;
+  }
+
+  async load(): Promise<void> {}
+  async save(): Promise<void> {}
+  async createNew(): Promise<void> {}
+}

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -24,14 +24,14 @@ export type CommandModeRender = {
  * Math.max(1, Math.floor(totalRows / 3))). maxRows is the absolute cap on
  * previewRows length (caller passes Math.floor(totalRows / 2)).
  */
-export function renderCommandMode(state: CommandModeState, cols: number, maxTextLines: number, maxRows: number): CommandModeRender {
+export function renderCommandMode(state: CommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number): CommandModeRender {
   return {
-    commandRow: buildCommandRow(state),
+    commandRow: buildCommandRow(state, conversationId),
     previewRows: buildPreviewRows(state, cols, maxTextLines, maxRows),
   };
 }
 
-function buildCommandRow(state: CommandModeState): string {
+function buildCommandRow(state: CommandModeState, conversationId: string): string {
   const hasAttachments = state.hasAttachments;
   if (!state.commandMode && !hasAttachments) {
     return '';
@@ -79,6 +79,9 @@ function buildCommandRow(state: CommandModeState): string {
   if (state.commandMode) {
     b.ansi(DIM);
     b.text('cmd');
+    if (conversationId) {
+      b.text(` [${conversationId.slice(0, 8)}]`);
+    }
     b.ansi(RESET);
     if (hasAttachments) {
       b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  ESC cancel');

--- a/apps/claude-sdk-cli/test/ConversationSession.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSession.spec.ts
@@ -1,0 +1,89 @@
+import { Conversation } from '@shellicar/claude-sdk';
+import { MemoryFileSystem } from '@shellicar/claude-sdk-tools/fs';
+import { describe, expect, it } from 'vitest';
+import { ConversationSession } from '../src/model/ConversationSession.js';
+
+const HOME = '/home/user';
+const CWD = '/project';
+const MARKER_FILE = `${CWD}/.claude/.sdk-conversation-id`;
+
+// ---------------------------------------------------------------------------
+// load
+// ---------------------------------------------------------------------------
+
+describe('ConversationSession — load', () => {
+  it('generates an ID when no marker file exists', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+
+    const expected = true;
+    const actual = session.id.length > 0;
+    expect(actual).toBe(expected);
+  });
+
+  it('restores the same ID from a previous run', async () => {
+    const savedId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const fs = new MemoryFileSystem({ [MARKER_FILE]: savedId }, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+
+    const expected = savedId;
+    const actual = session.id;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createNew
+// ---------------------------------------------------------------------------
+
+describe('ConversationSession — createNew', () => {
+  it('generates a different ID', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    const firstId = session.id;
+    await session.createNew();
+
+    const expected = false;
+    const actual = session.id === firstId;
+    expect(actual).toBe(expected);
+  });
+
+  it('clears the conversation', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const conversation = new Conversation();
+    const session = new ConversationSession(fs, conversation);
+    await session.load();
+    conversation.push({ role: 'user', content: [{ type: 'text', text: 'hello' }] });
+    await session.createNew();
+
+    const expected = 0;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// save
+// ---------------------------------------------------------------------------
+
+describe('ConversationSession — save', () => {
+  it('writes history that load can restore', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const conversation = new Conversation();
+    const session = new ConversationSession(fs, conversation);
+    await session.load();
+    conversation.push({ role: 'user', content: [{ type: 'text', text: 'hello' }] });
+    await session.save();
+
+    const restoredConversation = new Conversation();
+    const restoredSession = new ConversationSession(fs, restoredConversation);
+    await restoredSession.load();
+
+    const expected = 1;
+    const actual = restoredConversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
+++ b/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
@@ -36,13 +36,13 @@ function stateInCommandModeWithText(text = 'hello world'): CommandModeState {
 describe('renderCommandMode — empty state', () => {
   it('commandRow is empty when no command mode and no attachments', () => {
     const expected = '';
-    const actual = renderCommandMode(emptyState(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow;
+    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow;
     expect(actual).toBe(expected);
   });
 
   it('previewRows is empty when no command mode and no attachments', () => {
     const expected = 0;
-    const actual = renderCommandMode(emptyState(), COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
     expect(actual).toBe(expected);
   });
 });
@@ -54,13 +54,13 @@ describe('renderCommandMode — empty state', () => {
 describe('renderCommandMode — attachment chips without command mode', () => {
   it('commandRow is non-empty when attachments exist even without command mode', () => {
     const expected = true;
-    const actual = renderCommandMode(stateWithText(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.length > 0;
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.length > 0;
     expect(actual).toBe(expected);
   });
 
   it('commandRow does not include cmd hint when not in command mode', () => {
     const expected = false;
-    const actual = renderCommandMode(stateWithText(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
     expect(actual).toBe(expected);
   });
 });
@@ -72,19 +72,19 @@ describe('renderCommandMode — attachment chips without command mode', () => {
 describe('renderCommandMode — command mode active', () => {
   it('commandRow includes "cmd" when in command mode', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes paste hint when in command mode with no attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('paste');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('paste');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes select hint when in command mode with attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandModeWithText(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('select');
+    const actual = renderCommandMode(stateInCommandModeWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('select');
     expect(actual).toBe(expected);
   });
 });
@@ -96,7 +96,7 @@ describe('renderCommandMode — command mode active', () => {
 describe('renderCommandMode — text attachment chip', () => {
   it('commandRow includes [txt ...] chip for text attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateWithText(), COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('[txt ');
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('[txt ');
     expect(actual).toBe(expected);
   });
 });
@@ -106,7 +106,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/myfile.txt', 'file', 512);
     const expected = true;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('myfile.txt');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('myfile.txt');
     expect(actual).toBe(expected);
   });
 
@@ -114,7 +114,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/mydir', 'dir');
     const expected = true;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('mydir/');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('mydir/');
     expect(actual).toBe(expected);
   });
 
@@ -122,7 +122,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/missing.txt', 'missing');
     const expected = true;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('?');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('?');
     expect(actual).toBe(expected);
   });
 });
@@ -137,7 +137,7 @@ describe('renderCommandMode — previewRows', () => {
     state.togglePreview(); // no selection, no-op initially — need to add text first... actually addText selects it
     // Re-create: addText selects the item, but commandMode is off
     const expected = 0;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
     expect(actual).toBe(expected);
   });
 
@@ -145,7 +145,7 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText('line one\nline two');
     // previewMode is still false
     const expected = 0;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
     expect(actual).toBe(expected);
   });
 
@@ -153,14 +153,14 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText('line one\nline two');
     state.togglePreview();
     const expected = true;
-    const actual = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length > 0;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length > 0;
     expect(actual).toBe(expected);
   });
 
   it('previewRows contains text attachment content', () => {
     const state = stateInCommandModeWithText('unique-sentinel-value');
     state.togglePreview();
-    const rows = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('unique-sentinel-value'));
     expect(actual).toBe(expected);
@@ -171,7 +171,7 @@ describe('renderCommandMode — previewRows', () => {
     state.addFile('/tmp/special-path', 'file', 100);
     state.toggleCommandMode();
     state.togglePreview();
-    const rows = renderCommandMode(state, COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('special-path'));
     expect(actual).toBe(expected);
@@ -182,7 +182,7 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText(manyLines);
     state.togglePreview();
     const cap = 3;
-    const rows = renderCommandMode(state, COLS, MAX_TEXT_LINES, cap).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, cap).previewRows;
     const expected = true;
     const actual = rows.length <= cap;
     expect(actual).toBe(expected);
@@ -193,10 +193,29 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText(manyLines);
     state.togglePreview();
     const maxText = 4;
-    const rows = renderCommandMode(state, COLS, maxText, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, maxText, MAX_ROWS).previewRows;
     const expected = true;
     // Should see the "more lines" ellipsis
     const actual = rows.some((r) => r.includes('more lines'));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation ID display
+// ---------------------------------------------------------------------------
+
+describe('renderCommandMode — conversationId', () => {
+  it('shows the short ID in the command row when conversationId is set', () => {
+    const id = 'abcd1234-5678-90ab-cdef-1234567890ab';
+    const expected = true;
+    const actual = renderCommandMode(stateInCommandMode(), id, COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes(id.slice(0, 8));
+    expect(actual).toBe(expected);
+  });
+
+  it('does not show an ID label when conversationId is empty', () => {
+    const expected = false;
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('abcd1234');
     expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary

- Add `ConversationSession` to the model layer: persists conversation identity across runs
- Show short ID in command row for quick reference
- `n` key in command mode starts a new conversation

## Related Issues

Closes #245