### PR TITLE
Bump all packages to 1.0.0-beta.2

### DIFF
--- a/.claude/testament/2026-04-15-release-beta2.md
+++ b/.claude/testament/2026-04-15-release-beta2.md
@@ -1,43 +1,13 @@
-# 07:50
+# Release versioning — beta and pre-release
 
-Release `1.0.0-beta.2` — phase 1 (version bump).
+**No release markers in `changes.jsonl` for pre-releases.** The SC removed an existing `1.0.0-alpha.1` marker from `claude-sdk-tools` during this process. The pattern is consistent across all packages: no markers for alpha or beta, everything stays `[Unreleased]` until the stable `1.0.0` release. The publish workflow validates the top marker against the release tag, but pre-releases skip that validation anyway. Git tags are the authoritative record of what shipped in each pre-release.
 
-## What changed since beta.1
+**Run `generate-changelog.ts` on every version bump, not just stable releases.** Even with no release marker the output under `[Unreleased]` is useful and should be kept current.
 
-All four packages had commits since their respective `*@1.0.0-beta.1` tags.
+# Traps
 
-**packages/claude-sdk** (4 commits): finalMessage event emitter, CompactConfig type, COMPACT_BETA constant replacing enum member, omit empty context_management from request body.
+**`pnpm ci` is not the biome check.** `pnpm ci` is intercepted by pnpm's own unimplemented `ci` command. The biome check is `pnpm run ci`.
 
-**packages/claude-sdk-tools** (2 commits): appendFile added to IFileSystem/NodeFileSystem/MemoryFileSystem (#253), TypeScript language tools TsDiagnostics/TsHover/TsReferences/TsDefinition (#264).
+**Auditing changes against a tag: use `git diff`, not `changes.jsonl` comparison.** `git diff <tag>..HEAD -- <path>/src` shows source-only changes directly. Comparing jsonl at tag time vs HEAD via `git show` is slower and indirect.
 
-**packages/claude-core** (1 commit): package.json metadata fix (#250, missing keywords/homepage/repo). No source changes. No changes.jsonl entry added — SC confirmed not necessary.
-
-**apps/claude-sdk-cli** (5 commits): Write BetaMessage per turn, compact config, --init-config fix, image paste, TypeScript tools registered in main.ts. The last one (#264) had no changes.jsonl entry — added it before bumping.
-
-## Cross-reference process
-
-Used `git show <tag>:<path>/changes.jsonl` to compare the file at tag time vs HEAD, then matched against git log. SC pointed out the simpler approach: `git diff <tag>..HEAD -- <path>/src` to show source-only changes directly. Use that next time.
-
-## Release markers — pre-releases only
-
-No release markers in changes.jsonl for any pre-release (alpha or beta). The SC removed the 1.0.0-alpha.1 marker that existed in claude-sdk-tools — consistent pattern across all packages. Pre-releases aren't validated by the publish workflow, the markers would be replaced at 1.0.0 anyway, and git tags are the authoritative source of what shipped in each pre-release. Everything stays unreleased until the stable release.
-
-## Changelog generation
-
-Run `generate-changelog.ts` for all four packages as part of every version bump, not just stable releases. It updates CHANGELOG.md with the current unreleased entries. With no release marker, new entries appear under `[Unreleased]` — still useful and should be kept current.
-
-## Verification
-
-- `pnpm build`: pass
-- `pnpm type-check`: pass
-- `pnpm test`: pass
-- `pnpm run ci` (biome): pass — note: `pnpm ci` is intercepted by pnpm's own unimplemented ci command; must use `pnpm run ci`
-- `validate-changes.ts`: pass
-
-## Staged
-
-- `apps/claude-sdk-cli/changes.jsonl` (added missing TS tools entry)
-- `apps/claude-sdk-cli/package.json`
-- `packages/claude-core/package.json`
-- `packages/claude-sdk-tools/package.json`
-- `packages/claude-sdk/package.json`
+**Check `changes.jsonl` completeness before bumping.** A package may have commits with no corresponding `changes.jsonl` entry. Cross-reference `git log <tag>..HEAD --oneline -- <path>` against the jsonl. Add missing entries before bumping.

--- a/.claude/testament/2026-04-15-release-beta2.md
+++ b/.claude/testament/2026-04-15-release-beta2.md
@@ -1,0 +1,43 @@
+# 07:50
+
+Release `1.0.0-beta.2` — phase 1 (version bump).
+
+## What changed since beta.1
+
+All four packages had commits since their respective `*@1.0.0-beta.1` tags.
+
+**packages/claude-sdk** (4 commits): finalMessage event emitter, CompactConfig type, COMPACT_BETA constant replacing enum member, omit empty context_management from request body.
+
+**packages/claude-sdk-tools** (2 commits): appendFile added to IFileSystem/NodeFileSystem/MemoryFileSystem (#253), TypeScript language tools TsDiagnostics/TsHover/TsReferences/TsDefinition (#264).
+
+**packages/claude-core** (1 commit): package.json metadata fix (#250, missing keywords/homepage/repo). No source changes. No changes.jsonl entry added — SC confirmed not necessary.
+
+**apps/claude-sdk-cli** (5 commits): Write BetaMessage per turn, compact config, --init-config fix, image paste, TypeScript tools registered in main.ts. The last one (#264) had no changes.jsonl entry — added it before bumping.
+
+## Cross-reference process
+
+Used `git show <tag>:<path>/changes.jsonl` to compare the file at tag time vs HEAD, then matched against git log. SC pointed out the simpler approach: `git diff <tag>..HEAD -- <path>/src` to show source-only changes directly. Use that next time.
+
+## Release markers — pre-releases only
+
+No release markers in changes.jsonl for any pre-release (alpha or beta). The SC removed the 1.0.0-alpha.1 marker that existed in claude-sdk-tools — consistent pattern across all packages. Pre-releases aren't validated by the publish workflow, the markers would be replaced at 1.0.0 anyway, and git tags are the authoritative source of what shipped in each pre-release. Everything stays unreleased until the stable release.
+
+## Changelog generation
+
+Run `generate-changelog.ts` for all four packages as part of every version bump, not just stable releases. It updates CHANGELOG.md with the current unreleased entries. With no release marker, new entries appear under `[Unreleased]` — still useful and should be kept current.
+
+## Verification
+
+- `pnpm build`: pass
+- `pnpm type-check`: pass
+- `pnpm test`: pass
+- `pnpm run ci` (biome): pass — note: `pnpm ci` is intercepted by pnpm's own unimplemented ci command; must use `pnpm run ci`
+- `validate-changes.ts`: pass
+
+## Staged
+
+- `apps/claude-sdk-cli/changes.jsonl` (added missing TS tools entry)
+- `apps/claude-sdk-cli/package.json`
+- `packages/claude-core/package.json`
+- `packages/claude-sdk-tools/package.json`
+- `packages/claude-sdk/package.json`

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -6,3 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Add ConversationSession: persistent conversation identity and n key to start new conversation
+- Write BetaMessage per turn to ~/.claude/audit/<conversation-id>.jsonl
+- Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`
+- Add image paste from clipboard via command mode
+- Register TypeScript language tools (TsDiagnostics, TsHover, TsReferences, TsDefinition) in the CLI
+
+### Changed
+
+- Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement
+
+### Fixed
+
+- Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns
+- Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)
+- Fix `--init-config` to include all schema options in generated file

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -6,3 +6,4 @@
 {"description":"Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`","category":"added"}
 {"description":"Fix `--init-config` to include all schema options in generated file","category":"fixed"}
 {"description":"Add image paste from clipboard via command mode","category":"added"}
+{"description":"Register TypeScript language tools (TsDiagnostics, TsHover, TsReferences, TsDefinition) in the CLI","category":"added"}

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",

--- a/packages/claude-core/package.json
+++ b/packages/claude-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-core",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "description": "",
   "license": "MIT",

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -9,16 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry
-
-### Fixed
-
-- Package now publishes CJS alongside ESM with working sourcemaps
-
-## [1.0.0-alpha.1] - 2026-04-07
-
-### Added
-
 - File read tools: Find, ReadFile, Grep, Head, Tail, Range, SearchFiles
 - File write tools: CreateFile, DeleteFile, DeleteDirectory
 - PreviewEdit and EditFile tools for staged edits with diff preview
@@ -28,5 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ref system for paginating large tool results that exceed context threshold
 - Path expansion supporting ~, $HOME, and relative paths in all tools
 - Split PreviewEdit edits into lineEdits (structural, bottom-to-top) and textEdits (text-search, applied after lineEdits)
+- Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry
+- Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem
+- Add TypeScript language tools: ts_diagnostics, ts_hover, ts_references, ts_definition
 
-[1.0.0-alpha.1]: https://github.com/shellicar/claude-cli/releases/tag/claude-sdk-tools@1.0.0-alpha.1
+### Fixed
+
+- Package now publishes CJS alongside ESM with working sourcemaps

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -7,7 +7,6 @@
 {"description":"Ref system for paginating large tool results that exceed context threshold","category":"added"}
 {"description":"Path expansion supporting ~, $HOME, and relative paths in all tools","category":"added"}
 {"description":"Split PreviewEdit edits into lineEdits (structural, bottom-to-top) and textEdits (text-search, applied after lineEdits)","category":"added"}
-{"type":"release","version":"1.0.0-alpha.1","date":"2026-04-07"}
 {"description":"Package now publishes CJS alongside ESM with working sourcemaps","category":"fixed"}
 {"description":"Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry","category":"added"}
 {"description":"Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem","category":"added"}

--- a/packages/claude-sdk-tools/package.json
+++ b/packages/claude-sdk-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-tools",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add finalMessage event emitter surface to AnthropicClient
+- Add `CompactConfig` type; `cloneForRequest` converts compaction blocks to text when compact is disabled
+
+### Changed
+
+- Conversation retains full message history across compaction; adds internal `cloneForRequest()` that returns a deep-cloned post-compaction slice for API requests
+- Extract `AnthropicClient` from `AnthropicAgent`: auth, token refresh, and HTTP transport now live in a dedicated private class. `AnthropicAgent` becomes a thin composer that holds a client and a conversation. The previous `AnthropicMessageStreamer` wrapper is removed; `AnthropicClient` extends `IMessageStreamer` directly.
+- Replace `AnthropicBeta.Compact` enum member with standalone `COMPACT_BETA` constant
+- Omit empty `context_management` from request body instead of sending empty edits array
+
 ### Fixed
 
 - Package now publishes CJS alongside ESM with working sourcemaps

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",


### PR DESCRIPTION
## Summary

- Bump `claude-sdk`, `claude-sdk-tools`, `claude-core`, `claude-sdk-cli` to `1.0.0-beta.2`
- Add missing changelog entry for TypeScript tools in `claude-sdk-cli`
- Update `CHANGELOG.md` for all four packages