### PR TITLE
Add mcp-exec package: MCP server wrapping claude-sdk-tools Exec

### DIFF
--- a/.claude/testament/2026-04-15.md
+++ b/.claude/testament/2026-04-15.md
@@ -57,37 +57,28 @@ Each tool needs a `./TsXxx` export in `package.json` (import + require, types + 
 
 Shared types (`ITypeScriptService`, `Position`, etc.) and the `TsServerService` class are exported via `./TsService`, not via `./TsDiagnostics`. The original design put everything in the TsDiagnostics entry which triggered `noBarrelFile`. Splitting the shared infrastructure into its own entry avoids the barrel file issue and is a cleaner API boundary.
 
-
 # 08:56
 
-## Task: Create `packages/mcp-exec` (#268)
+## `packages/mcp-exec` (#268)
 
-New package wrapping the `claude-sdk-tools` Exec tool as an MCP server.
+### MCP SDK schema: use the full ZodObject, not `.shape`
 
-### What was built
+`registerTool` accepts `AnySchema` (a full ZodObject). Passing `Exec.input_schema` directly lets TypeScript infer the handler input type correctly. Passing `.shape` instead requires a cast and produces an implicit `any` error.
 
-`packages/mcp-exec/` with:
-- `src/entry/index.ts` - `createExecServer()` function (MCP server setup)
-- `src/entry/cli.ts` - binary entry point, imports from `./index.js`
-- `tsconfig.json`, `tsconfig.check.json`, `tsup.config.ts`
-- `package.json` created via `pnpm init` + `pnpm pkg set` + `pnpm add`
+### No `outputSchema`
 
-### Key design decisions
+`ExecOutputSchema` is not exported from `@shellicar/claude-sdk-tools/Exec`. It is optional in the MCP SDK, so leaving it out is the right call rather than duplicating the type inline.
 
-**Why `Exec.input_schema` directly, not `.shape`**: The MCP SDK's `registerTool` accepts `AnySchema` (a full ZodObject), not just a raw shape. Passing `Exec.input_schema` directly lets TypeScript infer the handler input type as `z.output<typeof ExecInputSchema>`, which is exactly what `Exec.handler` expects. Using `.shape` required a cast and caused an implicit `any` error.
+### `noBarrelFile` and the two-entry tsup split
 
-**Why no `outputSchema`**: `ExecOutputSchema` is not exported from `@shellicar/claude-sdk-tools/Exec`. Defining it inline would duplicate the type. Since `outputSchema` is optional in the MCP SDK, leaving it out is clean.
+The biome `noBarrelFile` rule fires on any file that only re-exports. The solution is to put the implementation directly in `src/entry/index.ts` and have `cli.ts` import from `./index.js`. Both are tsup entry points and tsup handles the shared chunk.
 
-**Why `cli.ts` imports from `./index.js`**: The biome `noBarrelFile` rule fired on the original `index.ts` which just re-exported from `../createExecServer.js`. Moving the implementation into `src/entry/index.ts` directly and having `cli.ts` import from `./index.js` satisfies the rule. Both are tsup entry points; tsup handles cross-entry imports via shared chunks.
+The CJS entry is `index.ts` only. A CLI binary only makes sense as ESM, so there is no `cli.cjs`.
 
-**tsup split**: ESM entry includes both `cli.ts` and `index.ts`. CJS entry is `index.ts` only - the CLI binary only makes sense as ESM, and avoiding a CJS `cli.cjs` is cleaner.
+### `pnpm pkg set` key syntax for the `.` export
 
-**`pnpm pkg set` gotcha**: Setting exports with `.` as the key is tricky. Shell quoting `'exports[.].import.types=...'` (bracket notation without inner quotes) works correctly - pnpm parses `[.]` as the literal key `.`. `exports.'.'.xxx` sends `'.'` as the key (with quotes as part of the key name). `exports["."].xxx` sends `"."` (with escaped quotes). Only the bare `[.]` form works.
+Shell quoting for the root export key is non-obvious. The only form that works is bracket notation without inner quotes: `exports[.].import.types=...`. The forms `exports.'.'.xxx` and `exports["."].xxx` both include the quote characters as part of the key name.
 
-**`pnpm pkg set private=false`** sets the value as string `"false"` (truthy), not boolean. Use `pnpm pkg delete private` instead - a public package without `private` field is public by default.
+### `pnpm pkg set private=false` does not work
 
-### What works
-- Build: `pnpm turbo build --filter=@shellicar/mcp-exec` passes
-- Type-check: `pnpm turbo type-check --filter=@shellicar/mcp-exec` passes
-- Biome: clean on all source files
-- The MCP server correctly wraps `Exec.handler` - execution logic lives entirely in `claude-sdk-tools`
+This sets the value to the string `"false"` (truthy). Use `pnpm pkg delete private` instead. A package without a `private` field is public by default.

--- a/.claude/testament/2026-04-15.md
+++ b/.claude/testament/2026-04-15.md
@@ -56,3 +56,38 @@ Each tool needs a `./TsXxx` export in `package.json` (import + require, types + 
 ## TsService entry point
 
 Shared types (`ITypeScriptService`, `Position`, etc.) and the `TsServerService` class are exported via `./TsService`, not via `./TsDiagnostics`. The original design put everything in the TsDiagnostics entry which triggered `noBarrelFile`. Splitting the shared infrastructure into its own entry avoids the barrel file issue and is a cleaner API boundary.
+
+
+# 08:56
+
+## Task: Create `packages/mcp-exec` (#268)
+
+New package wrapping the `claude-sdk-tools` Exec tool as an MCP server.
+
+### What was built
+
+`packages/mcp-exec/` with:
+- `src/entry/index.ts` - `createExecServer()` function (MCP server setup)
+- `src/entry/cli.ts` - binary entry point, imports from `./index.js`
+- `tsconfig.json`, `tsconfig.check.json`, `tsup.config.ts`
+- `package.json` created via `pnpm init` + `pnpm pkg set` + `pnpm add`
+
+### Key design decisions
+
+**Why `Exec.input_schema` directly, not `.shape`**: The MCP SDK's `registerTool` accepts `AnySchema` (a full ZodObject), not just a raw shape. Passing `Exec.input_schema` directly lets TypeScript infer the handler input type as `z.output<typeof ExecInputSchema>`, which is exactly what `Exec.handler` expects. Using `.shape` required a cast and caused an implicit `any` error.
+
+**Why no `outputSchema`**: `ExecOutputSchema` is not exported from `@shellicar/claude-sdk-tools/Exec`. Defining it inline would duplicate the type. Since `outputSchema` is optional in the MCP SDK, leaving it out is clean.
+
+**Why `cli.ts` imports from `./index.js`**: The biome `noBarrelFile` rule fired on the original `index.ts` which just re-exported from `../createExecServer.js`. Moving the implementation into `src/entry/index.ts` directly and having `cli.ts` import from `./index.js` satisfies the rule. Both are tsup entry points; tsup handles cross-entry imports via shared chunks.
+
+**tsup split**: ESM entry includes both `cli.ts` and `index.ts`. CJS entry is `index.ts` only - the CLI binary only makes sense as ESM, and avoiding a CJS `cli.cjs` is cleaner.
+
+**`pnpm pkg set` gotcha**: Setting exports with `.` as the key is tricky. Shell quoting `'exports[.].import.types=...'` (bracket notation without inner quotes) works correctly - pnpm parses `[.]` as the literal key `.`. `exports.'.'.xxx` sends `'.'` as the key (with quotes as part of the key name). `exports["."].xxx` sends `"."` (with escaped quotes). Only the bare `[.]` form works.
+
+**`pnpm pkg set private=false`** sets the value as string `"false"` (truthy), not boolean. Use `pnpm pkg delete private` instead - a public package without `private` field is public by default.
+
+### What works
+- Build: `pnpm turbo build --filter=@shellicar/mcp-exec` passes
+- Type-check: `pnpm turbo type-check --filter=@shellicar/mcp-exec` passes
+- Biome: clean on all source files
+- The MCP server correctly wraps `Exec.handler` - execution logic lives entirely in `claude-sdk-tools`

--- a/packages/mcp-exec/changes.jsonl
+++ b/packages/mcp-exec/changes.jsonl
@@ -1,0 +1,1 @@
+{"description":"Initial release: MCP server wrapping claude-sdk-tools Exec","category":"added"}

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@shellicar/mcp-exec",
+  "version": "1.0.0-beta.1",
+  "description": "MCP server wrapping the Exec tool from @shellicar/claude-sdk-tools",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "watch": "tsup --watch",
+    "type-check": "tsc -p tsconfig.check.json"
+  },
+  "author": "Stephen Hellicar",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shellicar/claude-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shellicar/claude-cli/issues"
+  },
+  "homepage": "https://github.com/shellicar/claude-cli#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "mcp-exec": "./dist/esm/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "contributors": [
+    "BananaBot9000 <bananabot9000@bananabot.dev>",
+    "Claude (Anthropic) <noreply@anthropic.com>"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@shellicar/claude-sdk-tools": "workspace:^"
+  },
+  "devDependencies": {
+    "@shellicar/build-clean": "^1.3.2",
+    "@shellicar/build-version": "^1.3.6",
+    "@shellicar/typescript-config": "workspace:*",
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^25.5.2",
+    "esbuild": "^0.27.5",
+    "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
+  }
+}

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/mcp-exec",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.3",
   "description": "MCP server wrapping the Exec tool from @shellicar/claude-sdk-tools",
   "scripts": {
     "build": "tsup",

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -6,7 +6,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "watch": "tsup --watch",
-    "type-check": "tsc -p tsconfig.check.json"
+    "type-check": "tsc -p tsconfig.check.json",
+    "test": "vitest run"
   },
   "author": "Stephen Hellicar",
   "license": "MIT",
@@ -45,7 +46,8 @@
     "esbuild": "^0.27.5",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
   },
   "exports": {
     ".": {

--- a/packages/mcp-exec/src/entry/cli.ts
+++ b/packages/mcp-exec/src/entry/cli.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createExecServer } from './index.js';
+
+async function main() {
+  const server = createExecServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(console.error);

--- a/packages/mcp-exec/src/entry/index.ts
+++ b/packages/mcp-exec/src/entry/index.ts
@@ -1,0 +1,28 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Exec } from '@shellicar/claude-sdk-tools/Exec';
+
+type ExecInput = Parameters<(typeof Exec)['handler']>[0];
+type ExecOutput = Awaited<ReturnType<(typeof Exec)['handler']>>;
+
+/** Create a configured McpServer with the exec tool registered, backed by @shellicar/claude-sdk-tools. */
+export function createExecServer(): McpServer {
+  const server = new McpServer({ name: 'mcp-exec', version: '1.0.0' });
+
+  server.registerTool(
+    'exec',
+    {
+      description: Exec.description,
+      inputSchema: Exec.input_schema,
+    },
+    async (input) => {
+      const result = await Exec.handler(input as ExecInput);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        structuredContent: result as ExecOutput,
+        isError: !result.success,
+      };
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp-exec/test/cli.spec.ts
+++ b/packages/mcp-exec/test/cli.spec.ts
@@ -1,0 +1,41 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cliEntry = path.join(packageRoot, 'src/entry/cli.ts');
+
+describe('CLI', () => {
+  let client: Client;
+
+  afterEach(async () => {
+    await client?.close();
+  });
+
+  async function setup() {
+    const transport = new StdioClientTransport({
+      command: 'tsx',
+      args: [cliEntry],
+      stderr: 'pipe',
+    });
+    client = new Client({ name: 'test', version: '1.0.0' });
+    await client.connect(transport);
+    return client;
+  }
+
+  it('lists the exec tool', async () => {
+    const c = await setup();
+    const { tools } = await c.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('exec');
+  });
+
+  it('exec tool has a description', async () => {
+    const c = await setup();
+    const { tools } = await c.listTools();
+    const exec = tools.find((t) => t.name === 'exec');
+    expect(exec?.description).toBeTruthy();
+  });
+});

--- a/packages/mcp-exec/test/cli.spec.ts
+++ b/packages/mcp-exec/test/cli.spec.ts
@@ -1,7 +1,7 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');

--- a/packages/mcp-exec/test/integration.spec.ts
+++ b/packages/mcp-exec/test/integration.spec.ts
@@ -1,0 +1,89 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createExecServer } from '../src/entry/index.js';
+
+describe('integration', () => {
+  let client: Client;
+
+  afterEach(async () => {
+    await client?.close();
+  });
+
+  async function setup() {
+    const server = createExecServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test', version: '1.0.0' });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function echoArgs() {
+    return {
+      name: 'exec' as const,
+      arguments: {
+        description: 'echo hello',
+        steps: [{ commands: [{ program: 'echo', args: ['hello'] }] }],
+      },
+    };
+  }
+
+  describe('successful command', () => {
+    it('returns success', async () => {
+      const c = await setup();
+      const result = await c.callTool(echoArgs());
+
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('structuredContent.success is true', async () => {
+      const c = await setup();
+      const result = await c.callTool(echoArgs());
+
+      const output = result.structuredContent as { success: boolean; results: unknown[] };
+      expect(output.success).toBe(true);
+    });
+
+    it('structuredContent.results contains step output', async () => {
+      const c = await setup();
+      const result = await c.callTool(echoArgs());
+
+      const output = result.structuredContent as {
+        success: boolean;
+        results: { stdout: string; stderr: string; exitCode: number | null; signal: string | null }[];
+      };
+      expect(output.results).toHaveLength(1);
+      expect(output.results[0]?.stdout.trim()).toBe('hello');
+      expect(output.results[0]?.exitCode).toBe(0);
+    });
+  });
+
+  describe('schema validation', () => {
+    it('returns an error for empty steps array', async () => {
+      const c = await setup();
+      const result = await c.callTool({
+        name: 'exec',
+        arguments: { description: 'empty', steps: [] },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('blocked command', () => {
+    it('returns error when command is blocked by validation rules', async () => {
+      const c = await setup();
+      const result = await c.callTool({
+        name: 'exec',
+        arguments: {
+          description: 'try rm',
+          steps: [{ commands: [{ program: 'rm', args: ['-rf', '/'] }] }],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const output = result.structuredContent as { success: boolean; results: unknown[] };
+      expect(output.success).toBe(false);
+    });
+  });
+});

--- a/packages/mcp-exec/tsconfig.check.json
+++ b/packages/mcp-exec/tsconfig.check.json
@@ -1,0 +1,1 @@
+../../tsconfig.check.json

--- a/packages/mcp-exec/tsconfig.json
+++ b/packages/mcp-exec/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shellicar/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/mcp-exec/tsup.config.ts
+++ b/packages/mcp-exec/tsup.config.ts
@@ -1,0 +1,41 @@
+import versionPlugin from '@shellicar/build-version/esbuild';
+import { defineConfig, type Options } from 'tsup';
+
+const esbuildPlugins = [versionPlugin({ versionCalculator: 'gitversion' })];
+
+const commonOptions = (config: Options) =>
+  ({
+    bundle: true,
+    clean: true,
+    dts: true,
+    esbuildPlugins,
+    esbuildOptions: (options) => {
+      options.chunkNames = 'chunks/[name]-[hash]';
+      options.entryNames = '[name]';
+    },
+    keepNames: true,
+    minify: false,
+    removeNodeProtocol: false,
+    platform: 'node',
+    sourcemap: true,
+    splitting: true,
+    target: 'node24',
+    treeshake: false,
+    watch: config.watch,
+    tsconfig: 'tsconfig.json',
+  }) satisfies Options;
+
+export default defineConfig((config) => [
+  {
+    ...commonOptions(config),
+    format: 'esm',
+    outDir: 'dist/esm',
+    entry: ['src/entry/*.ts'],
+  },
+  {
+    ...commonOptions(config),
+    format: 'cjs',
+    outDir: 'dist/cjs',
+    entry: ['src/entry/index.ts'],
+  },
+]);

--- a/packages/mcp-exec/vitest.config.ts
+++ b/packages/mcp-exec/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,43 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/mcp-exec:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      '@shellicar/claude-sdk-tools':
+        specifier: workspace:^
+        version: link:../claude-sdk-tools
+    devDependencies:
+      '@shellicar/build-clean':
+        specifier: ^1.3.2
+        version: 1.3.2(esbuild@0.27.5)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@shellicar/build-version':
+        specifier: ^1.3.6
+        version: 1.3.6(esbuild@0.27.5)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@shellicar/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@tsconfig/node24':
+        specifier: ^24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      esbuild:
+        specifier: ^0.27.5
+        version: 0.27.5
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/typescript-config:
     devDependencies:
       '@tsconfig/node24':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/typescript-config:
     devDependencies:


### PR DESCRIPTION
## Summary

- New `@shellicar/mcp-exec` package
- MCP server over stdio transport
- Wraps the `Exec` tool from `@shellicar/claude-sdk-tools` as a registered MCP tool
- Binary entry point: `mcp-exec`