### PR TITLE
Preserve editor content when starting a new conversation

### DIFF
--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -34,23 +34,18 @@ Task: fix #276 — compact defaults to disabled.
 One test (`returns defaults for empty object`) was asserting the old default of `enabled: true` and needed updating. Worth checking if there are tests for the corrupt-config fallback path — there weren't.
 # 22:59
 
-## Issue #271 — editor clears after Claude responds
+## Issue #271 — editor clears when starting a new session
 
-The bug: editor content typed while Claude was responding got wiped when the response completed.
+**The bug:** pressing `n` to start a new conversation wiped editor content. If the user had typed something, it was gone.
 
-**Root cause:** `editorState.reset()` was called in two wrong places:
-- `completeStreaming()` — called when the agent finishes a turn
-- `waitForInput()` — called to return to the editor for the next turn
+**Root cause:** `#clearConversation()` called `this.#editorState.reset()`. That method creates a new `ConversationState` — there's no reason for it to also reset the editor.
 
-Both of these run *after* the response is done, which means any text typed during the response was gone by the time the editor became active again.
+**Fix:** removed `this.#editorState.reset()` from `#clearConversation()`. One line deleted from `AppLayout.ts`.
 
-**Fix:** moved `editorState.reset()` to the ctrl+enter submit handler, right before `resolveInput()` is called. The editor clears at the moment of submission, not at the moment of response completion. This way, text typed while waiting for a response persists into the next turn.
+**What was not changed:** `editorState.reset()` still lives in `completeStreaming()` and `waitForInput()`. Those are correct — editor clears after the user submits (ctrl+enter resolves the input promise, then `waitForInput()` is called for the next turn). The cleared-on-respond behaviour is intentional, not a bug.
 
-**One file changed:** `apps/claude-sdk-cli/src/AppLayout.ts`
-- Removed `this.#editorState.reset()` from `completeStreaming()`
-- Removed `this.#editorState.reset()` from `waitForInput()`
-- Added `this.#editorState.reset()` in the ctrl+enter handler before `resolveInput()`
+**The testament written during Phase 1 described a broader fix** (moving reset to the ctrl+enter handler) that the supervisor narrowed before committing. The commit message and diff are the ground truth.
 
-`#clearConversation()` retains its `editorState.reset()` — that's correct, new session creation should clear the editor.
+# 23:14
 
-Build and type-check both pass.
+Phase 2 — shipped.

--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -49,3 +49,5 @@ One test (`returns defaults for empty object`) was asserting the old default of 
 # 23:14
 
 Phase 2 — shipped.
+
+**`changes.jsonl` is append-only.** New entries go at the bottom, after all existing entries. The instructions say "add an entry" but don't specify where — the right mental model is a log, not a list. With release markers interspersed, order determines which release an entry belongs to; an entry after the last marker is [Unreleased]. Prepending breaks that invariant. Always append.

--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -32,3 +32,25 @@ Task: fix #276 — compact defaults to disabled.
 ## Test
 
 One test (`returns defaults for empty object`) was asserting the old default of `enabled: true` and needed updating. Worth checking if there are tests for the corrupt-config fallback path — there weren't.
+# 22:59
+
+## Issue #271 — editor clears after Claude responds
+
+The bug: editor content typed while Claude was responding got wiped when the response completed.
+
+**Root cause:** `editorState.reset()` was called in two wrong places:
+- `completeStreaming()` — called when the agent finishes a turn
+- `waitForInput()` — called to return to the editor for the next turn
+
+Both of these run *after* the response is done, which means any text typed during the response was gone by the time the editor became active again.
+
+**Fix:** moved `editorState.reset()` to the ctrl+enter submit handler, right before `resolveInput()` is called. The editor clears at the moment of submission, not at the moment of response completion. This way, text typed while waiting for a response persists into the next turn.
+
+**One file changed:** `apps/claude-sdk-cli/src/AppLayout.ts`
+- Removed `this.#editorState.reset()` from `completeStreaming()`
+- Removed `this.#editorState.reset()` from `waitForInput()`
+- Added `this.#editorState.reset()` in the ctrl+enter handler before `resolveInput()`
+
+`#clearConversation()` retains its `editorState.reset()` — that's correct, new session creation should clear the editor.
+
+Build and type-check both pass.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -1,3 +1,4 @@
+{"description":"Preserve editor content when starting a new conversation","category":"fixed"}
 {"description":"Add `typescript` as a production dependency so consumers do not need it installed separately","category":"fixed"}
 {"description":"Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns","category":"fixed"}
 {"description":"Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)","category":"fixed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -1,4 +1,3 @@
-{"description":"Preserve editor content when starting a new conversation","category":"fixed"}
 {"description":"Add `typescript` as a production dependency so consumers do not need it installed separately","category":"fixed"}
 {"description":"Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns","category":"fixed"}
 {"description":"Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)","category":"fixed"}
@@ -12,3 +11,4 @@
 {"description":"Add web search and web fetch as built-in server tools","category":"added"}
 {"description":"Display server tool use as its own block in the conversation","category":"added"}
 {"description":"Default `compact.enabled` to `false`","category":"fixed"}
+{"description":"Preserve editor content when starting a new conversation","category":"fixed"}

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -460,6 +460,5 @@ export class AppLayout implements Disposable {
 
   #clearConversation(): void {
     this.#conversationState = new ConversationState();
-    this.#editorState.reset();
   }
 }


### PR DESCRIPTION
## Summary

- Remove `editorState.reset()` from `#clearConversation()` — pressing `n` to start a new session no longer wipes editor content

Fixes #271