### PR TITLE
Add compact config: control compaction settings

### DIFF
--- a/.claude/testament/2026-04-13.md
+++ b/.claude/testament/2026-04-13.md
@@ -17,3 +17,26 @@ EventEmitter composition on `AnthropicClient` (Design 3). The client holds a pri
 ## What was added to `IFileSystem`
 
 `appendFile(path: string, content: string): Promise<void>` on the abstract class. `NodeFileSystem` creates parent directories before appending (same pattern as `writeFile`). `MemoryFileSystem` concatenates to existing content or creates.
+
+
+# 23:55
+
+## Compaction block conversion investigation
+
+Branch: N/A (investigation only, output to fleet repo)
+
+### Key finding: the reference CLI doesn't help here
+
+The reference CLI (Claude Code) uses local (client-side) compaction. It makes a separate API call to summarize, creates its own boundary marker and summary user message, and `normalizeMessagesForAPI` filters out the boundary. It never sends `compaction` content blocks back to the API, so it never faces the problem of converting them when compact is disabled.
+
+The API's `compaction` content block (from server-side `compact_20260112` beta) appears in assistant responses. The reference CLI's code just passes it through in `normalizeMessagesForAPI` without special handling.
+
+### Where the conversion lives in our SDK
+
+`Conversation.cloneForRequest()` in `packages/claude-sdk/src/private/Conversation.ts`. It already has `hasCompactionBlock` and `trimToLastCompaction`. The conversion is a block-level transform: replace `{ type: 'compaction', content: 'summary' }` with `{ type: 'text', text: 'summary' }` inside the assistant message. The message role stays `assistant`.
+
+`cloneForRequest()` needs a parameter to know whether compact is enabled. The caller (`TurnRunner.run`) has `DurableConfig.betas` which contains `AnthropicBeta.Compact`.
+
+### BetaCompactionBlockParam
+
+`content` is `string | null`. Null means failed compaction. Our internal `ContentBlock` type has `content: string` (non-nullable). Null content means no summary to convert; drop the block.

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -1,0 +1,33 @@
+# 00:06
+
+## Phase 1 complete: Compact config
+
+Branch: `feature/compact-config`. 11 files staged, no commit yet.
+
+### What changed
+
+Compaction settings moved from hardcoded values in `main.ts` and flat fields on `DurableConfig` into a `CompactConfig` type with four fields: `enabled`, `inputTokens`, `pauseAfterCompaction`, `customInstructions`. The config schema in `sdk-config.json` exposes all four with safe defaults (enabled: true, inputTokens: 160000, pauseAfterCompaction: true).
+
+### Key design decisions
+
+**`AnthropicBeta.Compact` removed from the betas object**: Previously the compact beta was controlled via `betas: { [AnthropicBeta.Compact]: true }` and the beta header was built by iterating all enabled betas. Now the `compact.enabled` flag is the single source of truth. The `RequestBuilder` appends the compact beta string directly when `compact?.enabled` is true, after the betas loop. This means `AnthropicBeta.Compact` no longer appears in the `betas` object on `DurableConfig`.
+
+**`cloneForRequest(compactEnabled: boolean)` parameter**: The `Conversation.cloneForRequest` method now requires a boolean. When false, `convertCompactionBlocks` transforms each compaction block to a text block using its summary content. Null content (failed compaction) drops the block; empty assistant messages are dropped too. The existing trim-to-last-compaction logic still runs first, so only the most recent compaction slice is sent.
+
+**Compaction block type casting**: The `BetaContentBlockParam` union doesn't expose `content` on the compaction variant directly in a way TypeScript can narrow. Used `(block as { content?: string | null }).content` to read it. This is the same approach the codebase uses elsewhere for API types.
+
+### Test updates
+
+- `Conversation.spec.ts`: All `cloneForRequest()` calls now pass `true` (existing tests were compact-enabled scenarios).
+- `RequestBuilder.spec.ts`: Compact tests rewritten to use `compact: { enabled, inputTokens, pauseAfterCompaction }` instead of `betas + pauseAfterCompact + compactInputTokens`. Added tests for: disabled compact, missing compact, instructions default to null, custom instructions, beta header presence/absence.
+- `cli-config.spec.ts`: Defaults test updated to include compact defaults.
+
+### `AnthropicBeta.Compact` removed from enum
+
+The SC requested removing `Compact` from the `AnthropicBeta` enum entirely. The beta string is now a standalone `COMPACT_BETA` constant exported from `enums.ts` and the package index. `RequestBuilder` imports and uses it directly. The enum no longer drives compact behavior at all; `CompactConfig.enabled` is the sole gate.
+
+Test impact: the header tests in `RequestBuilder.spec.ts` that used `AnthropicBeta.Compact` to verify the betas header loop were switched to use `AnthropicBeta.ClaudeCodeAuth` instead. Separate tests verify compact header inclusion/exclusion via `COMPACT_BETA`.
+
+### Pre-existing biome issues
+
+`pnpm ci:fix` modifies three files outside our scope: `reflow.ts` (unsafe control char), `Find.ts`, `Find.spec.ts`. Exit code 1 is from the `reflow.ts` error. Not our files, not staged.

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -1,33 +1,9 @@
-# 00:06
+# Compact Config
 
-## Phase 1 complete: Compact config
+## Traps
 
-Branch: `feature/compact-config`. 11 files staged, no commit yet.
+**Type narrowing on compaction blocks**: `BetaContentBlockParam` doesn't let TypeScript narrow to `content` on the compaction variant. The codebase uses `(block as { content?: string | null }).content`. Don't fight the type system here; the cast is intentional.
 
-### What changed
+**`changes.jsonl` categories**: The valid values are `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`. Not `feature`, not `enhancement`. If a prompt says `"category":"feature"`, use `"added"`.
 
-Compaction settings moved from hardcoded values in `main.ts` and flat fields on `DurableConfig` into a `CompactConfig` type with four fields: `enabled`, `inputTokens`, `pauseAfterCompaction`, `customInstructions`. The config schema in `sdk-config.json` exposes all four with safe defaults (enabled: true, inputTokens: 160000, pauseAfterCompaction: true).
-
-### Key design decisions
-
-**`AnthropicBeta.Compact` removed from the betas object**: Previously the compact beta was controlled via `betas: { [AnthropicBeta.Compact]: true }` and the beta header was built by iterating all enabled betas. Now the `compact.enabled` flag is the single source of truth. The `RequestBuilder` appends the compact beta string directly when `compact?.enabled` is true, after the betas loop. This means `AnthropicBeta.Compact` no longer appears in the `betas` object on `DurableConfig`.
-
-**`cloneForRequest(compactEnabled: boolean)` parameter**: The `Conversation.cloneForRequest` method now requires a boolean. When false, `convertCompactionBlocks` transforms each compaction block to a text block using its summary content. Null content (failed compaction) drops the block; empty assistant messages are dropped too. The existing trim-to-last-compaction logic still runs first, so only the most recent compaction slice is sent.
-
-**Compaction block type casting**: The `BetaContentBlockParam` union doesn't expose `content` on the compaction variant directly in a way TypeScript can narrow. Used `(block as { content?: string | null }).content` to read it. This is the same approach the codebase uses elsewhere for API types.
-
-### Test updates
-
-- `Conversation.spec.ts`: All `cloneForRequest()` calls now pass `true` (existing tests were compact-enabled scenarios).
-- `RequestBuilder.spec.ts`: Compact tests rewritten to use `compact: { enabled, inputTokens, pauseAfterCompaction }` instead of `betas + pauseAfterCompact + compactInputTokens`. Added tests for: disabled compact, missing compact, instructions default to null, custom instructions, beta header presence/absence.
-- `cli-config.spec.ts`: Defaults test updated to include compact defaults.
-
-### `AnthropicBeta.Compact` removed from enum
-
-The SC requested removing `Compact` from the `AnthropicBeta` enum entirely. The beta string is now a standalone `COMPACT_BETA` constant exported from `enums.ts` and the package index. `RequestBuilder` imports and uses it directly. The enum no longer drives compact behavior at all; `CompactConfig.enabled` is the sole gate.
-
-Test impact: the header tests in `RequestBuilder.spec.ts` that used `AnthropicBeta.Compact` to verify the betas header loop were switched to use `AnthropicBeta.ClaudeCodeAuth` instead. Separate tests verify compact header inclusion/exclusion via `COMPACT_BETA`.
-
-### Pre-existing biome issues
-
-`pnpm ci:fix` modifies three files outside our scope: `reflow.ts` (unsafe control char), `Find.ts`, `Find.spec.ts`. Exit code 1 is from the `reflow.ts` error. Not our files, not staged.
+**Biome exit code 1**: `pnpm ci:fix` always exits 1 due to a pre-existing unsafe lint error in `packages/claude-core/src/reflow.ts`. It also auto-formats `Find.ts` and `Find.spec.ts` outside your scope. Don't stage those. This is not your problem.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -3,3 +3,4 @@
 {"description":"Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement","category":"changed"}
 {"description":"Add ConversationSession: persistent conversation identity and n key to start new conversation","category":"added"}
 {"description":"Write BetaMessage per turn to ~/.claude/audit/<conversation-id>.jsonl","category":"added"}
+{"description":"Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`","category":"added"}

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -19,11 +19,23 @@ const claudeMdSchema = z
   .default({ enabled: true })
   .catch({ enabled: true });
 
+const compactSchema = z
+  .object({
+    enabled: z.boolean().optional().default(true).catch(true).describe('Enable conversation compaction'),
+    inputTokens: z.number().int().positive().optional().default(160_000).catch(160_000).describe('Token threshold at which compaction triggers'),
+    pauseAfterCompaction: z.boolean().optional().default(true).catch(true).describe('Whether to pause after a compaction occurs'),
+    customInstructions: z.string().optional().describe('Custom instructions to guide the compaction summary'),
+  })
+  .optional()
+  .default({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true })
+  .catch({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true });
+
 export const sdkConfigSchema = z
   .object({
     $schema: z.string().optional().describe('JSON Schema reference for editor autocomplete'),
     model: z.string().optional().default(DEFAULT_MODEL).catch(DEFAULT_MODEL).describe('Claude model to use'),
     historyReplay: historyReplaySchema.describe('History replay configuration'),
     claudeMd: claudeMdSchema.describe('CLAUDE.md loading configuration'),
+    compact: compactSchema.describe('Compaction configuration'),
   })
   .meta({ title: 'Claude SDK CLI Configuration', description: 'Configuration for @shellicar/claude-sdk-cli' });

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -168,15 +168,13 @@ const main = async () => {
     systemPrompts,
     tools,
     betas: {
-      [AnthropicBeta.Compact]: true,
       [AnthropicBeta.ClaudeCodeAuth]: true,
       [AnthropicBeta.ContextManagement]: false,
       [AnthropicBeta.PromptCachingScope]: false,
       [AnthropicBeta.AdvancedToolUse]: true,
     },
     requireToolApproval: true,
-    pauseAfterCompact: true,
-    compactInputTokens: 160_000,
+    compact: watcher.config.compact,
     cacheTtl: CacheTtl.OneHour,
   };
 
@@ -218,6 +216,7 @@ const main = async () => {
 
     // Update durable config with current values before each query
     durableConfig.model = watcher.config.model;
+    durableConfig.compact = watcher.config.compact;
     durableConfig.cachedReminders = claudeMdContent != null ? [claudeMdContent] : undefined;
 
     const abortController = new AbortController();

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -13,6 +13,7 @@ describe('sdkConfigSchema', () => {
         model: 'claude-sonnet-4-6',
         historyReplay: { enabled: true, showThinking: false },
         claudeMd: { enabled: true },
+        compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: true },
       });
     });
 

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -2,3 +2,5 @@
 {"description":"Conversation retains full message history across compaction; adds internal `cloneForRequest()` that returns a deep-cloned post-compaction slice for API requests","category":"changed"}
 {"description":"Extract `AnthropicClient` from `AnthropicAgent`: auth, token refresh, and HTTP transport now live in a dedicated private class. `AnthropicAgent` becomes a thin composer that holds a client and a conversation. The previous `AnthropicMessageStreamer` wrapper is removed; `AnthropicClient` extends `IMessageStreamer` directly.","category":"changed"}
 {"description":"Add finalMessage event emitter surface to AnthropicClient","category":"added"}
+{"description":"Add `CompactConfig` type; `cloneForRequest` converts compaction blocks to text when compact is disabled","category":"added"}
+{"description":"Replace `AnthropicBeta.Compact` enum member with standalone `COMPACT_BETA` constant","category":"changed"}

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -10,9 +10,28 @@ import { StreamProcessor } from './private/StreamProcessor';
 import { ToolRegistry } from './private/ToolRegistry';
 import { TurnRunner } from './private/TurnRunner';
 import { defineTool } from './public/defineTool';
-import { AnthropicBeta, CacheTtl } from './public/enums';
-import type { AnthropicBetaFlags, AnyToolDefinition, ConsumerMessage, DurableConfig, ILogger, SdkDone, SdkError, SdkMessage, SdkMessageEnd, SdkMessageStart, SdkMessageText, SdkMessageUsage, SdkQuerySummary, SdkToolApprovalRequest, ToolDefinition, ToolOperation, TransformToolResult } from './public/types';
+import { AnthropicBeta, CacheTtl, COMPACT_BETA } from './public/enums';
+import type {
+  AnthropicBetaFlags,
+  AnyToolDefinition,
+  CompactConfig,
+  ConsumerMessage,
+  DurableConfig,
+  ILogger,
+  SdkDone,
+  SdkError,
+  SdkMessage,
+  SdkMessageEnd,
+  SdkMessageStart,
+  SdkMessageText,
+  SdkMessageUsage,
+  SdkQuerySummary,
+  SdkToolApprovalRequest,
+  ToolDefinition,
+  ToolOperation,
+  TransformToolResult,
+} from './public/types';
 
 export type { BetaMessage, BetaMessageParam } from '@anthropic-ai/sdk/resources/beta.js';
-export type { AnthropicBetaFlags, AnyToolDefinition, AuthCredentials, ConsumerMessage, DurableConfig, ILogger, SdkDone, SdkError, SdkMessage, SdkMessageEnd, SdkMessageStart, SdkMessageText, SdkMessageUsage, SdkQuerySummary, SdkToolApprovalRequest, ToolDefinition, ToolOperation, TransformToolResult };
-export { AnthropicAuth, AnthropicBeta, AnthropicClient, ApprovalCoordinator, CacheTtl, ControlChannel, Conversation, calculateCost, defineTool, QueryRunner, StreamProcessor, ToolRegistry, TurnRunner };
+export type { AnthropicBetaFlags, AnyToolDefinition, AuthCredentials, CompactConfig, ConsumerMessage, DurableConfig, ILogger, SdkDone, SdkError, SdkMessage, SdkMessageEnd, SdkMessageStart, SdkMessageText, SdkMessageUsage, SdkQuerySummary, SdkToolApprovalRequest, ToolDefinition, ToolOperation, TransformToolResult };
+export { AnthropicAuth, AnthropicBeta, AnthropicClient, ApprovalCoordinator, CacheTtl, COMPACT_BETA, ControlChannel, Conversation, calculateCost, defineTool, QueryRunner, StreamProcessor, ToolRegistry, TurnRunner };

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -46,9 +46,19 @@ export class Conversation {
    * sending to the API. The returned array is owned by the caller and may be
    * mutated freely. If there is no compaction block, the entire history is
    * cloned.
+   *
+   * When `compactEnabled` is false and compaction blocks exist in the trimmed
+   * slice, each compaction block is converted to a text block using its summary
+   * content. Blocks with null content (failed compaction) are dropped. If
+   * dropping blocks leaves an assistant message with no content, that message
+   * is dropped too.
    */
-  public cloneForRequest(): Anthropic.Beta.Messages.BetaMessageParam[] {
-    return trimToLastCompaction(this.#items).map((item) => structuredClone(item.msg));
+  public cloneForRequest(compactEnabled: boolean): Anthropic.Beta.Messages.BetaMessageParam[] {
+    const cloned = trimToLastCompaction(this.#items).map((item) => structuredClone(item.msg));
+    if (compactEnabled) {
+      return cloned;
+    }
+    return convertCompactionBlocks(cloned);
   }
 
   /**
@@ -94,4 +104,34 @@ export class Conversation {
     this.#items.splice(idx, 1);
     return true;
   }
+}
+
+/**
+ * Convert compaction blocks to text blocks so the API accepts them without
+ * the compact beta header. Blocks with null/missing content (failed
+ * compaction) are dropped. Messages left with no content blocks are dropped.
+ */
+function convertCompactionBlocks(messages: Anthropic.Beta.Messages.BetaMessageParam[]): Anthropic.Beta.Messages.BetaMessageParam[] {
+  const result: Anthropic.Beta.Messages.BetaMessageParam[] = [];
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) {
+      result.push(msg);
+      continue;
+    }
+    const converted: typeof msg.content = [];
+    for (const block of msg.content) {
+      if (block.type === 'compaction') {
+        const content = (block as { content?: string | null }).content;
+        if (content != null) {
+          converted.push({ type: 'text', text: content });
+        }
+      } else {
+        converted.push(block);
+      }
+    }
+    if (converted.length > 0) {
+      result.push({ ...msg, content: converted });
+    }
+  }
+  return result;
 }

--- a/packages/claude-sdk/src/private/RequestBuilder.ts
+++ b/packages/claude-sdk/src/private/RequestBuilder.ts
@@ -2,8 +2,8 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaCacheControlEphemeral, BetaClearThinking20251015Edit, BetaClearToolUses20250919Edit, BetaCompact20260112Edit, BetaContextManagementConfig, BetaTextBlockParam, BetaToolUnion } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { Model } from '@anthropic-ai/sdk/resources/messages';
-import { AnthropicBeta, CacheTtl } from '../public/enums';
-import type { AnthropicBetaFlags, AnyToolDefinition } from '../public/types';
+import { AnthropicBeta, CacheTtl, COMPACT_BETA } from '../public/enums';
+import type { AnthropicBetaFlags, AnyToolDefinition, CompactConfig } from '../public/types';
 import { AGENT_SDK_PREFIX } from './consts';
 
 export type RequestParams = {
@@ -19,8 +19,7 @@ export type RequestBuilderOptions = {
   systemReminder?: string;
   tools: AnyToolDefinition[];
   betas?: AnthropicBetaFlags;
-  pauseAfterCompact?: boolean;
-  compactInputTokens?: number;
+  compact?: CompactConfig;
   cacheTtl?: CacheTtl;
 };
 
@@ -95,16 +94,12 @@ export function buildRequestParams(options: RequestBuilderOptions, messages: Ant
     context_management.edits?.push({ type: 'clear_thinking_20251015' } satisfies BetaClearThinking20251015Edit);
     context_management.edits?.push({ type: 'clear_tool_uses_20250919' } satisfies BetaClearToolUses20250919Edit);
   }
-  if (betas[AnthropicBeta.Compact]) {
+  if (options.compact?.enabled) {
     context_management.edits?.push({
       type: 'compact_20260112',
-      pause_after_compaction: options.pauseAfterCompact ?? false,
-      trigger: options.compactInputTokens
-        ? {
-            type: 'input_tokens',
-            value: options.compactInputTokens,
-          }
-        : null,
+      pause_after_compaction: options.compact.pauseAfterCompaction,
+      instructions: options.compact.customInstructions ?? null,
+      trigger: { type: 'input_tokens', value: options.compact.inputTokens },
     } satisfies BetaCompact20260112Edit);
   }
 
@@ -157,14 +152,17 @@ export function buildRequestParams(options: RequestBuilderOptions, messages: Ant
     body.thinking = { type: 'adaptive' };
   }
 
-  const anthropicBetas = Object.entries(betas)
+  const betaStrings = Object.entries(betas)
     .filter(([, enabled]) => enabled)
-    .map(([beta]) => beta)
-    .join(',');
+    .map(([beta]) => beta);
+
+  if (options.compact?.enabled) {
+    betaStrings.push(COMPACT_BETA);
+  }
 
   return {
     body,
-    headers: { 'anthropic-beta': anthropicBetas },
+    headers: { 'anthropic-beta': betaStrings.join(',') },
   };
 }
 

--- a/packages/claude-sdk/src/private/TurnRunner.ts
+++ b/packages/claude-sdk/src/private/TurnRunner.ts
@@ -54,7 +54,8 @@ export class TurnRunner extends ITurnRunner {
   }
 
   public async run(conversation: Conversation, durable: DurableConfig, turnInput: TurnInput): Promise<MessageStreamResult> {
-    const messages = conversation.cloneForRequest();
+    const compactEnabled = durable.compact?.enabled ?? false;
+    const messages = conversation.cloneForRequest(compactEnabled);
 
     const builderOptions: RequestBuilderOptions = {
       model: durable.model,
@@ -64,8 +65,7 @@ export class TurnRunner extends ITurnRunner {
       betas: durable.betas,
       systemPrompts: durable.systemPrompts,
       systemReminder: turnInput.systemReminder,
-      pauseAfterCompact: durable.pauseAfterCompact,
-      compactInputTokens: durable.compactInputTokens,
+      compact: durable.compact,
       cacheTtl: durable.cacheTtl,
     };
     const { body, headers } = buildRequestParams(builderOptions, messages);

--- a/packages/claude-sdk/src/public/enums.ts
+++ b/packages/claude-sdk/src/public/enums.ts
@@ -3,11 +3,10 @@ export enum CacheTtl {
   OneHour = '1h',
 }
 
+/** Beta header string for compact. Not in the enum because compact is controlled by CompactConfig, not the betas flags. */
+export const COMPACT_BETA = 'compact-2026-01-12';
+
 export enum AnthropicBeta {
-  /**
-   * @see https://platform.claude.com/docs/en/build-with-claude/compaction
-   */
-  Compact = 'compact-2026-01-12',
   ClaudeCodeAuth = 'oauth-2025-04-20',
   /**
    * @see https://platform.claude.com/docs/en/build-with-claude/extended-thinking#interleaved-thinking

--- a/packages/claude-sdk/src/public/types.ts
+++ b/packages/claude-sdk/src/public/types.ts
@@ -59,6 +59,13 @@ export type ToolResolveResult = { kind: 'ready'; run: (transform?: TransformTool
  * Does NOT contain per-query inputs: the user message list, `transformToolResult`, or the
  * one-shot `systemReminder`. Those are supplied per call, not held across queries.
  */
+export type CompactConfig = {
+  enabled: boolean;
+  inputTokens: number;
+  pauseAfterCompaction: boolean;
+  customInstructions?: string;
+};
+
 export type DurableConfig = {
   model: Model;
   thinking?: boolean;
@@ -67,8 +74,7 @@ export type DurableConfig = {
   tools: AnyToolDefinition[];
   betas?: AnthropicBetaFlags;
   requireToolApproval?: boolean;
-  pauseAfterCompact?: boolean;
-  compactInputTokens?: number;
+  compact?: CompactConfig;
   cacheTtl?: CacheTtl;
   cachedReminders?: string[];
 };

--- a/packages/claude-sdk/test/Conversation.spec.ts
+++ b/packages/claude-sdk/test/Conversation.spec.ts
@@ -261,7 +261,7 @@ describe('Conversation.setHistory', () => {
   it('cloneForRequest respects compaction blocks from setHistory', () => {
     const c = new Conversation();
     c.setHistory([msg('user', 'old'), msg('assistant', 'old reply'), compactionMsg(), msg('user', 'new')]);
-    const clone = c.cloneForRequest();
+    const clone = c.cloneForRequest(true);
     // compaction + new = 2; old + old reply excluded
     const expected = 2;
     const actual = clone.length;
@@ -286,7 +286,7 @@ describe('Conversation.cloneForRequest', () => {
   it('returns an empty array for an empty conversation', () => {
     const c = new Conversation();
     const expected = 0;
-    const actual = c.cloneForRequest().length;
+    const actual = c.cloneForRequest(true).length;
     expect(actual).toBe(expected);
   });
 
@@ -296,7 +296,7 @@ describe('Conversation.cloneForRequest', () => {
     c.push(msg('assistant', 'b'));
     c.push(msg('user', 'c'));
     const expected = 3;
-    const actual = c.cloneForRequest().length;
+    const actual = c.cloneForRequest(true).length;
     expect(actual).toBe(expected);
   });
 
@@ -306,7 +306,7 @@ describe('Conversation.cloneForRequest', () => {
     c.push(msg('assistant', 'old reply'));
     c.push(compactionMsg());
     c.push(msg('user', 'new'));
-    const clone = c.cloneForRequest();
+    const clone = c.cloneForRequest(true);
     // compaction + new user message = 2 entries; old + old reply are excluded
     const expected = 2;
     const actual = clone.length;
@@ -316,7 +316,7 @@ describe('Conversation.cloneForRequest', () => {
   it('mutating the returned array does not affect stored history', () => {
     const c = new Conversation();
     c.push(msg('user', 'hello'));
-    const clone = c.cloneForRequest();
+    const clone = c.cloneForRequest(true);
     clone.push(msg('assistant', 'injected'));
     const expected = 1;
     const actual = c.messages.length;
@@ -326,7 +326,7 @@ describe('Conversation.cloneForRequest', () => {
   it('mutating a cloned message does not affect stored history', () => {
     const c = new Conversation();
     c.push(msg('user', 'hello'));
-    const clone = c.cloneForRequest();
+    const clone = c.cloneForRequest(true);
     const content = clone[0]?.content as { text: string }[];
     if (content[0]) {
       content[0].text = 'mutated';
@@ -340,7 +340,7 @@ describe('Conversation.cloneForRequest', () => {
   it('pushing a content block to a cloned message does not affect stored history', () => {
     const c = new Conversation();
     c.push(msg('user', 'hello'));
-    const clone = c.cloneForRequest();
+    const clone = c.cloneForRequest(true);
     (clone[0]?.content as { type: string; text: string }[]).push({ type: 'text', text: 'extra' });
     const stored = c.messages[0]?.content as unknown[];
     const expected = 1;

--- a/packages/claude-sdk/test/RequestBuilder.spec.ts
+++ b/packages/claude-sdk/test/RequestBuilder.spec.ts
@@ -4,7 +4,7 @@ import type { BetaMessageParam } from '../src/index.js';
 import { AGENT_SDK_PREFIX } from '../src/private/consts.js';
 import type { RequestBuilderOptions } from '../src/private/RequestBuilder.js';
 import { buildRequestParams } from '../src/private/RequestBuilder.js';
-import { AnthropicBeta, CacheTtl } from '../src/public/enums.js';
+import { AnthropicBeta, CacheTtl, COMPACT_BETA } from '../src/public/enums.js';
 import type { AnyToolDefinition } from '../src/public/types.js';
 
 // ---------------------------------------------------------------------------
@@ -154,43 +154,79 @@ describe('buildRequestParams — ContextManagement beta', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildRequestParams — Compact beta', () => {
-  it('adds compact_20260112 edit when Compact is enabled', () => {
+  it('adds compact_20260112 edit when compact is enabled', () => {
     const expected = 'compact_20260112';
-    const { body } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true } }), noMessages);
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
     const actual = body.context_management?.edits?.find((e) => e.type === 'compact_20260112')?.type;
     expect(actual).toBe(expected);
   });
 
-  it('compact edit pause_after_compaction defaults to false', () => {
+  it('compact edit pause_after_compaction is false when configured false', () => {
     const expected = false;
-    const { body } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true } }), noMessages);
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
     const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
     const actual = (compactEdit as { pause_after_compaction?: boolean })?.pause_after_compaction;
     expect(actual).toBe(expected);
   });
 
-  it('compact edit pause_after_compaction is true when pauseAfterCompact is set', () => {
+  it('compact edit pause_after_compaction is true when configured true', () => {
     const expected = true;
-    const { body } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true }, pauseAfterCompact: true }), noMessages);
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: true } }), noMessages);
     const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
     const actual = (compactEdit as { pause_after_compaction?: boolean })?.pause_after_compaction;
     expect(actual).toBe(expected);
   });
 
-  it('compact edit trigger is null when compactInputTokens is not set', () => {
-    const expected = null;
-    const { body } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true } }), noMessages);
-    const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
-    const actual = (compactEdit as { trigger?: unknown })?.trigger;
-    expect(actual).toBe(expected);
-  });
-
-  it('compact edit trigger.value matches compactInputTokens', () => {
+  it('compact edit trigger.value matches inputTokens', () => {
     const expected = 50000;
-    const { body } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true }, compactInputTokens: 50000 }), noMessages);
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 50000, pauseAfterCompaction: false } }), noMessages);
     const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
     const actual = (compactEdit as { trigger?: { type: string; value: number } | null })?.trigger?.value;
     expect(actual).toBe(expected);
+  });
+
+  it('no compact edit when compact is not provided', () => {
+    const { body } = buildRequestParams(makeOptions(), noMessages);
+    const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
+    const expected = undefined;
+    const actual = compactEdit;
+    expect(actual).toBe(expected);
+  });
+
+  it('no compact edit when compact.enabled is false', () => {
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: false, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
+    const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
+    const expected = undefined;
+    const actual = compactEdit;
+    expect(actual).toBe(expected);
+  });
+
+  it('compact edit instructions defaults to null when not provided', () => {
+    const expected = null;
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
+    const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
+    const actual = (compactEdit as { instructions?: string | null })?.instructions;
+    expect(actual).toBe(expected);
+  });
+
+  it('compact edit instructions matches customInstructions', () => {
+    const expected = 'Summarize concisely';
+    const { body } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: false, customInstructions: 'Summarize concisely' } }), noMessages);
+    const compactEdit = body.context_management?.edits?.find((e) => e.type === 'compact_20260112');
+    const actual = (compactEdit as { instructions?: string | null })?.instructions;
+    expect(actual).toBe(expected);
+  });
+
+  it('compact beta header is included when compact is enabled', () => {
+    const { headers } = buildRequestParams(makeOptions({ compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
+    const actual = headers['anthropic-beta'].includes(COMPACT_BETA);
+    expect(actual).toBe(true);
+  });
+
+  it('compact beta header is not included when compact is disabled', () => {
+    const { headers } = buildRequestParams(makeOptions({ compact: { enabled: false, inputTokens: 160_000, pauseAfterCompaction: false } }), noMessages);
+    const actual = headers['anthropic-beta'].includes(COMPACT_BETA);
+    expect(actual).toBe(false);
   });
 });
 
@@ -246,21 +282,21 @@ describe('buildRequestParams — headers', () => {
   });
 
   it('anthropic-beta header contains the enabled beta', () => {
-    const expected = AnthropicBeta.Compact;
-    const actual = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true } }), noMessages).headers['anthropic-beta'];
+    const expected = AnthropicBeta.ClaudeCodeAuth;
+    const actual = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.ClaudeCodeAuth]: true } }), noMessages).headers['anthropic-beta'];
     expect(actual).toBe(expected);
   });
 
   it('anthropic-beta header contains all enabled betas comma-joined', () => {
-    const { headers } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true, [AnthropicBeta.ContextManagement]: true } }), noMessages);
+    const { headers } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.ClaudeCodeAuth]: true, [AnthropicBeta.ContextManagement]: true } }), noMessages);
     const betas = headers['anthropic-beta'].split(',');
     const expected = true;
-    const actual = betas.includes(AnthropicBeta.Compact) && betas.includes(AnthropicBeta.ContextManagement);
+    const actual = betas.includes(AnthropicBeta.ClaudeCodeAuth) && betas.includes(AnthropicBeta.ContextManagement);
     expect(actual).toBe(expected);
   });
 
   it('disabled betas are excluded from the header', () => {
-    const { headers } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.Compact]: true, [AnthropicBeta.ContextManagement]: false } }), noMessages);
+    const { headers } = buildRequestParams(makeOptions({ betas: { [AnthropicBeta.ClaudeCodeAuth]: true, [AnthropicBeta.ContextManagement]: false } }), noMessages);
     const expected = false;
     const actual = headers['anthropic-beta'].split(',').includes(AnthropicBeta.ContextManagement);
     expect(actual).toBe(expected);

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -44,6 +44,37 @@
           "type": "boolean"
         }
       }
+    },
+    "compact": {
+      "default": {
+        "enabled": true,
+        "inputTokens": 160000,
+        "pauseAfterCompaction": true
+      },
+      "description": "Compaction configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable conversation compaction",
+          "type": "boolean"
+        },
+        "inputTokens": {
+          "default": 160000,
+          "description": "Token threshold at which compaction triggers",
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "pauseAfterCompaction": {
+          "default": true,
+          "description": "Whether to pause after a compaction occurs",
+          "type": "boolean"
+        },
+        "customInstructions": {
+          "description": "Custom instructions to guide the compaction summary",
+          "type": "string"
+        }
+      }
     }
   },
   "title": "Claude SDK CLI Configuration",


### PR DESCRIPTION
## Summary

- Expose compaction settings in `sdk-config.json`: `enabled`, `inputTokens`, `pauseAfterCompaction`, `customInstructions`
- Convert compaction blocks to text blocks when compact is disabled, preserving context
- Replace `AnthropicBeta.Compact` enum member with standalone `COMPACT_BETA` constant
- Add `CompactConfig` type to SDK public API

## Related Issues

Closes #251

Co-Authored-By: Claude <noreply@anthropic.com>