### PR TITLE
Add image paste from clipboard via command mode

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,6 +49,62 @@ Think about what didn't help — don't write that.
 Write what you know that the code doesn't say.
 <!-- END:TEMPLATE:testament -->
 
+<!-- BEGIN:TEMPLATE:instructions -->
+## Prompt Instructions
+
+Your prompt declares which patterns and phases are active. This section explains what they mean.
+
+### Stage approval
+
+Stage only the files you modified. Use explicit `git add` paths — never `git add .` or `git add -A`. Do not commit. Propose a short commit message for the supervisor. The commit is the supervisor's approval of the work.
+
+### Preflight
+
+Verify the repo is in a clean state before starting. Run the preflight script, confirm the branch and working tree. If the prompt includes a branch name, create it from `origin/main`.
+
+### Red
+
+Write failing tests against stub implementations. The stub must compile but not pass the tests — that is the goal. Do not implement anything beyond the stub. The tests are the contract for the next phase.
+
+### Green
+
+Implement to make the red tests pass. Do not modify tests unless absolutely necessary — if you do, document what changed and why in your testament. If you need to run a formatter or fixer, scope it to the files you changed.
+
+### Code
+
+General implementation phase. Same discipline as Green but without a test contract. Follow the prompt's instructions prescriptively.
+
+### Ship
+
+Load the ship agent. Distil the testament — rewrite it for whoever comes after, not as a log of what you did. Then open the PR.
+
+Read your testament. Read previous testaments. Think about what helped you, what didn't. This is an opportunity to rewrite your testament — the testament is by you, for you, no one else will read it.
+
+### Investigation
+
+Explore the codebase and write a findings report. Trace how things actually work — data flow, ownership, what calls what. Present what you found, not what you think should change. Do not recommend — the SC decides direction.
+
+### System Design
+
+This is not code design. Do not produce classes, methods, or type signatures — that is class design. Think about the system: who owns the data, how does it flow, where are the boundaries, how does control move between components. If the user will see it, account for how it reaches the screen.
+
+Each design must be complete. If data reaches the user, account for how it gets to the screen. If state changes mid-session, account for that. A design that defers a critical path is not a design — it is a sketch that will collapse when the deferred part becomes the task.
+
+Produce two or three distinct options that differ in ownership, boundaries, or data flow — not variations on the same code structure. State the trade-offs for each. No recommendation — the SC decides direction.
+
+### Class Design
+
+The system-level direction has already been decided. Now produce the blueprint: interfaces, type signatures, method signatures, how new classes wire into existing code. Match existing codebase patterns — read what's there before designing anything new. The implementation phases build exactly what you specify here.
+
+### Codebase Discovery
+
+Verify assumptions and fill in implementation detail. Your findings feed the next phase via your testament, not a separate file.
+
+### Code Review
+
+Review the implementation for quality. You have full access to the codebase. Read the diff, the prompt, and the surrounding code. Report what you find.
+<!-- END:TEMPLATE:instructions -->
+
 <!-- BEGIN:REPO:current-state -->
 ## Current State
 Branch: `feature/sdk-refactor`. PR #231 open, auto-merge enabled.

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -18,123 +18,22 @@
 
 The SDK's `DurableConfig` type expects `customInstructions?: string | undefined`, not `string | null`. So `main.ts` has a `mapConfig()` that converts `null` back to `undefined` at the boundary. This is the intentional seam between "config file representation" (null means explicitly absent) and "SDK representation" (undefined means not provided).
 
-# 19:21
+# Image Paste (#261)
 
-## Image paste investigation (#261)
+## Traps
 
-Branch: N/A (investigation only, output to fleet repo)
+**`Attachment` union exhaustiveness**: Adding `ImageAttachment` to the `Attachment` union broke three files that assumed the non-text case was always `FileAttachment`. The `else` branches in `buildSubmitText.ts`, `renderCommandMode.ts`, and `AppLayout.ts` all needed explicit `kind` checks. If you add another attachment kind, expect the same pattern.
 
-### The key insight: no terminal protocol involved
+**SDK type widening**: `PerQueryInput.messages` changed from `string[]` to `(string | BetaMessageParam)[]`. This is a widening, so existing callers compile without changes. But `QueryRunner.run()` needed a new branch to handle structured messages (reminder injection prepends to the content array instead of wrapping a string).
 
-Image paste has nothing to do with terminal image protocols (iTerm2 inline images, Kitty graphics, sixel). Those are for *displaying* images in the terminal. Image paste reads from the system clipboard via external commands (`pngpaste` on macOS, `wl-paste` on Wayland, `xclip` on X11, PowerShell on Windows). The user copies an image to clipboard, enters command mode, presses `i`, and the app runs a subprocess to read the clipboard contents as bytes.
+**`runAgent` signature change**: The function now takes `RunAgentInput = { displayText: string; message: string | BetaMessageParam }` instead of a bare `string`. `displayText` goes to the layout for rendering; `message` goes to the SDK. The split exists because image content cannot be meaningfully displayed as text.
 
-### Old app pipeline: four steps
+**`waitForInput` return type**: Changed from `string` to `UserInput = { text: string; images: ImageAttachment[] }`. Images are separated from non-image attachments at the return boundary because they follow a different path (structured content blocks vs. text folding).
 
-1. `CommandMode` dispatches `paste-image` on `i` keypress
-2. `clipboard.ts:readClipboardImage()` runs a platform-specific command to get raw PNG bytes as a `Buffer`
-3. `AttachmentStore.addImage()` hashes (SHA-256), deduplicates, base64-encodes, stores
-4. `session.ts:buildPrompt()` builds a multi-content user message with `ImageBlockParam` blocks for the Anthropic API
+## Design Decisions
 
-### The SDK gap in the new app
+**macOS-only for now**: `readClipboardImage()` wraps `readClipboardImageCore` with a single `pngpaste -` reader. The `readClipboardImageCore` function takes `...readers: ImageReader[]` so adding Wayland/X11 readers later is just adding arguments. BMP-to-PNG conversion (`sharp` dependency) is deferred because `pngpaste` always outputs PNG.
 
-The new app's `PerQueryInput.messages` is `string[]`. The old app used the `@anthropic-ai/claude-agent-sdk` which accepted `AsyncIterable<SDKUserMessage>` with structured content blocks. To support native image blocks (not just base64 text), the SDK's `PerQueryInput` type needs to accept structured content.
+**`execBuffer` helper**: New sibling to `execText` in clipboard.ts. 50 MB max buffer, 5s timeout. Returns raw `Buffer` from subprocess stdout. Used for `pngpaste` which writes binary PNG to stdout.
 
-`Conversation.push()` already accepts `BetaMessageParam` which can contain `BetaImageBlockParam` in its content array. The gap is only in `PerQueryInput` and `QueryRunner.run()` which currently assumes messages are plain strings.
-
-### BMP-to-PNG and sharp
-
-The `sharp` dependency exists solely for Wayland BMP-to-PNG conversion. `pngpaste` on macOS always outputs PNG. If the implementation starts macOS-only, `sharp` is not needed. The manual pixel conversion in `bmpToPng()` (clipboard.ts:71-110) is 40 lines of BGRA-to-RGBA row flipping that only matters on Linux.
-
-### Testability pattern
-
-The new app already has the right pattern from `readClipboardPathCore`: inject callables instead of calling `execFile` directly. `readClipboardImageCore(...readers: ImageReader[])` with `ImageReader = () => Promise<Buffer | null>` follows the same structure. Tests inject stubs returning synthetic `Buffer` instances. Media type detection (magic bytes) and the attachment store are pure functions, trivially testable.
-
-# 23:10
-
-## Phase 1 (Red) complete: image paste stubs + 16 failing tests
-
-Branch: `feature/image-paste`
-
-### What was added
-
-**`apps/claude-sdk-cli/src/clipboard.ts`** (appended at bottom):
-- `ImageReader` type: `() => Promise<Buffer | null>`
-- `ClipboardImageResult` union: `{ kind: 'image'; data: Buffer } | { kind: 'empty' } | { kind: 'unsupported' }`
-- `ImageMediaType` type: `'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'`
-- `readClipboardImageCore(...readers: ImageReader[])` stub (throws)
-- `detectMediaType(data: Buffer)` stub (throws)
-
-**`apps/claude-sdk-cli/src/model/AttachmentStore.ts`**:
-- `ImageAttachment` type added (kind, hash, base64, mediaType, sizeBytes)
-- `Attachment` union extended to include `ImageAttachment`
-- `addImage(data: Buffer, mediaType: ImageMediaType)` stub method added (throws)
-- Import of `ImageMediaType` from clipboard.ts
-
-**`apps/claude-sdk-cli/test/image-clipboard.spec.ts`** (new, 16 tests):
-- 5 tests for `readClipboardImageCore` (image result, fallback, empty, unsupported, short-circuit)
-- 7 tests for `detectMediaType` (PNG, JPEG, GIF87a, GIF89a, WebP, unrecognised, empty buffer)
-- 4 tests for `AttachmentStore.addImage` (correct storage, added return, duplicate return, hash-based dedup)
-
-### Test results
-- 16 new tests: all FAIL ("not implemented")
-- 440 existing tests: all PASS
-- 21 existing test files: all PASS
-- Type-check: PASS
-
-### Biome warnings (expected)
-Unused parameter warnings on stubs (`readers`, `data`, `mediaType`). These are "unsafe" fixes (rename to underscore). Not applied because the params will be used in Phase 2.
-
-### Proposed commit message
-`Add image paste stubs and failing tests (#261)`
-
-# 23:30
-
-## Phase 2 (Green) complete: image paste implementations + wiring
-
-Branch: `feature/image-paste`
-
-### Three stubs implemented (makes 16 tests pass)
-
-**`readClipboardImageCore`**: Tries each `ImageReader` in order. First non-null Buffer wins. All null returns `empty`. No readers returns `unsupported`. Exactly mirrors the `readClipboardPathCore` injectable pattern.
-
-**`detectMediaType`**: Pure byte-matching function. PNG (8 bytes), JPEG (3 bytes), GIF87a/89a (6 bytes), WebP (RIFF+WEBP at bytes 0-3 and 8-11). Returns null for unrecognised or too-short buffers.
-
-**`AttachmentStore.addImage`**: SHA-256 hash of raw bytes, dedup by `kind === 'image'` hash match, base64 encode, store. Returns `'added'` or `'duplicate'`. Pattern matches `addText`.
-
-### Wiring (steps 4 and 5)
-
-**Command mode `i` key** (AppLayout): `readClipboardImage()` reads clipboard, `detectMediaType()` identifies format, `commandModeState.addImage()` stores it. Same async `.then()/.catch()` pattern as `t` and `f` handlers.
-
-**`readClipboardImage()`** (clipboard.ts): Real version wraps `readClipboardImageCore` with one `pngpaste -` reader. Added `execBuffer` helper alongside `execText`, with 50 MB max buffer and 5s timeout.
-
-**Submit path changes**: `waitForInput()` now returns `UserInput = { text: string; images: ImageAttachment[] }`. On ctrl+enter, image attachments are separated from non-image attachments. Non-images go through `buildSubmitText` as before. Images are returned separately.
-
-**`PerQueryInput.messages`** changed from `string[]` to `(string | BetaMessageParam)[]`. This is a widening of the SDK's public type. Existing code passing `string[]` compiles without changes.
-
-**`QueryRunner.run()`** handles both string and structured `BetaMessageParam` messages. For structured messages, reminder injection prepends to the content array. String path is unchanged.
-
-**`runAgent()`** signature changed from `(queryRunner, prompt: string, ...)` to `(queryRunner, input: RunAgentInput, ...)` where `RunAgentInput = { displayText: string; message: string | BetaMessageParam }`. Display text goes to `layout.startStreaming()`, message goes to `queryRunner.run()`.
-
-**`main.ts`** builds the structured `BetaMessageParam` when images are present: image blocks (base64 source) followed by a text block, wrapped as `{ role: 'user', content: [...] }`.
-
-### Type fixes needed after adding ImageAttachment to Attachment union
-
-Three files had `else` branches that assumed the non-text case was always `FileAttachment`. Adding `ImageAttachment` to the union broke the assumption:
-
-- **`buildSubmitText.ts`**: Changed `else` to `else if (att.kind === 'file')`. Images are skipped (sent via structured content, not text).
-- **`renderCommandMode.ts`**: Both chip rendering and preview rendering needed a new `ImageAttachment` branch. Image chips show as `[img 42.0KB]`, preview shows media type + hash prefix.
-- **`AppLayout.ts`**: The `nonImageAttachments` filter used `?? null` which was possibly null when accessing `.length`. Changed to `?? []`.
-
-### Test results
-- All 456 CLI tests pass
-- All 233 tools tests pass
-- All SDK tests pass
-- Type-check: pass
-- Build: pass
-- Biome CI: pass
-
-### No tests modified
-All 16 Red phase tests passed without modification.
-
-### Proposed commit message
-`Implement image paste from clipboard (#261)`
+**Image chips in command mode**: Render as `[img 42.0KB]`. Preview shows media type + hash prefix. Consistent with the existing text chip pattern but adapted for binary content where showing a text preview would be meaningless.

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -17,3 +17,72 @@
 `defaultConfig()` spreads `sdkConfigSchema.parse({})` into the config object. For this to work, every field that should appear in the generated file needs a defined value in the parse result. `z.string().optional()` produces `undefined` which gets dropped by `JSON.stringify`. The fix was changing `customInstructions` to `z.string().nullable().default(null).catch(null)` so it serialises as `null` in the output.
 
 The SDK's `DurableConfig` type expects `customInstructions?: string | undefined`, not `string | null`. So `main.ts` has a `mapConfig()` that converts `null` back to `undefined` at the boundary. This is the intentional seam between "config file representation" (null means explicitly absent) and "SDK representation" (undefined means not provided).
+
+# 19:21
+
+## Image paste investigation (#261)
+
+Branch: N/A (investigation only, output to fleet repo)
+
+### The key insight: no terminal protocol involved
+
+Image paste has nothing to do with terminal image protocols (iTerm2 inline images, Kitty graphics, sixel). Those are for *displaying* images in the terminal. Image paste reads from the system clipboard via external commands (`pngpaste` on macOS, `wl-paste` on Wayland, `xclip` on X11, PowerShell on Windows). The user copies an image to clipboard, enters command mode, presses `i`, and the app runs a subprocess to read the clipboard contents as bytes.
+
+### Old app pipeline: four steps
+
+1. `CommandMode` dispatches `paste-image` on `i` keypress
+2. `clipboard.ts:readClipboardImage()` runs a platform-specific command to get raw PNG bytes as a `Buffer`
+3. `AttachmentStore.addImage()` hashes (SHA-256), deduplicates, base64-encodes, stores
+4. `session.ts:buildPrompt()` builds a multi-content user message with `ImageBlockParam` blocks for the Anthropic API
+
+### The SDK gap in the new app
+
+The new app's `PerQueryInput.messages` is `string[]`. The old app used the `@anthropic-ai/claude-agent-sdk` which accepted `AsyncIterable<SDKUserMessage>` with structured content blocks. To support native image blocks (not just base64 text), the SDK's `PerQueryInput` type needs to accept structured content.
+
+`Conversation.push()` already accepts `BetaMessageParam` which can contain `BetaImageBlockParam` in its content array. The gap is only in `PerQueryInput` and `QueryRunner.run()` which currently assumes messages are plain strings.
+
+### BMP-to-PNG and sharp
+
+The `sharp` dependency exists solely for Wayland BMP-to-PNG conversion. `pngpaste` on macOS always outputs PNG. If the implementation starts macOS-only, `sharp` is not needed. The manual pixel conversion in `bmpToPng()` (clipboard.ts:71-110) is 40 lines of BGRA-to-RGBA row flipping that only matters on Linux.
+
+### Testability pattern
+
+The new app already has the right pattern from `readClipboardPathCore`: inject callables instead of calling `execFile` directly. `readClipboardImageCore(...readers: ImageReader[])` with `ImageReader = () => Promise<Buffer | null>` follows the same structure. Tests inject stubs returning synthetic `Buffer` instances. Media type detection (magic bytes) and the attachment store are pure functions, trivially testable.
+
+# 23:10
+
+## Phase 1 (Red) complete: image paste stubs + 16 failing tests
+
+Branch: `feature/image-paste`
+
+### What was added
+
+**`apps/claude-sdk-cli/src/clipboard.ts`** (appended at bottom):
+- `ImageReader` type: `() => Promise<Buffer | null>`
+- `ClipboardImageResult` union: `{ kind: 'image'; data: Buffer } | { kind: 'empty' } | { kind: 'unsupported' }`
+- `ImageMediaType` type: `'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'`
+- `readClipboardImageCore(...readers: ImageReader[])` stub (throws)
+- `detectMediaType(data: Buffer)` stub (throws)
+
+**`apps/claude-sdk-cli/src/model/AttachmentStore.ts`**:
+- `ImageAttachment` type added (kind, hash, base64, mediaType, sizeBytes)
+- `Attachment` union extended to include `ImageAttachment`
+- `addImage(data: Buffer, mediaType: ImageMediaType)` stub method added (throws)
+- Import of `ImageMediaType` from clipboard.ts
+
+**`apps/claude-sdk-cli/test/image-clipboard.spec.ts`** (new, 16 tests):
+- 5 tests for `readClipboardImageCore` (image result, fallback, empty, unsupported, short-circuit)
+- 7 tests for `detectMediaType` (PNG, JPEG, GIF87a, GIF89a, WebP, unrecognised, empty buffer)
+- 4 tests for `AttachmentStore.addImage` (correct storage, added return, duplicate return, hash-based dedup)
+
+### Test results
+- 16 new tests: all FAIL ("not implemented")
+- 440 existing tests: all PASS
+- 21 existing test files: all PASS
+- Type-check: PASS
+
+### Biome warnings (expected)
+Unused parameter warnings on stubs (`readers`, `data`, `mediaType`). These are "unsafe" fixes (rename to underscore). Not applied because the params will be used in Phase 2.
+
+### Proposed commit message
+`Add image paste stubs and failing tests (#261)`

--- a/.claude/testament/2026-04-14.md
+++ b/.claude/testament/2026-04-14.md
@@ -86,3 +86,55 @@ Unused parameter warnings on stubs (`readers`, `data`, `mediaType`). These are "
 
 ### Proposed commit message
 `Add image paste stubs and failing tests (#261)`
+
+# 23:30
+
+## Phase 2 (Green) complete: image paste implementations + wiring
+
+Branch: `feature/image-paste`
+
+### Three stubs implemented (makes 16 tests pass)
+
+**`readClipboardImageCore`**: Tries each `ImageReader` in order. First non-null Buffer wins. All null returns `empty`. No readers returns `unsupported`. Exactly mirrors the `readClipboardPathCore` injectable pattern.
+
+**`detectMediaType`**: Pure byte-matching function. PNG (8 bytes), JPEG (3 bytes), GIF87a/89a (6 bytes), WebP (RIFF+WEBP at bytes 0-3 and 8-11). Returns null for unrecognised or too-short buffers.
+
+**`AttachmentStore.addImage`**: SHA-256 hash of raw bytes, dedup by `kind === 'image'` hash match, base64 encode, store. Returns `'added'` or `'duplicate'`. Pattern matches `addText`.
+
+### Wiring (steps 4 and 5)
+
+**Command mode `i` key** (AppLayout): `readClipboardImage()` reads clipboard, `detectMediaType()` identifies format, `commandModeState.addImage()` stores it. Same async `.then()/.catch()` pattern as `t` and `f` handlers.
+
+**`readClipboardImage()`** (clipboard.ts): Real version wraps `readClipboardImageCore` with one `pngpaste -` reader. Added `execBuffer` helper alongside `execText`, with 50 MB max buffer and 5s timeout.
+
+**Submit path changes**: `waitForInput()` now returns `UserInput = { text: string; images: ImageAttachment[] }`. On ctrl+enter, image attachments are separated from non-image attachments. Non-images go through `buildSubmitText` as before. Images are returned separately.
+
+**`PerQueryInput.messages`** changed from `string[]` to `(string | BetaMessageParam)[]`. This is a widening of the SDK's public type. Existing code passing `string[]` compiles without changes.
+
+**`QueryRunner.run()`** handles both string and structured `BetaMessageParam` messages. For structured messages, reminder injection prepends to the content array. String path is unchanged.
+
+**`runAgent()`** signature changed from `(queryRunner, prompt: string, ...)` to `(queryRunner, input: RunAgentInput, ...)` where `RunAgentInput = { displayText: string; message: string | BetaMessageParam }`. Display text goes to `layout.startStreaming()`, message goes to `queryRunner.run()`.
+
+**`main.ts`** builds the structured `BetaMessageParam` when images are present: image blocks (base64 source) followed by a text block, wrapped as `{ role: 'user', content: [...] }`.
+
+### Type fixes needed after adding ImageAttachment to Attachment union
+
+Three files had `else` branches that assumed the non-text case was always `FileAttachment`. Adding `ImageAttachment` to the union broke the assumption:
+
+- **`buildSubmitText.ts`**: Changed `else` to `else if (att.kind === 'file')`. Images are skipped (sent via structured content, not text).
+- **`renderCommandMode.ts`**: Both chip rendering and preview rendering needed a new `ImageAttachment` branch. Image chips show as `[img 42.0KB]`, preview shows media type + hash prefix.
+- **`AppLayout.ts`**: The `nonImageAttachments` filter used `?? null` which was possibly null when accessing `.length`. Changed to `?? []`.
+
+### Test results
+- All 456 CLI tests pass
+- All 233 tools tests pass
+- All SDK tests pass
+- Type-check: pass
+- Build: pass
+- Biome CI: pass
+
+### No tests modified
+All 16 Red phase tests passed without modification.
+
+### Proposed commit message
+`Implement image paste from clipboard (#261)`

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -5,3 +5,4 @@
 {"description":"Write BetaMessage per turn to ~/.claude/audit/<conversation-id>.jsonl","category":"added"}
 {"description":"Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`","category":"added"}
 {"description":"Fix `--init-config` to include all schema options in generated file","category":"fixed"}
+{"description":"Add image paste from clipboard via command mode","category":"added"}

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -8,7 +8,7 @@ import { StdoutScreen } from '@shellicar/claude-core/screen';
 import { detectMediaType, readClipboardImage, readClipboardPath, readClipboardText } from './clipboard.js';
 import { logger } from './logger.js';
 import { buildSubmitText } from './model/buildSubmitText.js';
-import { CommandModeState } from './model/CommandModeState.js';
+import { CommandModeState, type ImageAttachment } from './model/CommandModeState.js';
 import type { ConversationSession } from './model/ConversationSession.js';
 import type { Block, BlockType } from './model/ConversationState.js';
 import { ConversationState } from './model/ConversationState.js';
@@ -21,9 +21,6 @@ import { buildDivider, renderBlocksToString, renderConversation } from './view/r
 import { renderEditor } from './view/renderEditor.js';
 import { renderModel, renderStatus } from './view/renderStatus.js';
 import { renderToolApproval } from './view/renderToolApproval.js';
-
-export type { ImageAttachment } from './model/CommandModeState.js';
-export type { PendingTool } from './model/ToolApprovalState.js';
 
 export type UserInput = {
   text: string;

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -5,7 +5,7 @@ import type { KeyAction } from '@shellicar/claude-core/input';
 import { sanitiseLoneSurrogates } from '@shellicar/claude-core/sanitise';
 import type { Screen } from '@shellicar/claude-core/screen';
 import { StdoutScreen } from '@shellicar/claude-core/screen';
-import { readClipboardPath, readClipboardText } from './clipboard.js';
+import { detectMediaType, readClipboardImage, readClipboardPath, readClipboardText } from './clipboard.js';
 import { logger } from './logger.js';
 import { buildSubmitText } from './model/buildSubmitText.js';
 import { CommandModeState } from './model/CommandModeState.js';
@@ -22,7 +22,13 @@ import { renderEditor } from './view/renderEditor.js';
 import { renderModel, renderStatus } from './view/renderStatus.js';
 import { renderToolApproval } from './view/renderToolApproval.js';
 
+export type { ImageAttachment } from './model/CommandModeState.js';
 export type { PendingTool } from './model/ToolApprovalState.js';
+
+export type UserInput = {
+  text: string;
+  images: ImageAttachment[];
+};
 
 type Mode = 'editor' | 'streaming';
 
@@ -52,7 +58,7 @@ export class AppLayout implements Disposable {
 
   #commandModeState = new CommandModeState();
 
-  #editorResolve: ((value: string) => void) | null = null;
+  #editorResolve: ((value: UserInput) => void) | null = null;
   #cancelFn: (() => void) | null = null;
 
   readonly #statusState: StatusState;
@@ -178,7 +184,7 @@ export class AppLayout implements Disposable {
   }
 
   /** Enter editor mode and wait for the user to submit input via Ctrl+Enter. */
-  public waitForInput(): Promise<string> {
+  public waitForInput(): Promise<UserInput> {
     this.#mode = 'editor';
     this.#editorState.reset();
     this.#toolApprovalState.resetExpanded();
@@ -289,9 +295,11 @@ export class AppLayout implements Disposable {
       return;
     }
     const attachments = this.#commandModeState.takeAttachments();
+    const images = attachments?.filter((a): a is ImageAttachment => a.kind === 'image') ?? [];
+    const nonImageAttachments = attachments?.filter((a) => a.kind !== 'image') ?? [];
     const resolveInput = this.#editorResolve;
     this.#editorResolve = null;
-    resolveInput(buildSubmitText(text, attachments));
+    resolveInput({ text: buildSubmitText(text, nonImageAttachments.length > 0 ? nonImageAttachments : null), images });
   }
 
   #flushToScroll(): void {
@@ -393,6 +401,22 @@ export class AppLayout implements Disposable {
                   if (isLikelyPath(filePath)) {
                     this.#commandModeState.addFile(resolved, 'missing');
                   }
+                }
+              }
+              this.render();
+            })
+            .catch(() => {
+              this.render();
+            });
+          return;
+        }
+        case 'i': {
+          readClipboardImage()
+            .then((result) => {
+              if (result.kind === 'image') {
+                const mediaType = detectMediaType(result.data);
+                if (mediaType) {
+                  this.#commandModeState.addImage(result.data, mediaType);
                 }
               }
               this.render();

--- a/apps/claude-sdk-cli/src/clipboard.ts
+++ b/apps/claude-sdk-cli/src/clipboard.ts
@@ -15,6 +15,20 @@ function execText(command: string, args: string[]): Promise<string | null> {
   });
 }
 
+const MAX_IMAGE_BUFFER = 50 * 1024 * 1024;
+
+function execBuffer(command: string, args: string[]): Promise<Buffer | null> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: 'buffer', timeout: 5000, maxBuffer: MAX_IMAGE_BUFFER }, (error, stdout) => {
+      if (error) {
+        reject(new Error(`${command} failed: ${error.message}`));
+        return;
+      }
+      resolve(stdout && stdout.length > 0 ? stdout : null);
+    });
+  });
+}
+
 /** Read plain text from the system clipboard. Returns null if empty or unavailable. */
 export async function readClipboardText(): Promise<string | null> {
   return execText('pbpaste', []);
@@ -197,7 +211,16 @@ export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/w
  * All null means empty. No readers means unsupported.
  */
 export async function readClipboardImageCore(...readers: ImageReader[]): Promise<ClipboardImageResult> {
-  throw new Error('not implemented');
+  if (readers.length === 0) {
+    return { kind: 'unsupported' };
+  }
+  for (const reader of readers) {
+    const data = await reader();
+    if (data !== null) {
+      return { kind: 'image', data };
+    }
+  }
+  return { kind: 'empty' };
 }
 
 /**
@@ -207,5 +230,31 @@ export async function readClipboardImageCore(...readers: ImageReader[]): Promise
  * Returns null for unrecognised formats or buffers too short to identify.
  */
 export function detectMediaType(data: Buffer): ImageMediaType | null {
-  throw new Error('not implemented');
+  if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47 && data[4] === 0x0d && data[5] === 0x0a && data[6] === 0x1a && data[7] === 0x0a) {
+    return 'image/png';
+  }
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (data.length >= 6) {
+    const header = data.toString('ascii', 0, 6);
+    if (header === 'GIF87a' || header === 'GIF89a') {
+      return 'image/gif';
+    }
+  }
+  if (data.length >= 12 && data.toString('ascii', 0, 4) === 'RIFF' && data.toString('ascii', 8, 12) === 'WEBP') {
+    return 'image/webp';
+  }
+  return null;
+}
+
+/**
+ * Read an image from the system clipboard (macOS only).
+ *
+ * Uses `pngpaste -` to read raw PNG bytes from the clipboard.
+ * Returns `unsupported` if no readers are available, `empty` if the
+ * clipboard has no image, or `image` with the raw bytes on success.
+ */
+export async function readClipboardImage(): Promise<ClipboardImageResult> {
+  return readClipboardImageCore(() => execBuffer('pngpaste', ['-']));
 }

--- a/apps/claude-sdk-cli/src/clipboard.ts
+++ b/apps/claude-sdk-cli/src/clipboard.ts
@@ -179,3 +179,33 @@ export async function readClipboardPath(): Promise<string | null> {
   logger.trace('clipboard: readClipboardPath', { result });
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Image clipboard
+// ---------------------------------------------------------------------------
+
+export type ImageReader = () => Promise<Buffer | null>;
+
+export type ClipboardImageResult = { kind: 'image'; data: Buffer } | { kind: 'empty' } | { kind: 'unsupported' };
+
+export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+/**
+ * Core image clipboard reader with injectable callables for testing.
+ *
+ * Tries each reader in order. First one to return a non-null Buffer wins.
+ * All null means empty. No readers means unsupported.
+ */
+export async function readClipboardImageCore(...readers: ImageReader[]): Promise<ClipboardImageResult> {
+  throw new Error('not implemented');
+}
+
+/**
+ * Detect image media type from magic bytes.
+ *
+ * Supports PNG, JPEG, GIF (87a/89a), and WebP.
+ * Returns null for unrecognised formats or buffers too short to identify.
+ */
+export function detectMediaType(data: Buffer): ImageMediaType | null {
+  throw new Error('not implemented');
+}

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -2,9 +2,10 @@ import { relative } from 'node:path';
 import type { MessagePort } from 'node:worker_threads';
 import { CacheTtl, calculateCost, type DurableConfig, type SdkMessage, type SdkMessageUsage, type SdkToolApprovalRequest } from '@shellicar/claude-sdk';
 import type { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
-import type { AppLayout, PendingTool } from '../AppLayout.js';
+import type { AppLayout } from '../AppLayout.js';
 import type { logger } from '../logger.js';
 import type { StatusState } from '../model/StatusState.js';
+import type { PendingTool } from '../model/ToolApprovalState.js';
 import { getPermission, PermissionAction } from '../permissions.js';
 
 // ---- helpers (moved from runAgent.ts) ------------------------------------

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -30,7 +30,7 @@ import { ConversationSession } from '../model/ConversationSession.js';
 import { StatusState } from '../model/StatusState.js';
 import { ReadLine } from '../ReadLine.js';
 import { replayHistory } from '../replayHistory.js';
-import { runAgent } from '../runAgent.js';
+import { buildRunAgentInput, runAgent } from '../runAgent.js';
 import { systemPrompts } from '../systemPrompts.js';
 
 const { values } = parseArgs({
@@ -220,7 +220,7 @@ const main = async () => {
   const claudeMdLoader = new ClaudeMdLoader(nodeFs);
 
   while (true) {
-    const prompt = await layout.waitForInput();
+    const userInput = await layout.waitForInput();
     const claudeMdContent = watcher.config.claudeMd.enabled ? await claudeMdLoader.getContent() : null;
 
     // Update durable config with current values before each query
@@ -236,7 +236,8 @@ const main = async () => {
     layout.render();
     turnInProgress = true;
     const gitDelta = await gitMonitor.getDelta();
-    await runAgent(queryRunner, prompt, layout, channel.consumerPort, transformToolResult, abortController, gitDelta);
+    const agentInput = buildRunAgentInput(userInput);
+    await runAgent(queryRunner, agentInput, layout, channel.consumerPort, transformToolResult, abortController, gitDelta);
     await gitMonitor.takeSnapshot();
     turnInProgress = false;
 

--- a/apps/claude-sdk-cli/src/model/AttachmentStore.ts
+++ b/apps/claude-sdk-cli/src/model/AttachmentStore.ts
@@ -63,7 +63,14 @@ export class AttachmentStore {
 
   /** Add an image attachment. Returns 'duplicate' if already present (by SHA-256 of raw bytes). */
   public addImage(data: Buffer, mediaType: ImageMediaType): 'added' | 'duplicate' {
-    throw new Error('not implemented');
+    const hash = createHash('sha256').update(data).digest('hex');
+    if (this.#attachments.some((a) => a.kind === 'image' && a.hash === hash)) {
+      return 'duplicate';
+    }
+    const base64 = data.toString('base64');
+    this.#attachments.push({ kind: 'image', hash, base64, mediaType, sizeBytes: data.length });
+    this.#selectedIndex = this.#attachments.length - 1;
+    return 'added';
   }
 
   /** Add a file/dir/missing path reference. Returns 'duplicate' if the same path is already attached. */

--- a/apps/claude-sdk-cli/src/model/AttachmentStore.ts
+++ b/apps/claude-sdk-cli/src/model/AttachmentStore.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import type { ImageMediaType } from '../clipboard.js';
 
 export type TextAttachment = {
   readonly kind: 'text';
@@ -16,7 +17,15 @@ export type FileAttachment = {
   readonly sizeBytes?: number; // only when fileType === 'file'
 };
 
-export type Attachment = TextAttachment | FileAttachment;
+export type ImageAttachment = {
+  readonly kind: 'image';
+  readonly hash: string;
+  readonly base64: string;
+  readonly mediaType: ImageMediaType;
+  readonly sizeBytes: number;
+};
+
+export type Attachment = TextAttachment | FileAttachment | ImageAttachment;
 
 export class AttachmentStore {
   readonly #attachments: Attachment[] = [];
@@ -50,6 +59,11 @@ export class AttachmentStore {
     this.#attachments.push({ kind: 'text', hash, text: storedText, sizeBytes, fullSizeBytes, truncated });
     this.#selectedIndex = this.#attachments.length - 1;
     return 'added';
+  }
+
+  /** Add an image attachment. Returns 'duplicate' if already present (by SHA-256 of raw bytes). */
+  public addImage(data: Buffer, mediaType: ImageMediaType): 'added' | 'duplicate' {
+    throw new Error('not implemented');
   }
 
   /** Add a file/dir/missing path reference. Returns 'duplicate' if the same path is already attached. */

--- a/apps/claude-sdk-cli/src/model/CommandModeState.ts
+++ b/apps/claude-sdk-cli/src/model/CommandModeState.ts
@@ -1,7 +1,8 @@
+import type { ImageMediaType } from '../clipboard.js';
 import type { Attachment } from './AttachmentStore.js';
 import { AttachmentStore } from './AttachmentStore.js';
 
-export type { Attachment, FileAttachment, TextAttachment } from './AttachmentStore.js';
+export type { Attachment, FileAttachment, ImageAttachment, TextAttachment } from './AttachmentStore.js';
 
 /**
  * Pure state for the command mode UI: the active/inactive flag, attachment preview
@@ -65,6 +66,10 @@ export class CommandModeState {
 
   public addFile(path: string, fileType: 'file' | 'dir' | 'missing', sizeBytes?: number): 'added' | 'duplicate' {
     return this.#attachments.addFile(path, fileType, sizeBytes);
+  }
+
+  public addImage(data: Buffer, mediaType: ImageMediaType): 'added' | 'duplicate' {
+    return this.#attachments.addImage(data, mediaType);
   }
 
   public removeSelected(): void {

--- a/apps/claude-sdk-cli/src/model/buildSubmitText.ts
+++ b/apps/claude-sdk-cli/src/model/buildSubmitText.ts
@@ -25,7 +25,7 @@ export function buildSubmitText(text: string, attachments: readonly Attachment[]
       const fullSize = att.fullSizeBytes >= 1024 ? `${(att.fullSizeBytes / 1024).toFixed(1)}KB` : `${att.fullSizeBytes}B`;
       const truncPrefix = att.truncated ? `// showing ${showSize} of ${fullSize} (truncated)\n` : '';
       parts.push(`\n\n[attachment #${n + 1}]\n${truncPrefix}${att.text}\n[/attachment]`);
-    } else {
+    } else if (att.kind === 'file') {
       const lines: string[] = [`path: ${att.path}`];
       if (att.fileType === 'missing') {
         lines.push('// not found');
@@ -39,6 +39,8 @@ export function buildSubmitText(text: string, attachments: readonly Attachment[]
       }
       parts.push(`\n\n[attachment #${n + 1}]\n${lines.join('\n')}\n[/attachment]`);
     }
+    // Image attachments are not serialised to text; they are sent as native
+    // BetaImageBlockParam content blocks via the structured message path.
   }
   return parts.join('');
 }

--- a/apps/claude-sdk-cli/src/runAgent.ts
+++ b/apps/claude-sdk-cli/src/runAgent.ts
@@ -1,15 +1,59 @@
 import type { MessagePort } from 'node:worker_threads';
+import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaImageBlockParam, BetaTextBlockParam } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { QueryRunner, TransformToolResult } from '@shellicar/claude-sdk';
-import type { AppLayout } from './AppLayout.js';
+import type { AppLayout, ImageAttachment, UserInput } from './AppLayout.js';
 import { logger } from './logger.js';
 
-export async function runAgent(queryRunner: QueryRunner, prompt: string, layout: AppLayout, consumerPort: MessagePort, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string): Promise<void> {
-  layout.startStreaming(prompt);
+export type RunAgentInput = {
+  displayText: string;
+  message: Anthropic.Beta.Messages.BetaMessageParam;
+};
+
+/**
+ * Build the RunAgentInput from a UserInput.
+ *
+ * When images are present, constructs a multi-content BetaMessageParam with
+ * image blocks (and a text block if text is non-empty). The display text
+ * appends an image summary so the prompt block shows what was sent.
+ *
+ * When no images are present, wraps the text in a single-block BetaMessageParam.
+ */
+export function buildRunAgentInput(userInput: UserInput): RunAgentInput {
+  const contentBlocks: (BetaImageBlockParam | BetaTextBlockParam)[] = [];
+  let displayText = userInput.text;
+
+  for (const img of userInput.images) {
+    contentBlocks.push({
+      type: 'image',
+      source: { type: 'base64', media_type: img.mediaType, data: img.base64 },
+    });
+  }
+
+  if (userInput.text) {
+    contentBlocks.push({ type: 'text', text: userInput.text });
+  }
+
+  if (userInput.images.length > 0) {
+    const imgSummary = userInput.images
+      .map((img) => {
+        const sz = img.sizeBytes >= 1024 ? `${(img.sizeBytes / 1024).toFixed(1)}KB` : `${img.sizeBytes}B`;
+        return `[image ${img.mediaType} ${sz}]`;
+      })
+      .join(' ');
+    displayText = displayText ? `${displayText}\n${imgSummary}` : imgSummary;
+  }
+
+  return { displayText, message: { role: 'user', content: contentBlocks } };
+}
+
+export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, layout: AppLayout, consumerPort: MessagePort, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string): Promise<void> {
+  layout.startStreaming(input.displayText);
   layout.setCancelFn(() => consumerPort.postMessage({ type: 'cancel' }));
 
   try {
     await queryRunner.run({
-      messages: [prompt],
+      messages: [input.message],
       systemReminder: gitDelta,
       transformToolResult,
       abortController,

--- a/apps/claude-sdk-cli/src/runAgent.ts
+++ b/apps/claude-sdk-cli/src/runAgent.ts
@@ -2,7 +2,7 @@ import type { MessagePort } from 'node:worker_threads';
 import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaImageBlockParam, BetaTextBlockParam } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { QueryRunner, TransformToolResult } from '@shellicar/claude-sdk';
-import type { AppLayout, ImageAttachment, UserInput } from './AppLayout.js';
+import type { AppLayout, UserInput } from './AppLayout.js';
 import { logger } from './logger.js';
 
 export type RunAgentInput = {

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -53,7 +53,7 @@ function buildCommandRow(state: CommandModeState, conversationId: string): strin
         const sizeStr = att.sizeBytes >= 1024 ? `${(att.sizeBytes / 1024).toFixed(1)}KB` : `${att.sizeBytes}B`;
         chip = `[txt ${sizeStr}]`;
       }
-    } else {
+    } else if (att.kind === 'file') {
       const name = basename(att.path);
       if (att.fileType === 'missing') {
         chip = `[${name} ?]`;
@@ -64,6 +64,10 @@ function buildCommandRow(state: CommandModeState, conversationId: string): strin
         const sizeStr = sz >= 1024 ? `${(sz / 1024).toFixed(1)}KB` : `${sz}B`;
         chip = `[${name} ${sizeStr}]`;
       }
+    } else {
+      const sz = att.sizeBytes;
+      const sizeStr = sz >= 1024 ? `${(sz / 1024).toFixed(1)}KB` : `${sz}B`;
+      chip = `[img ${sizeStr}]`;
     }
     if (state.commandMode && i === state.selectedIndex) {
       b.ansi(INVERSE_ON);
@@ -84,9 +88,9 @@ function buildCommandRow(state: CommandModeState, conversationId: string): strin
     }
     b.ansi(RESET);
     if (hasAttachments) {
-      b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  ESC cancel');
+      b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  i img  \u00b7  ESC cancel');
     } else {
-      b.text('  t paste  \u00b7  f file  \u00b7  ESC cancel');
+      b.text('  t paste  \u00b7  f file  \u00b7  i img  \u00b7  ESC cancel');
     }
   }
   return b.output;
@@ -120,7 +124,7 @@ function buildPreviewRows(state: CommandModeState, cols: number, maxTextLines: n
     if (lines.length > maxTextLines) {
       rows.push(`${DIM}   \u2026 ${lines.length - maxTextLines} more lines${RESET}`);
     }
-  } else {
+  } else if (att.kind === 'file') {
     rows.push(`   path: ${att.path}`);
     if (att.fileType === 'file') {
       const sz = att.sizeBytes ?? 0;
@@ -131,6 +135,11 @@ function buildPreviewRows(state: CommandModeState, cols: number, maxTextLines: n
     } else {
       rows.push('   // not found');
     }
+  } else {
+    const sz = att.sizeBytes;
+    const sizeStr = sz >= 1024 ? `${(sz / 1024).toFixed(1)}KB` : `${sz}B`;
+    rows.push(`   type: ${att.mediaType}  size: ${sizeStr}`);
+    rows.push(`   hash: ${att.hash.slice(0, 12)}`);
   }
   return rows.slice(0, maxRows);
 }

--- a/apps/claude-sdk-cli/test/image-clipboard.spec.ts
+++ b/apps/claude-sdk-cli/test/image-clipboard.spec.ts
@@ -1,0 +1,181 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { detectMediaType, type ImageMediaType, readClipboardImageCore } from '../src/clipboard.js';
+import { AttachmentStore } from '../src/model/AttachmentStore.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a callable that resolves to a Buffer. */
+const buf = (data: Buffer) => () => Promise.resolve(data);
+
+/** Returns a callable that resolves to null. */
+const empty = () => () => Promise.resolve(null as Buffer | null);
+
+// ---------------------------------------------------------------------------
+// PNG magic bytes: \x89PNG\r\n\x1a\n
+// ---------------------------------------------------------------------------
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+
+// JPEG magic bytes: \xFF\xD8\xFF
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x00]);
+
+// GIF87a magic bytes
+const GIF87A_MAGIC = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x00, 0x00]);
+
+// GIF89a magic bytes
+const GIF89A_MAGIC = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00]);
+
+// WebP magic bytes: RIFF....WEBP
+const WEBP_MAGIC = Buffer.from([
+  0x52,
+  0x49,
+  0x46,
+  0x46, // RIFF
+  0x00,
+  0x00,
+  0x00,
+  0x00, // file size (placeholder)
+  0x57,
+  0x45,
+  0x42,
+  0x50, // WEBP
+]);
+
+// ---------------------------------------------------------------------------
+// readClipboardImageCore
+// ---------------------------------------------------------------------------
+
+describe('readClipboardImageCore', () => {
+  it('returns image result when first reader returns a Buffer', async () => {
+    const expected = { kind: 'image', data: PNG_MAGIC };
+    const actual = await readClipboardImageCore(buf(PNG_MAGIC));
+    expect(actual).toEqual(expected);
+  });
+
+  it('tries second reader when first returns null', async () => {
+    const expected = { kind: 'image', data: JPEG_MAGIC };
+    const actual = await readClipboardImageCore(empty(), buf(JPEG_MAGIC));
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns empty when all readers return null', async () => {
+    const expected = { kind: 'empty' };
+    const actual = await readClipboardImageCore(empty(), empty());
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns unsupported when no readers provided', async () => {
+    const expected = { kind: 'unsupported' };
+    const actual = await readClipboardImageCore();
+    expect(actual).toEqual(expected);
+  });
+
+  it('does not call subsequent readers after one succeeds', async () => {
+    let secondCalled = false;
+    const second = () => {
+      secondCalled = true;
+      return Promise.resolve(JPEG_MAGIC);
+    };
+    await readClipboardImageCore(buf(PNG_MAGIC), second);
+    const expected = false;
+    const actual = secondCalled;
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectMediaType
+// ---------------------------------------------------------------------------
+
+describe('detectMediaType', () => {
+  it('detects PNG from magic bytes', () => {
+    const expected: ImageMediaType = 'image/png';
+    const actual = detectMediaType(PNG_MAGIC);
+    expect(actual).toBe(expected);
+  });
+
+  it('detects JPEG from magic bytes', () => {
+    const expected: ImageMediaType = 'image/jpeg';
+    const actual = detectMediaType(JPEG_MAGIC);
+    expect(actual).toBe(expected);
+  });
+
+  it('detects GIF87a from magic bytes', () => {
+    const expected: ImageMediaType = 'image/gif';
+    const actual = detectMediaType(GIF87A_MAGIC);
+    expect(actual).toBe(expected);
+  });
+
+  it('detects GIF89a from magic bytes', () => {
+    const expected: ImageMediaType = 'image/gif';
+    const actual = detectMediaType(GIF89A_MAGIC);
+    expect(actual).toBe(expected);
+  });
+
+  it('detects WebP from magic bytes', () => {
+    const expected: ImageMediaType = 'image/webp';
+    const actual = detectMediaType(WEBP_MAGIC);
+    expect(actual).toBe(expected);
+  });
+
+  it('returns null for unrecognised format', () => {
+    const expected = null;
+    const actual = detectMediaType(Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b]));
+    expect(actual).toBe(expected);
+  });
+
+  it('returns null for empty buffer', () => {
+    const expected = null;
+    const actual = detectMediaType(Buffer.alloc(0));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AttachmentStore.addImage
+// ---------------------------------------------------------------------------
+
+describe('AttachmentStore.addImage', () => {
+  it('stores image attachment with correct hash, base64, mediaType, sizeBytes', () => {
+    const store = new AttachmentStore();
+    store.addImage(PNG_MAGIC, 'image/png');
+
+    const attachment = store.attachments[0];
+    const expectedHash = createHash('sha256').update(PNG_MAGIC).digest('hex');
+    const expectedBase64 = PNG_MAGIC.toString('base64');
+
+    expect(attachment).toEqual({
+      kind: 'image',
+      hash: expectedHash,
+      base64: expectedBase64,
+      mediaType: 'image/png',
+      sizeBytes: PNG_MAGIC.length,
+    });
+  });
+
+  it('returns added on first add', () => {
+    const store = new AttachmentStore();
+    const expected = 'added';
+    const actual = store.addImage(PNG_MAGIC, 'image/png');
+    expect(actual).toBe(expected);
+  });
+
+  it('returns duplicate on duplicate add', () => {
+    const store = new AttachmentStore();
+    store.addImage(PNG_MAGIC, 'image/png');
+    const expected = 'duplicate';
+    const actual = store.addImage(PNG_MAGIC, 'image/png');
+    expect(actual).toBe(expected);
+  });
+
+  it('deduplicates by content hash, not by reference', () => {
+    const store = new AttachmentStore();
+    const copy = Buffer.from(PNG_MAGIC);
+    store.addImage(PNG_MAGIC, 'image/png');
+    const expected = 'duplicate';
+    const actual = store.addImage(copy, 'image/png');
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -80,15 +80,30 @@ export class QueryRunner extends IQueryRunner {
     const injectReminders = cachedReminders != null && cachedReminders.length > 0 && !this.#conversation.messages.some((m) => m.role === 'user');
 
     let isFirst = true;
-    for (const content of input.messages) {
-      if (isFirst && injectReminders) {
-        const reminderBlocks: BetaTextBlockParam[] = cachedReminders.map((text, i, arr) => ({
-          type: 'text' as const,
-          text: `<system-reminder>\n${text}\n</system-reminder>\n${i === arr.length - 1 ? '\n' : ''}`,
-        }));
-        this.#conversation.push({ role: 'user', content: [...reminderBlocks, { type: 'text' as const, text: content }] });
+    for (const msg of input.messages) {
+      if (typeof msg === 'string') {
+        // Plain string message: wrap in a user message, optionally injecting cached reminders.
+        if (isFirst && injectReminders) {
+          const reminderBlocks: BetaTextBlockParam[] = cachedReminders.map((text, i, arr) => ({
+            type: 'text' as const,
+            text: `<system-reminder>\n${text}\n</system-reminder>\n${i === arr.length - 1 ? '\n' : ''}`,
+          }));
+          this.#conversation.push({ role: 'user', content: [...reminderBlocks, { type: 'text' as const, text: msg }] });
+        } else {
+          this.#conversation.push({ role: 'user', content: msg });
+        }
       } else {
-        this.#conversation.push({ role: 'user', content });
+        // Pre-built structured BetaMessageParam: push directly, injecting reminders if needed.
+        if (isFirst && injectReminders) {
+          const reminderBlocks: BetaTextBlockParam[] = cachedReminders.map((text, i, arr) => ({
+            type: 'text' as const,
+            text: `<system-reminder>\n${text}\n</system-reminder>\n${i === arr.length - 1 ? '\n' : ''}`,
+          }));
+          const existingContent = Array.isArray(msg.content) ? msg.content : [{ type: 'text' as const, text: msg.content }];
+          this.#conversation.push({ role: msg.role, content: [...reminderBlocks, ...existingContent] });
+        } else {
+          this.#conversation.push(msg);
+        }
       }
       isFirst = false;
     }

--- a/packages/claude-sdk/src/public/types.ts
+++ b/packages/claude-sdk/src/public/types.ts
@@ -1,3 +1,4 @@
+import type { Anthropic } from '@anthropic-ai/sdk';
 import type { Model } from '@anthropic-ai/sdk/resources/messages';
 import type { z } from 'zod';
 import type { AnthropicBeta, CacheTtl } from './enums';
@@ -109,7 +110,7 @@ export type TurnInput = {
  * into every turn so the in-flight HTTP call can be cancelled.
  */
 export type PerQueryInput = {
-  messages: string[];
+  messages: (string | Anthropic.Beta.Messages.BetaMessageParam)[];
   systemReminder?: string;
   transformToolResult?: TransformToolResult;
   abortController: AbortController;


### PR DESCRIPTION
## Summary

- Paste images from the system clipboard in command mode (`i` key)
- Detect image format from magic bytes (PNG, JPEG, GIF, WebP)
- Deduplicate image attachments by content hash
- Send images as native `BetaImageBlockParam` content blocks
- macOS-only via `pngpaste` (injectable reader pattern for future platform support)

## Related Issues

Closes #261

Co-Authored-By: Claude <noreply@anthropic.com>