### PR TITLE
Add typescript as production dependency, release claude-sdk-cli 1.0.0-beta.3

### DIFF
--- a/.claude/testament/2026-04-15-typescript-prod-dep.md
+++ b/.claude/testament/2026-04-15-typescript-prod-dep.md
@@ -1,0 +1,9 @@
+# 08:24
+
+## #266 — Add typescript as a production dependency
+
+Trivial fix. `typescript` was only in `devDependencies`, so consumers running in environments without a separate `typescript` install (e.g. Docker images built from the published package) would fail at `TsServerService` startup when `createRequire` tries to resolve `typescript` to find `tsserver.js`.
+
+The fix is a `pnpm add typescript` in `apps/claude-sdk-cli`. The `pnpm version` bump (beta.2 to beta.3) is the only other change.
+
+No build, type-check, or test failures. No surprises.

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add `typescript` as a production dependency so consumers do not need it installed separately
 - Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns
 - Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)
 - Fix `--init-config` to include all schema options in generated file

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -1,3 +1,4 @@
+{"description":"Add `typescript` as a production dependency so consumers do not need it installed separately","category":"fixed"}
 {"description":"Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns","category":"fixed"}
 {"description":"Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)","category":"fixed"}
 {"description":"Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement","category":"changed"}

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",
@@ -51,6 +51,7 @@
     "@shellicar/claude-sdk": "workspace:^",
     "@shellicar/claude-sdk-tools": "workspace:^",
     "cli-highlight": "^2.1.11",
+    "typescript": "^5.9.3",
     "winston": "^3.19.0",
     "zod": "^4.3.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       cli-highlight:
         specifier: ^2.1.11
         version: 2.1.11
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       winston:
         specifier: ^3.19.0
         version: 3.19.0


### PR DESCRIPTION
## Summary

- Add `typescript` as a production dependency in `claude-sdk-cli`
- Bump `claude-sdk-cli` to `1.0.0-beta.3`

Closes #266 