### PR TITLE
Restore cursor on exit

### DIFF
--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -51,3 +51,16 @@ One test (`returns defaults for empty object`) was asserting the old default of 
 Phase 2 — shipped.
 
 **`changes.jsonl` is append-only.** New entries go at the bottom, after all existing entries. The instructions say "add an entry" but don't specify where — the right mental model is a log, not a list. With release markers interspersed, order determines which release an entry belongs to; an entry after the last marker is [Unreleased]. Prepending breaks that invariant. Always append.
+# 22:58
+
+Phase 1 of prompt #277 (cursor-restore). Fix was already in the working tree when I started.
+
+The problem: `AppLayout.exit()` calls `exitAltBuffer()` but never wrote `showCursor` (`\e[?25h`) before leaving. The cursor is hidden on entry with `hideCursor` (`\e[?25l`) but nothing restored it.
+
+The fix (already applied): import `showCursor` from `@shellicar/claude-core/ansi` and write it in `exit()` immediately before `exitAltBuffer()`. One line, right next to the alt-buffer exit — the natural place since both are cleanup operations.
+
+`showCursor` and `hideCursor` were already defined in `packages/claude-core/src/ansi.ts`. No new constants needed.
+
+Build and type-check both pass. File staged: `apps/claude-sdk-cli/src/AppLayout.ts`.
+
+Proposed commit: `Restore cursor on exit`

--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -52,15 +52,10 @@ Phase 2 — shipped.
 
 **`changes.jsonl` is append-only.** New entries go at the bottom, after all existing entries. The instructions say "add an entry" but don't specify where — the right mental model is a log, not a list. With release markers interspersed, order determines which release an entry belongs to; an entry after the last marker is [Unreleased]. Prepending breaks that invariant. Always append.
 # 22:58
+# Cursor restore fix
 
-Phase 1 of prompt #277 (cursor-restore). Fix was already in the working tree when I started.
+`AppLayout.exit()` hides the cursor on entry via `hideCursor` but never restored it. After quitting the CLI, the cursor stayed invisible in the terminal until the user ran `printf '\e[?25h'` manually.
 
-The problem: `AppLayout.exit()` calls `exitAltBuffer()` but never wrote `showCursor` (`\e[?25h`) before leaving. The cursor is hidden on entry with `hideCursor` (`\e[?25l`) but nothing restored it.
+Fix: one line in `exit()`, `this.#screen.write(showCursor)` placed immediately before `exitAltBuffer()`. Both are cleanup operations and belong together.
 
-The fix (already applied): import `showCursor` from `@shellicar/claude-core/ansi` and write it in `exit()` immediately before `exitAltBuffer()`. One line, right next to the alt-buffer exit — the natural place since both are cleanup operations.
-
-`showCursor` and `hideCursor` were already defined in `packages/claude-core/src/ansi.ts`. No new constants needed.
-
-Build and type-check both pass. File staged: `apps/claude-sdk-cli/src/AppLayout.ts`.
-
-Proposed commit: `Restore cursor on exit`
+`showCursor` was already exported from `@shellicar/claude-core/ansi` alongside `hideCursor`. No new primitives needed, just an import addition.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -12,3 +12,4 @@
 {"description":"Display server tool use as its own block in the conversation","category":"added"}
 {"description":"Default `compact.enabled` to `false`","category":"fixed"}
 {"description":"Preserve editor content when starting a new conversation","category":"fixed"}
+{"description":"Restore cursor visibility after exiting the CLI","category":"fixed","metadata":{"issue":277}}

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -1,6 +1,6 @@
 import { stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { clearDown, clearLine, cursorAt, hideCursor, syncEnd, syncStart } from '@shellicar/claude-core/ansi';
+import { clearDown, clearLine, cursorAt, hideCursor, showCursor, syncEnd, syncStart } from '@shellicar/claude-core/ansi';
 import type { KeyAction } from '@shellicar/claude-core/input';
 import { sanitiseLoneSurrogates } from '@shellicar/claude-core/sanitise';
 import type { Screen } from '@shellicar/claude-core/screen';
@@ -99,6 +99,7 @@ export class AppLayout implements Disposable {
   public exit(): void {
     this.#cleanupResize();
     clearTimeout(this.#resizeTimer);
+    this.#screen.write(showCursor);
     this.#screen.exitAltBuffer();
   }
 


### PR DESCRIPTION
## Summary

- Cursor was hidden on CLI entry but never restored on exit, leaving the terminal without a visible cursor after quitting

## Related Issues

Fixes #277