### PR TITLE
Fix --init-config to include all schema options

### DIFF
--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -8,10 +8,12 @@
 
 **Biome exit code 1**: `pnpm ci:fix` always exits 1 due to a pre-existing unsafe lint error in `packages/claude-core/src/reflow.ts`. It also auto-formats `Find.ts` and `Find.spec.ts` outside your scope. Don't stage those. This is not your problem.
 
-# 00:57 — GitVersion tag-prefix fix
+# GitVersion tag-prefix
 
-`next-version` and regex `tag-prefix` cannot coexist. GitVersion applies the tag-prefix regex to the `next-version` value itself, which crashes. If you ever need `next-version` back, you would have to switch to a literal tag-prefix or drop the regex.
+`next-version` and regex `tag-prefix` cannot coexist. GitVersion applies the tag-prefix regex to the `next-version` value itself, which crashes. The `.*@` regex is greedy but safe because every tag has exactly one `@`.
 
-The `.*@` regex is greedy but safe because every tag has exactly one `@`. Multiple packages' tags in history means GitVersion might pick the highest version from any package as the base version on untagged commits. This is fine while all packages track the same milestone. It would become a problem if packages diverged significantly in version.
+# Init config: optional vs nullable for schema defaults
 
-Both CI workflows (`node.js.yml`, `npm-publish.yml`) read `GitVersion.yml` with no CLI overrides, so the config change covers everything.
+`defaultConfig()` spreads `sdkConfigSchema.parse({})` into the config object. For this to work, every field that should appear in the generated file needs a defined value in the parse result. `z.string().optional()` produces `undefined` which gets dropped by `JSON.stringify`. The fix was changing `customInstructions` to `z.string().nullable().default(null).catch(null)` so it serialises as `null` in the output.
+
+The SDK's `DurableConfig` type expects `customInstructions?: string | undefined`, not `string | null`. So `main.ts` has a `mapConfig()` that converts `null` back to `undefined` at the boundary. This is the intentional seam between "config file representation" (null means explicitly absent) and "SDK representation" (undefined means not provided).

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
     - name: Install GitVersion
       run: |
-        curl -sL https://github.com/GitTools/GitVersion/releases/download/6.6.0/gitversion-linux-x64-6.6.0.tar.gz -o /tmp/gitversion.tar.gz
+        curl -sL --retry 3 --retry-delay 5 https://github.com/GitTools/GitVersion/releases/download/6.6.0/gitversion-linux-x64-6.6.0.tar.gz -o /tmp/gitversion.tar.gz
         tar xzf /tmp/gitversion.tar.gz -C /usr/local/bin gitversion
         chmod +x /usr/local/bin/gitversion
     - uses: pnpm/action-setup@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install GitVersion
         run: |
-          curl -sL https://github.com/GitTools/GitVersion/releases/download/6.6.0/gitversion-linux-x64-6.6.0.tar.gz -o /tmp/gitversion.tar.gz
+          curl -sL --retry 3 --retry-delay 5 https://github.com/GitTools/GitVersion/releases/download/6.6.0/gitversion-linux-x64-6.6.0.tar.gz -o /tmp/gitversion.tar.gz
           tar xzf /tmp/gitversion.tar.gz -C /usr/local/bin gitversion
           chmod +x /usr/local/bin/gitversion
 

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -4,3 +4,4 @@
 {"description":"Add ConversationSession: persistent conversation identity and n key to start new conversation","category":"added"}
 {"description":"Write BetaMessage per turn to ~/.claude/audit/<conversation-id>.jsonl","category":"added"}
 {"description":"Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`","category":"added"}
+{"description":"Fix `--init-config` to include all schema options in generated file","category":"fixed"}

--- a/apps/claude-sdk-cli/src/cli-config/initConfig.ts
+++ b/apps/claude-sdk-cli/src/cli-config/initConfig.ts
@@ -3,6 +3,14 @@ import { dirname } from 'node:path';
 import { CONFIG_PATH, SCHEMA_URL } from './consts';
 import { sdkConfigSchema } from './schema';
 
+export const defaultConfig = () => {
+  const defaults = sdkConfigSchema.parse({});
+  return {
+    $schema: SCHEMA_URL,
+    ...defaults,
+  };
+};
+
 export function initConfig(log: (msg: string) => void): void {
   if (existsSync(CONFIG_PATH)) {
     log(`Config already exists at ${CONFIG_PATH}`);
@@ -14,16 +22,7 @@ export function initConfig(log: (msg: string) => void): void {
     mkdirSync(dir, { recursive: true });
   }
 
-  const defaults = sdkConfigSchema.parse({});
-  const content = JSON.stringify(
-    {
-      $schema: SCHEMA_URL,
-      model: defaults.model,
-      historyReplay: defaults.historyReplay,
-    },
-    null,
-    2,
-  );
+  const content = JSON.stringify(defaultConfig(), undefined, 2);
 
   writeFileSync(CONFIG_PATH, `${content}\n`);
   log(`Created config at ${CONFIG_PATH}`);

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -24,11 +24,11 @@ const compactSchema = z
     enabled: z.boolean().optional().default(true).catch(true).describe('Enable conversation compaction'),
     inputTokens: z.number().int().positive().optional().default(160_000).catch(160_000).describe('Token threshold at which compaction triggers'),
     pauseAfterCompaction: z.boolean().optional().default(true).catch(true).describe('Whether to pause after a compaction occurs'),
-    customInstructions: z.string().optional().describe('Custom instructions to guide the compaction summary'),
+    customInstructions: z.string().nullable().default(null).catch(null).describe('Custom instructions to guide the compaction summary'),
   })
   .optional()
-  .default({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true })
-  .catch({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true });
+  .default({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null })
+  .catch({ enabled: true, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null });
 
 export const sdkConfigSchema = z
   .object({

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -161,8 +161,18 @@ const main = async () => {
   const turnRunner = new TurnRunner(client, processor, logger);
   const cwd = process.cwd();
 
+  const mapConfig = () => {
+    return {
+      model: watcher.config.model,
+      compact: {
+        ...watcher.config.compact,
+        customInstructions: watcher.config.compact.customInstructions ?? undefined,
+      },
+    };
+  };
+
   const durableConfig: DurableConfig = {
-    model: watcher.config.model,
+    ...mapConfig(),
     maxTokens: 32000,
     thinking: true,
     systemPrompts,
@@ -174,7 +184,6 @@ const main = async () => {
       [AnthropicBeta.AdvancedToolUse]: true,
     },
     requireToolApproval: true,
-    compact: watcher.config.compact,
     cacheTtl: CacheTtl.OneHour,
   };
 
@@ -215,8 +224,9 @@ const main = async () => {
     const claudeMdContent = watcher.config.claudeMd.enabled ? await claudeMdLoader.getContent() : null;
 
     // Update durable config with current values before each query
-    durableConfig.model = watcher.config.model;
-    durableConfig.compact = watcher.config.compact;
+    const newConfig = mapConfig();
+    durableConfig.model = newConfig.model;
+    durableConfig.compact = newConfig.compact;
     durableConfig.cachedReminders = claudeMdContent != null ? [claudeMdContent] : undefined;
 
     const abortController = new AbortController();

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -13,7 +13,7 @@ describe('sdkConfigSchema', () => {
         model: 'claude-sonnet-4-6',
         historyReplay: { enabled: true, showThinking: false },
         claudeMd: { enabled: true },
-        compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: true },
+        compact: { enabled: true, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null },
       });
     });
 

--- a/apps/claude-sdk-cli/test/initConfig.spec.ts
+++ b/apps/claude-sdk-cli/test/initConfig.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { z } from 'zod';
+import { defaultConfig } from '../src/cli-config/initConfig';
+import { sdkConfigSchema } from '../src/cli-config/schema';
+
+function unwrapToObject(schema: { _zod: { def: { type: string; innerType?: any } } }): z.ZodObject | null {
+  if (schema._zod.def.type === 'object') {
+    return schema as unknown as z.ZodObject;
+  }
+  if (schema._zod.def.innerType) {
+    return unwrapToObject(schema._zod.def.innerType);
+  }
+  return null;
+}
+
+describe('defaultConfig', () => {
+  it('default config has all properties', () => {
+    const c = defaultConfig();
+
+    const recurse = (shape: z.ZodRawShape, obj: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(shape)) {
+        expect(obj).toHaveProperty(key);
+        const unwrapped = unwrapToObject(value);
+        if (unwrapped) {
+          recurse(unwrapped.shape, obj[key] as Record<string, unknown>);
+        }
+      }
+    };
+
+    recurse(sdkConfigSchema.shape, c);
+  });
+});

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -4,3 +4,4 @@
 {"description":"Add finalMessage event emitter surface to AnthropicClient","category":"added"}
 {"description":"Add `CompactConfig` type; `cloneForRequest` converts compaction blocks to text when compact is disabled","category":"added"}
 {"description":"Replace `AnthropicBeta.Compact` enum member with standalone `COMPACT_BETA` constant","category":"changed"}
+{"description":"Omit empty `context_management` from request body instead of sending empty edits array","category":"changed"}

--- a/packages/claude-sdk/src/private/RequestBuilder.ts
+++ b/packages/claude-sdk/src/private/RequestBuilder.ts
@@ -87,15 +87,13 @@ export function buildRequestParams(options: RequestBuilderOptions, messages: Ant
 
   const betas = resolveCapabilities(options.betas, AnthropicBeta);
 
-  const context_management: BetaContextManagementConfig = {
-    edits: [],
-  };
+  const context_management: BetaContextManagementConfig['edits'] = [];
   if (betas[AnthropicBeta.ContextManagement]) {
-    context_management.edits?.push({ type: 'clear_thinking_20251015' } satisfies BetaClearThinking20251015Edit);
-    context_management.edits?.push({ type: 'clear_tool_uses_20250919' } satisfies BetaClearToolUses20250919Edit);
+    context_management.push({ type: 'clear_thinking_20251015' } satisfies BetaClearThinking20251015Edit);
+    context_management.push({ type: 'clear_tool_uses_20250919' } satisfies BetaClearToolUses20250919Edit);
   }
   if (options.compact?.enabled) {
-    context_management.edits?.push({
+    context_management.push({
       type: 'compact_20260112',
       pause_after_compaction: options.compact.pauseAfterCompaction,
       instructions: options.compact.customInstructions ?? null,
@@ -139,11 +137,15 @@ export function buildRequestParams(options: RequestBuilderOptions, messages: Ant
     model: options.model,
     max_tokens: options.maxTokens,
     tools,
-    context_management,
     system: systemPrompts.map((text) => ({ type: 'text', text, cache_control: { type: 'ephemeral', ttl: options.cacheTtl } }) satisfies BetaTextBlockParam),
     messages,
     stream: true,
   } satisfies BetaMessageStreamParams;
+  if (context_management.length > 0) {
+    body.context_management = {
+      edits: context_management,
+    };
+  }
 
   if (betas[AnthropicBeta.PromptCachingScope]) {
     body.cache_control = { type: 'ephemeral', scope: 'global' } as BetaCacheControlEphemeral;

--- a/packages/claude-sdk/test/RequestBuilder.spec.ts
+++ b/packages/claude-sdk/test/RequestBuilder.spec.ts
@@ -82,10 +82,9 @@ describe('buildRequestParams — base', () => {
     expect(actual).toBe(expected);
   });
 
-  it('context_management edits are empty when no betas enabled', () => {
-    const expected = 0;
-    const actual = buildRequestParams(makeOptions(), noMessages).body.context_management?.edits?.length;
-    expect(actual).toBe(expected);
+  it('context_management edits is not sent when no betas enabled', () => {
+    const actual = buildRequestParams(makeOptions(), noMessages).body.context_management;
+    expect(actual).toBeUndefined();
   });
 });
 

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -49,7 +49,8 @@
       "default": {
         "enabled": true,
         "inputTokens": 160000,
-        "pauseAfterCompaction": true
+        "pauseAfterCompaction": true,
+        "customInstructions": null
       },
       "description": "Compaction configuration",
       "type": "object",
@@ -71,8 +72,16 @@
           "type": "boolean"
         },
         "customInstructions": {
+          "default": null,
           "description": "Custom instructions to guide the compaction summary",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary

- Generated config now spreads all schema defaults instead of picking fields by name
- `compact.customInstructions` changed from optional to nullable with a default, so it appears in the output file
- Test validates `defaultConfig()` contains every property defined in the schema
- Empty `context_management` omitted from API request body

## Related Issues

Closes #256

Co-Authored-By: Claude <noreply@anthropic.com>