### PR TITLE
Fix GitVersion tag-prefix for package-name@version tag format

### DIFF
--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -8,29 +8,10 @@
 
 **Biome exit code 1**: `pnpm ci:fix` always exits 1 due to a pre-existing unsafe lint error in `packages/claude-core/src/reflow.ts`. It also auto-formats `Find.ts` and `Find.spec.ts` outside your scope. Don't stage those. This is not your problem.
 
+# 00:57 — GitVersion tag-prefix fix
 
-# 00:57
+`next-version` and regex `tag-prefix` cannot coexist. GitVersion applies the tag-prefix regex to the `next-version` value itself, which crashes. If you ever need `next-version` back, you would have to switch to a literal tag-prefix or drop the regex.
 
-## GitVersion tag-prefix fix
+The `.*@` regex is greedy but safe because every tag has exactly one `@`. Multiple packages' tags in history means GitVersion might pick the highest version from any package as the base version on untagged commits. This is fine while all packages track the same milestone. It would become a problem if packages diverged significantly in version.
 
-Branch: `fix/gitversion-publish-tag`
-
-### The problem
-
-Release tags use `package-name@version` format (e.g., `claude-sdk-cli@1.0.0`). GitVersion's default tag-prefix expects a `v` prefix or no prefix. With no `tag-prefix` set in `GitVersion.yml`, GitVersion doesn't recognise any of these tags. It falls back to `ConfiguredNextVersion` (which was `next-version: 1.0.0`) and calculates versions from that anchor instead of from actual release tags.
-
-### The fix
-
-Two changes to `GitVersion.yml`:
-
-1. **`tag-prefix: '.*@'`**: regex that matches everything up to and including `@`. For `claude-sdk-cli@1.0.0`, this strips `claude-sdk-cli@` and GitVersion parses `1.0.0`.
-
-2. **Remove `next-version` and `ConfiguredNextVersion`**: `next-version` conflicts with regex tag-prefix (GitVersion applies the regex to the next-version value too, causing a crash). `ConfiguredNextVersion` strategy is only useful with `next-version`. Both removed.
-
-### Multi-package tag concern
-
-The `.*@` regex is greedy and matches up to the last `@`. Since tags have exactly one `@`, the prefix always consumes `<package-name>@`. Multiple package tags in history means GitVersion may pick the highest version from any package's tags as the base. This is acceptable because all packages track the same `1.0.0` milestone. On a tagged commit, the exact tag is used directly (Mainline strategy behavior).
-
-### Workflow impact
-
-Both `node.js.yml` and `npm-publish.yml` install GitVersion and run builds that invoke `gitversion -showvariable SemVer`. Neither passes tag-prefix as a CLI arg; both rely on `GitVersion.yml`. The config change applies to both without workflow modifications.
+Both CI workflows (`node.js.yml`, `npm-publish.yml`) read `GitVersion.yml` with no CLI overrides, so the config change covers everything.

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -7,3 +7,30 @@
 **`changes.jsonl` categories**: The valid values are `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`. Not `feature`, not `enhancement`. If a prompt says `"category":"feature"`, use `"added"`.
 
 **Biome exit code 1**: `pnpm ci:fix` always exits 1 due to a pre-existing unsafe lint error in `packages/claude-core/src/reflow.ts`. It also auto-formats `Find.ts` and `Find.spec.ts` outside your scope. Don't stage those. This is not your problem.
+
+
+# 00:57
+
+## GitVersion tag-prefix fix
+
+Branch: `fix/gitversion-publish-tag`
+
+### The problem
+
+Release tags use `package-name@version` format (e.g., `claude-sdk-cli@1.0.0`). GitVersion's default tag-prefix expects a `v` prefix or no prefix. With no `tag-prefix` set in `GitVersion.yml`, GitVersion doesn't recognise any of these tags. It falls back to `ConfiguredNextVersion` (which was `next-version: 1.0.0`) and calculates versions from that anchor instead of from actual release tags.
+
+### The fix
+
+Two changes to `GitVersion.yml`:
+
+1. **`tag-prefix: '.*@'`**: regex that matches everything up to and including `@`. For `claude-sdk-cli@1.0.0`, this strips `claude-sdk-cli@` and GitVersion parses `1.0.0`.
+
+2. **Remove `next-version` and `ConfiguredNextVersion`**: `next-version` conflicts with regex tag-prefix (GitVersion applies the regex to the next-version value too, causing a crash). `ConfiguredNextVersion` strategy is only useful with `next-version`. Both removed.
+
+### Multi-package tag concern
+
+The `.*@` regex is greedy and matches up to the last `@`. Since tags have exactly one `@`, the prefix always consumes `<package-name>@`. Multiple package tags in history means GitVersion may pick the highest version from any package's tags as the base. This is acceptable because all packages track the same `1.0.0` milestone. On a tagged commit, the exact tag is used directly (Mainline strategy behavior).
+
+### Workflow impact
+
+Both `node.js.yml` and `npm-publish.yml` install GitVersion and run builds that invoke `gitversion -showvariable SemVer`. Neither passes tag-prefix as a CLI arg; both rely on `GitVersion.yml`. The config change applies to both without workflow modifications.

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,6 @@
-next-version: 1.0.0
+tag-prefix: '.*@'
 increment: Patch
 strategies:
-- ConfiguredNextVersion
 - MergeMessage
 - TrackReleaseBranches
 - VersionInBranchName


### PR DESCRIPTION
## Summary

- Add `tag-prefix: '.*@'` so GitVersion recognises `package-name@version` tags
- Remove `next-version` and `ConfiguredNextVersion` strategy (incompatible with regex tag-prefix)

Co-Authored-By: Claude <noreply@anthropic.com>