### PR TITLE
Fix Find tool to follow symlinks

### DIFF
--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -87,3 +87,20 @@ Fix: one line in `exit()`, `this.#screen.write(showCursor)` placed immediately b
 **Commit message for supervisor**: `Add failing tests for symlink discovery in Find tool`
 
 **Mistake to avoid**: I added `as { type: 'files'; values: string[] }` casts throughout the tests, preemptively assuming the union type would be a problem. It wasn't — the types flow through `call()` correctly. Stephen removed them. The rule: write the code, run `TsDiagnostics`, cast only if the compiler actually complains. Never cast on suspicion.
+
+
+# 02:20
+
+## Phase 2: Builder — symlink implementation
+
+**What I changed**: `NodeFileSystem.ts` only. Added `realpath` import, added `visited: Set<string>` parameter with default, added cycle detection at start of `walk`, added `else if (entry.isSymbolicLink())` block that `stat`s the target and handles it as file or directory accordingly. Threaded `visited` through all recursive calls.
+
+**Visited set behaviour**: `realpath` is called on `dir` at the start of each `walk` invocation. If the resolved path is already in `visited`, return immediately. Otherwise add it. This means: when `dir-link` (symlink to `real-dir`) is traversed first (alphabetically), `real-dir`'s real path gets added to `visited`. When `real-dir` is processed next, its real path is already there — it returns empty. Result: `dir-link/inner.txt` appears, `real-dir/inner.txt` does not. The tests assert by symlinked path so this is fine.
+
+**Circular symlink**: `circle` points back to `fixturePath`. When processing it as a symlink-to-directory, we recurse into `walk(circle_path)`. At that start, `realpath(circle_path)` resolves to the fixture root, which is already in `visited`. Returns immediately. No loop.
+
+**ci:fix side-effects**: Running `pnpm ci:fix` to fix the Phase 1 formatting error in `find-symlinks.spec.ts` also touched three other files: `reflow.ts` (reverted the `new RegExp(...)` lint workaround back to a literal, re-triggering the lint error), `Find.ts` and `Find.spec.ts` (removed `\` from `'\.ts$'` patterns). I restored `reflow.ts` manually. `Find.ts` and `Find.spec.ts` changes are legitimate biome safe-fixes and were staged.
+
+**All 248 tests pass. CI passes.**
+
+**Commit message for supervisor**: `Implement symlink following with cycle detection in Find tool`

--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -59,3 +59,31 @@ Phase 2 — shipped.
 Fix: one line in `exit()`, `this.#screen.write(showCursor)` placed immediately before `exitAltBuffer()`. Both are cleanup operations and belong together.
 
 `showCursor` was already exported from `@shellicar/claude-core/ansi` alongside `hideCursor`. No new primitives needed, just an import addition.
+# 23:19
+
+## Phase 1: Scaffolder — find-symlinks tests
+
+**Task**: Fix #244. The `walk` function in `NodeFileSystem.ts` silently drops symlinks because `Dirent.isFile()` and `Dirent.isDirectory()` both return false for symlinks.
+
+**Fixture design**: Created a temp directory in `beforeAll` using `node:fs/promises`. The fixture contains:
+- `real-file.txt` — a regular file
+- `file-link.txt` — symlink to `real-file.txt` (absolute path)
+- `real-dir/inner.txt` — a real directory with one file
+- `dir-link` — symlink to `real-dir` (absolute path)
+- `other-dir/other.txt` — a second real directory, for the exclude test
+- `other-link` — symlink to `other-dir` (absolute path)
+- `circle` — symlink to `fixturePath` itself (circular)
+
+**Why absolute symlink targets**: Relative symlinks require careful relative path calculation that varies by fixture layout. Absolute paths are simpler and unambiguous.
+
+**Key insight about the visited-set design**: The phase 2 instructions say to track visited real paths to prevent infinite loops. A side-effect: if a symlinked directory is traversed BEFORE the real directory (alphabetically `dir-link` < `real-dir`), the real directory's path is added to `visited` when the symlink is followed. Then the real directory itself gets skipped. This is fine — it means `dir-link/inner.txt` appears in results instead of `real-dir/inner.txt`. Tests assert the symlinked path, not the real path.
+
+**Test results** (phase 1 — current code, symlinks skipped):
+- 5 tests FAIL as expected (1, 2, 4, 5, 6 — all require symlinks to be followed)
+- 1 test PASSES vacuously (test 3: no infinite loop, because current code can't loop on something it skips)
+- 243 existing tests still pass
+- Type-check clean
+
+**Commit message for supervisor**: `Add failing tests for symlink discovery in Find tool`
+
+**Mistake to avoid**: I added `as { type: 'files'; values: string[] }` casts throughout the tests, preemptively assuming the union type would be a problem. It wasn't — the types flow through `call()` correctly. Stephen removed them. The rule: write the code, run `TsDiagnostics`, cast only if the compiler actually complains. Never cast on suspicion.

--- a/.claude/testament/2026-04-19.md
+++ b/.claude/testament/2026-04-19.md
@@ -104,3 +104,30 @@ Fix: one line in `exit()`, `this.#screen.write(showCursor)` placed immediately b
 **All 248 tests pass. CI passes.**
 
 **Commit message for supervisor**: `Implement symlink following with cycle detection in Find tool`
+
+# 03:28
+
+## Phase 2 amendment: followSymlinks option + discussion of the broader problem space
+
+**Amendment**: Before shipping, added `followSymlinks` to `FindOptions` (default `true`). When `false`, symlink entries are still returned (stat'd to determine file vs directory), but directory symlinks are not recursed into. The gate is on the `walk` call inside the directory branch only, not on the whole symlink block. A previous version gated the entire symlink block, making symlinks invisible — that was wrong. Changes: `IFileSystem.ts` (interface), `NodeFileSystem.ts` (destructure + gate), `schema.ts` (Zod field), `Find.ts` (pass-through), `find-symlinks.spec.ts` (new test). 249/249 tests pass, CI clean.
+
+**Commit message for supervisor**: `Add followSymlinks option to Find tool (default true)`
+
+## The broader problem space — for future operators
+
+During phase 2, a longer discussion identified gaps in the Find tool that go beyond this PR. Captured here so the next operator doesn't have to rediscover it.
+
+**Find output carries no per-path metadata.** The pipe contract is `{ type: 'files', values: string[] }` — plain path strings. When a path is a symlink, nothing in the output says so. This matters because:
+
+- `EditFile` and `ReadFile` work through symlinks transparently — fine for content access.
+- `CreateFile` at a symlinked path produces a real file, silently discarding the symlink relationship.
+- Retargeting a symlink (changing what it points to) requires `Exec` with `ln -sf`, not the file tools. Without knowing a path is a symlink, there is no signal to reach for `Exec`.
+- With `type: 'both'`, directories and files are mixed in `values` with no annotation — you cannot tell them apart from the path alone.
+
+**Two independent options are needed, not one.** The correct mental model:
+- `followSymlinks` (traversal): do we enter symlinked directories? (done in this PR)
+- `returnSymlinks` (filter): do we include symlink entries in results, and mark them as such?
+
+`symlink` is not a peer of `file`/`directory`. It is metadata about how a path was reached, not what kind of thing it is. Mixing `symlink` into the `type` enum would conflate two orthogonal axes.
+
+**Why `returnSymlinks` can't be done yet.** The pipe schema is `string[]` — there is nowhere to attach per-path metadata. Exposing symlink status in the output requires a schema change. All downstream consumers (Grep, SearchFiles, DeleteFile, DeleteDirectory) take `PipeFiles` and iterate `values` directly, so any change to the element type is a breaking change. The fix requires either adding optional parallel fields to the result object, or a richer per-entry format with a versioned schema. That work is not in this PR.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -23,3 +23,16 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 ## mcp-exec cli.spec.ts PATH issue
 
 `test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
+# 03:36
+
+## find-symlinks: symlink following with cycle detection
+
+**The traversal ordering surprise.** `visited` is keyed on `realpath`, not the path passed to `walk`. When `dir-link` (a symlink to `real-dir`) is alphabetically sorted before `real-dir`, following the symlink resolves to `real-dir`'s real path and adds it to `visited`. When `real-dir` is reached directly, it's already visited and returns empty. Result: `dir-link/inner.txt` appears in results; `real-dir/inner.txt` does not. The tests assert by the symlinked path, so this is correct behaviour, not a bug.
+
+**`followSymlinks: false` only gates directory recursion.** The option controls whether symlinked directories are entered, not whether symlinks appear in results at all. Symlinked files are always returned. A previous version gated the entire symlink block, making symlinks invisible when `followSymlinks: false`. The correct boundary: only the `walk()` call inside the directory branch is conditional.
+
+**`ci:fix` has a reach problem.** Running `pnpm ci:fix` to fix formatting in `find-symlinks.spec.ts` also modified `reflow.ts` (reverted a `new RegExp(...)` lint workaround back to a literal, which re-triggers a lint error). That change has to be manually restored after every `ci:fix` run. `Find.ts` and `Find.spec.ts` changes (removing unnecessary `\\` in `'\\.ts$'` patterns) are legitimate and safe to stage.
+
+**Don't cast on suspicion.** Phase 1 added `as { type: 'files'; values: string[] }` casts throughout the tests before checking whether the compiler actually needed them. It didn't. The types flow correctly through `call()`. Rule: write the code, run TsDiagnostics, cast only when the compiler complains.
+
+**The output metadata gap is a separate problem.** This PR adds symlink traversal. It does not (and cannot without a breaking schema change) expose whether a returned path is a symlink. The `{ type: 'files', values: string[] }` pipe format carries no per-path metadata. `returnSymlinks` as a filter, or type-annotation on entries, requires changing the element type in `values` -- a breaking change that touches every downstream consumer (Grep, SearchFiles, DeleteFile, DeleteDirectory). That work is not here.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -36,3 +36,20 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 **Don't cast on suspicion.** Phase 1 added `as { type: 'files'; values: string[] }` casts throughout the tests before checking whether the compiler actually needed them. It didn't. The types flow correctly through `call()`. Rule: write the code, run TsDiagnostics, cast only when the compiler complains.
 
 **The output metadata gap is a separate problem.** This PR adds symlink traversal. It does not (and cannot without a breaking schema change) expose whether a returned path is a symlink. The `{ type: 'files', values: string[] }` pipe format carries no per-path metadata. `returnSymlinks` as a filter, or type-annotation on entries, requires changing the element type in `values` -- a breaking change that touches every downstream consumer (Grep, SearchFiles, DeleteFile, DeleteDirectory). That work is not here.
+
+
+# 04:00
+
+## Phase 3: IFileSystem abstraction refactor
+
+**The circular import non-problem.** `IFileSystem.ts` imports from `walk.ts`, and `walk.ts` imports types from `IFileSystem.ts`. This looks like a circular dependency but isn't at runtime. `walk.ts` uses `import type { ... }` — type-only imports are erased at compile time. The runtime module graph has no cycle. This is a well-known TypeScript pattern. Don't avoid it by duplicating type definitions.
+
+**`find` moved from abstract to concrete on `IFileSystem`.** Both `NodeFileSystem` and `MemoryFileSystem` had identical one-liner `find` methods calling `walk`. Making it concrete on the base class removes that duplication. Subclasses now only implement the primitives: `readdir`, `realpath`, `stat`.
+
+**`MemoryFileSystem.readdir` derives directory contents from the flat file Map.** Directories are implicit — a file at `/a/b/c` implies `/a/b` is a directory. `readdir('/a')` scans the Map, takes the first path component under `/a/`, and classifies it as file (1 component) or directory (multiple). Nothing is a symlink in MemoryFS, so `isSymbolicLink` always returns false.
+
+**`ci:fix` reverts `reflow.ts` — restore it manually.** Every time `pnpm ci:fix` runs, biome converts `new RegExp('...', 'g')` back to a literal, which re-triggers the `noControlCharactersInRegex` lint error. The revert is a one-liner. This is a pre-existing pattern documented by the previous operator — do not stage `reflow.ts` unless you need to; restore it before committing.
+
+**Mock design: alphabetical readdir ordering matters.** `walk` uses `realpath` for cycle detection: the first call to walk a path adds its realpath to `visited`. If `dir-link` (→ `real-dir`) is processed before `real-dir` in readdir order, then `dir-link/inner.txt` appears in results and `real-dir` returns empty (already visited). If the order were reversed, `real-dir/inner.txt` would appear and `dir-link` would return empty. Tests assert by the symlink path, so the mock must return entries in alphabetical order to make the assertions correct. This is intentional and documented in the mock's JSDoc comment.
+
+**`stat` in MemoryFS: always `isFile: true`.** Directories are implicit and have no stat entry in the Map. `stat('/src')` would throw ENOENT. That's acceptable because `walk` only calls `stat` on symlink entries, and MemoryFS has no symlinks. No test exercises `stat` on a MemoryFS directory.

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -11,3 +11,4 @@
 {"description":"Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry","category":"added"}
 {"description":"Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem","category":"added"}
 {"description":"Add TypeScript language tools: ts_diagnostics, ts_hover, ts_references, ts_definition","category":"added"}
+{"description":"Find tool follows symlinks with cycle detection","category":"fixed"}

--- a/packages/claude-sdk-tools/src/Find/Find.ts
+++ b/packages/claude-sdk-tools/src/Find/Find.ts
@@ -21,6 +21,7 @@ export function createFind(fs: IFileSystem) {
           type: input.type,
           exclude: input.exclude,
           maxDepth: input.maxDepth,
+          followSymlinks: input.followSymlinks,
         });
       } catch (err) {
         if (isNodeError(err, 'ENOENT')) {

--- a/packages/claude-sdk-tools/src/Find/Find.ts
+++ b/packages/claude-sdk-tools/src/Find/Find.ts
@@ -11,7 +11,7 @@ export function createFind(fs: IFileSystem) {
     name: 'Find',
     description: 'Find files or directories. Excludes node_modules, dist and .git by default. Output can be piped into Grep.',
     input_schema: FindInputSchema,
-    input_examples: [{ path: '.' }, { path: './src', pattern: '\.ts$' }, { path: '.', type: 'directory' }, { path: '.', pattern: '\.(ts|js)$' }],
+    input_examples: [{ path: '.' }, { path: './src', pattern: '.ts$' }, { path: '.', type: 'directory' }, { path: '.', pattern: '.(ts|js)$' }],
     handler: async (input) => {
       const dir = expandPath(input.path, fs);
       let paths: string[];

--- a/packages/claude-sdk-tools/src/Find/schema.ts
+++ b/packages/claude-sdk-tools/src/Find/schema.ts
@@ -17,4 +17,5 @@ export const FindInputSchema = z.object({
   type: z.enum(['file', 'directory', 'both']).default('file').describe('Whether to find files, directories, or both'),
   exclude: z.array(z.string()).default(['dist', 'node_modules', '.git']).describe('Directory names to exclude from search'),
   maxDepth: z.number().int().min(1).optional().describe('Maximum directory depth to search'),
+  followSymlinks: z.boolean().default(true).describe('When true (default), recurses into directories that are symlinks, discovering files within them. When false, symlinked directories appear in results but are not entered. Symlinked files are always returned regardless of this setting.'),
 });

--- a/packages/claude-sdk-tools/src/entry/fs.ts
+++ b/packages/claude-sdk-tools/src/entry/fs.ts
@@ -1,7 +1,7 @@
-import type { FindOptions, IFileSystem, StatResult } from '../fs/IFileSystem.js';
+import type { FindOptions, IFileEntry, IFileSystem, StatResult } from '../fs/IFileSystem.js';
 import { MemoryFileSystem } from '../fs/MemoryFileSystem.js';
 import { NodeFileSystem } from '../fs/NodeFileSystem.js';
 import { nodeFs } from '../fs/nodeFs.js';
 
-export type { FindOptions, IFileSystem, StatResult };
+export type { FindOptions, IFileEntry, IFileSystem, StatResult };
 export { MemoryFileSystem, NodeFileSystem, nodeFs };

--- a/packages/claude-sdk-tools/src/fs/IFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/IFileSystem.ts
@@ -1,3 +1,12 @@
+import { walk } from './walk';
+
+export interface IFileEntry {
+  name: string;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
 export interface FindOptions {
   pattern?: string;
   type?: 'file' | 'directory' | 'both';
@@ -8,6 +17,8 @@ export interface FindOptions {
 
 export interface StatResult {
   size: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
 }
 
 export abstract class IFileSystem {
@@ -18,7 +29,12 @@ export abstract class IFileSystem {
   public abstract writeFile(path: string, content: string): Promise<void>;
   public abstract deleteFile(path: string): Promise<void>;
   public abstract deleteDirectory(path: string): Promise<void>;
-  public abstract find(path: string, options?: FindOptions): Promise<string[]>;
+  public async find(path: string, options?: FindOptions): Promise<string[]> {
+    const re = options?.pattern ? new RegExp(options.pattern) : undefined;
+    return walk(this, path, options ?? {}, 1, re);
+  }
   public abstract appendFile(path: string, content: string): Promise<void>;
   public abstract stat(path: string): Promise<StatResult>;
+  public abstract readdir(path: string): Promise<IFileEntry[]>;
+  public abstract realpath(path: string): Promise<string>;
 }

--- a/packages/claude-sdk-tools/src/fs/IFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/IFileSystem.ts
@@ -3,6 +3,7 @@ export interface FindOptions {
   type?: 'file' | 'directory' | 'both';
   exclude?: string[];
   maxDepth?: number;
+  followSymlinks?: boolean;
 }
 
 export interface StatResult {

--- a/packages/claude-sdk-tools/src/fs/MemoryFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/MemoryFileSystem.ts
@@ -1,4 +1,4 @@
-import { type FindOptions, IFileSystem, type StatResult } from './IFileSystem';
+import { type IFileEntry, IFileSystem, type StatResult } from './IFileSystem';
 
 /**
  * In-memory filesystem implementation for testing.
@@ -82,7 +82,11 @@ export class MemoryFileSystem extends IFileSystem {
       err.code = 'ENOENT';
       throw err;
     }
-    return { size: content.length };
+    return {
+      size: content.length,
+      isFile: () => true,
+      isDirectory: () => false,
+    };
   }
 
   public async appendFile(path: string, content: string): Promise<void> {
@@ -90,70 +94,37 @@ export class MemoryFileSystem extends IFileSystem {
     this.files.set(path, existing + content);
   }
 
-  public async find(path: string, options?: FindOptions): Promise<string[]> {
+  public async readdir(path: string): Promise<IFileEntry[]> {
     const prefix = path.endsWith('/') ? path : `${path}/`;
-    const type = options?.type ?? 'file';
-    const exclude = options?.exclude ?? [];
-    const maxDepth = options?.maxDepth;
-    const pattern = options?.pattern;
-
-    // Check that the directory exists (at least one file lives under it).
-    // Empty directories cannot be represented in MemoryFileSystem.
-    const dirExists = [...this.files.keys()].some((p) => p.startsWith(prefix));
-    if (!dirExists) {
+    const exists = [...this.files.keys()].some((p) => p.startsWith(prefix));
+    if (!exists) {
       const err = new Error(`ENOENT: no such file or directory, scandir '${path}'`) as NodeJS.ErrnoException;
       err.code = 'ENOENT';
       throw err;
     }
-
-    const re = pattern ? new RegExp(pattern) : undefined;
-    const results: string[] = [];
-    const dirs = new Set<string>();
-
+    const children = new Map<string, 'file' | 'directory'>();
     for (const filePath of this.files.keys()) {
       if (!filePath.startsWith(prefix)) {
         continue;
       }
-
       const relative = filePath.slice(prefix.length);
       const parts = relative.split('/');
-
-      if (maxDepth !== undefined && parts.length > maxDepth) {
-        continue;
-      }
-      if (parts.some((p) => exclude.includes(p))) {
-        continue;
-      }
-
-      if (type === 'directory' || type === 'both') {
-        for (let i = 1; i < parts.length; i++) {
-          const dirPath = prefix + parts.slice(0, i).join('/');
-          if (!dirs.has(dirPath)) {
-            const dirName = parts[i - 1];
-            if (!exclude.includes(dirName) && (maxDepth === undefined || i <= maxDepth)) {
-              dirs.add(dirPath);
-            }
-          }
-        }
-      }
-
-      if (type === 'file' || type === 'both') {
-        const fileName = parts[parts.length - 1];
-        if (!re || re.test(fileName)) {
-          results.push(filePath);
-        }
+      const first = parts[0];
+      if (parts.length === 1) {
+        children.set(first, 'file');
+      } else if (!children.has(first)) {
+        children.set(first, 'directory');
       }
     }
+    return [...children.entries()].map(([name, kind]) => ({
+      name,
+      isFile: () => kind === 'file',
+      isDirectory: () => kind === 'directory',
+      isSymbolicLink: () => false,
+    }));
+  }
 
-    if (type === 'directory' || type === 'both') {
-      for (const dir of dirs) {
-        const dirName = dir.split('/').pop() ?? '';
-        if (!re || re.test(dirName)) {
-          results.push(dir);
-        }
-      }
-    }
-
-    return results.sort();
+  public async realpath(path: string): Promise<string> {
+    return path;
   }
 }

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -54,7 +54,7 @@ export class NodeFileSystem extends IFileSystem {
 }
 
 async function walk(dir: string, options: FindOptions, depth: number, re: RegExp | undefined, visited: Set<string> = new Set()): Promise<string[]> {
-  const { maxDepth, exclude = [], type = 'file' } = options;
+  const { maxDepth, exclude = [], type = 'file', followSymlinks = true } = options;
 
   if (maxDepth !== undefined && depth > maxDepth) {
     return [];
@@ -103,7 +103,9 @@ async function walk(dir: string, options: FindOptions, depth: number, re: RegExp
             results.push(fullPath);
           }
         }
-        results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
+        if (followSymlinks) {
+          results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
+        }
       } else if (targetStat.isFile()) {
         if (type === 'file' || type === 'both') {
           if (!re || re.test(entry.name)) {

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, readdir, readFile, rm, rmdir, stat, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readdir, readFile, realpath, rm, rmdir, stat, writeFile } from 'node:fs/promises';
 import { homedir as osHomedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { type FindOptions, IFileSystem, type StatResult } from './IFileSystem';
@@ -53,12 +53,18 @@ export class NodeFileSystem extends IFileSystem {
   }
 }
 
-async function walk(dir: string, options: FindOptions, depth: number, re: RegExp | undefined): Promise<string[]> {
+async function walk(dir: string, options: FindOptions, depth: number, re: RegExp | undefined, visited: Set<string> = new Set()): Promise<string[]> {
   const { maxDepth, exclude = [], type = 'file' } = options;
 
   if (maxDepth !== undefined && depth > maxDepth) {
     return [];
   }
+
+  const realDir = await realpath(dir);
+  if (visited.has(realDir)) {
+    return [];
+  }
+  visited.add(realDir);
 
   const results: string[] = [];
   const entries = await readdir(dir, { withFileTypes: true });
@@ -76,11 +82,33 @@ async function walk(dir: string, options: FindOptions, depth: number, re: RegExp
           results.push(fullPath);
         }
       }
-      results.push(...(await walk(fullPath, options, depth + 1, re)));
+      results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
     } else if (entry.isFile()) {
       if (type === 'file' || type === 'both') {
         if (!re || re.test(entry.name)) {
           results.push(fullPath);
+        }
+      }
+    } else if (entry.isSymbolicLink()) {
+      let targetStat: Awaited<ReturnType<typeof stat>>;
+      try {
+        targetStat = await stat(fullPath);
+      } catch {
+        // Broken symlink — skip
+        continue;
+      }
+      if (targetStat.isDirectory()) {
+        if (type === 'directory' || type === 'both') {
+          if (!re || re.test(entry.name)) {
+            results.push(fullPath);
+          }
+        }
+        results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
+      } else if (targetStat.isFile()) {
+        if (type === 'file' || type === 'both') {
+          if (!re || re.test(entry.name)) {
+            results.push(fullPath);
+          }
         }
       }
     }

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, readdir, readFile, realpath, rm, rmdir, stat, writeFile } from 'node:fs/promises';
+import { appendFile, readdir as fsReaddir, realpath as fsRealpath, stat as fsStat, mkdir, readFile, rm, rmdir, writeFile } from 'node:fs/promises';
 import { homedir as osHomedir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { type FindOptions, IFileSystem, type StatResult } from './IFileSystem';
+import { dirname } from 'node:path';
+import { type IFileEntry, IFileSystem, type StatResult } from './IFileSystem';
 
 /**
  * Production filesystem implementation using Node.js fs APIs.
@@ -42,79 +42,26 @@ export class NodeFileSystem extends IFileSystem {
     await appendFile(path, content, 'utf-8');
   }
 
-  public async find(path: string, options?: FindOptions): Promise<string[]> {
-    const re = options?.pattern ? new RegExp(options.pattern) : undefined;
-    return walk(path, options ?? {}, 1, re);
-  }
-
   public async stat(path: string): Promise<StatResult> {
-    const s = await stat(path);
-    return { size: s.size };
-  }
-}
-
-async function walk(dir: string, options: FindOptions, depth: number, re: RegExp | undefined, visited: Set<string> = new Set()): Promise<string[]> {
-  const { maxDepth, exclude = [], type = 'file', followSymlinks = true } = options;
-
-  if (maxDepth !== undefined && depth > maxDepth) {
-    return [];
+    const s = await fsStat(path);
+    return {
+      size: s.size,
+      isFile: () => s.isFile(),
+      isDirectory: () => s.isDirectory(),
+    };
   }
 
-  const realDir = await realpath(dir);
-  if (visited.has(realDir)) {
-    return [];
-  }
-  visited.add(realDir);
-
-  const results: string[] = [];
-  const entries = await readdir(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (exclude.includes(entry.name)) {
-      continue;
-    }
-
-    const fullPath = join(dir, entry.name);
-
-    if (entry.isDirectory()) {
-      if (type === 'directory' || type === 'both') {
-        if (!re || re.test(entry.name)) {
-          results.push(fullPath);
-        }
-      }
-      results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
-    } else if (entry.isFile()) {
-      if (type === 'file' || type === 'both') {
-        if (!re || re.test(entry.name)) {
-          results.push(fullPath);
-        }
-      }
-    } else if (entry.isSymbolicLink()) {
-      let targetStat: Awaited<ReturnType<typeof stat>>;
-      try {
-        targetStat = await stat(fullPath);
-      } catch {
-        // Broken symlink — skip
-        continue;
-      }
-      if (targetStat.isDirectory()) {
-        if (type === 'directory' || type === 'both') {
-          if (!re || re.test(entry.name)) {
-            results.push(fullPath);
-          }
-        }
-        if (followSymlinks) {
-          results.push(...(await walk(fullPath, options, depth + 1, re, visited)));
-        }
-      } else if (targetStat.isFile()) {
-        if (type === 'file' || type === 'both') {
-          if (!re || re.test(entry.name)) {
-            results.push(fullPath);
-          }
-        }
-      }
-    }
+  public async readdir(path: string): Promise<IFileEntry[]> {
+    const entries = await fsReaddir(path, { withFileTypes: true });
+    return entries.map((entry) => ({
+      name: entry.name,
+      isFile: () => entry.isFile(),
+      isDirectory: () => entry.isDirectory(),
+      isSymbolicLink: () => entry.isSymbolicLink(),
+    }));
   }
 
-  return results;
+  public async realpath(path: string): Promise<string> {
+    return fsRealpath(path);
+  }
 }

--- a/packages/claude-sdk-tools/src/fs/walk.ts
+++ b/packages/claude-sdk-tools/src/fs/walk.ts
@@ -1,0 +1,74 @@
+import { join } from 'node:path';
+import type { FindOptions, IFileEntry, StatResult } from './IFileSystem';
+
+interface WalkFs {
+  readdir(path: string): Promise<IFileEntry[]>;
+  realpath(path: string): Promise<string>;
+  stat(path: string): Promise<StatResult>;
+}
+
+export async function walk(fs: WalkFs, dir: string, options: FindOptions, depth: number, re: RegExp | undefined, visited: Set<string> = new Set()): Promise<string[]> {
+  const { maxDepth, exclude = [], type = 'file', followSymlinks = true } = options;
+
+  if (maxDepth !== undefined && depth > maxDepth) {
+    return [];
+  }
+
+  const realDir = await fs.realpath(dir);
+  if (visited.has(realDir)) {
+    return [];
+  }
+  visited.add(realDir);
+
+  const results: string[] = [];
+  const entries = await fs.readdir(dir);
+
+  for (const entry of entries) {
+    if (exclude.includes(entry.name)) {
+      continue;
+    }
+
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (type === 'directory' || type === 'both') {
+        if (!re || re.test(entry.name)) {
+          results.push(fullPath);
+        }
+      }
+      results.push(...(await walk(fs, fullPath, options, depth + 1, re, visited)));
+    } else if (entry.isFile()) {
+      if (type === 'file' || type === 'both') {
+        if (!re || re.test(entry.name)) {
+          results.push(fullPath);
+        }
+      }
+    } else if (entry.isSymbolicLink()) {
+      let targetStat: StatResult;
+      try {
+        targetStat = await fs.stat(fullPath);
+      } catch {
+        // Broken symlink — skip
+        continue;
+      }
+      if (targetStat.isDirectory()) {
+        if (type === 'directory' || type === 'both') {
+          if (!re || re.test(entry.name)) {
+            results.push(fullPath);
+          }
+        }
+        if (followSymlinks) {
+          results.push(...(await walk(fs, fullPath, options, depth + 1, re, visited)));
+        }
+      } else if (targetStat.isFile()) {
+        if (type === 'file' || type === 'both') {
+          if (!re || re.test(entry.name)) {
+            results.push(fullPath);
+          }
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/packages/claude-sdk-tools/test/Find.spec.ts
+++ b/packages/claude-sdk-tools/test/Find.spec.ts
@@ -25,7 +25,7 @@ describe('createFind u2014 file results', () => {
 
   it('filters by regex pattern', async () => {
     const Find = createFind(makeFs());
-    const result = await call(Find, { path: '/src', pattern: '\.ts$' });
+    const result = await call(Find, { path: '/src', pattern: '.ts$' });
     const { values } = result as { type: 'files'; values: string[] };
     expect(values).toContain('/src/index.ts');
     expect(values).toContain('/src/utils.ts');
@@ -73,7 +73,7 @@ describe('createFind u2014 file results', () => {
 
   it('regex pattern matches files in subdirectories', async () => {
     const Find = createFind(makeFs());
-    const result = await call(Find, { path: '/', pattern: '\.ts$' });
+    const result = await call(Find, { path: '/', pattern: '.ts$' });
     const { values } = result as { type: 'files'; values: string[] };
     expect(values).toContain('/src/index.ts');
     expect(values).toContain('/src/utils.ts');

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -1,94 +1,183 @@
-import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createFind } from '../src/Find/Find';
-import { NodeFileSystem } from '../src/fs/NodeFileSystem';
+import { type IFileEntry, IFileSystem, type StatResult } from '../src/fs/IFileSystem';
 import { call } from './helpers';
 
-let fixturePath: string;
+/**
+ * Mock filesystem representing this structure:
+ *
+ *   /fixture/
+ *     circle           (symlink → /fixture)
+ *     dir-link         (symlink → /fixture/real-dir)
+ *     file-link.txt    (symlink → /fixture/real-file.txt)
+ *     other-dir/
+ *       other.txt
+ *     other-link       (symlink → /fixture/other-dir)
+ *     real-dir/
+ *       inner.txt
+ *     real-file.txt
+ *
+ * Entries in readdir use a specific order to make tests meaningful:
+ * - dir-link before real-dir: the cycle-detector marks /fixture/real-dir visited
+ *   via dir-link, so dir-link/inner.txt appears in results and real-dir returns [].
+ * - other-link before other-dir: if the exclude check were broken for symlinks,
+ *   other-link would be entered first, marking /fixture/other-dir visited, and
+ *   other-link/other.txt would appear in results. The negative assertion in the
+ *   exclude test would then catch the regression.
+ */
+const ROOT = '/fixture';
 
-beforeAll(async () => {
-  fixturePath = join(tmpdir(), `find-symlinks-${Date.now()}`);
-  await mkdir(fixturePath, { recursive: true });
+function makeFile(name: string): IFileEntry {
+  return { name, isFile: () => true, isDirectory: () => false, isSymbolicLink: () => false };
+}
 
-  // A regular file and a symlink pointing to it
-  await writeFile(join(fixturePath, 'real-file.txt'), 'real content');
-  await symlink(join(fixturePath, 'real-file.txt'), join(fixturePath, 'file-link.txt'));
+function makeDir(name: string): IFileEntry {
+  return { name, isFile: () => false, isDirectory: () => true, isSymbolicLink: () => false };
+}
 
-  // A real directory with a file, and a symlink to that directory
-  await mkdir(join(fixturePath, 'real-dir'));
-  await writeFile(join(fixturePath, 'real-dir', 'inner.txt'), 'inner content');
-  await symlink(join(fixturePath, 'real-dir'), join(fixturePath, 'dir-link'));
+function makeSymlink(name: string): IFileEntry {
+  return { name, isFile: () => false, isDirectory: () => false, isSymbolicLink: () => true };
+}
 
-  // Another directory and its symlink, for testing exclude by name
-  await mkdir(join(fixturePath, 'other-dir'));
-  await writeFile(join(fixturePath, 'other-dir', 'other.txt'), 'other content');
-  await symlink(join(fixturePath, 'other-dir'), join(fixturePath, 'other-link'));
+function fileStat(): StatResult {
+  return { size: 0, isFile: () => true, isDirectory: () => false };
+}
 
-  // A circular symlink: points back to the fixture root
-  await symlink(fixturePath, join(fixturePath, 'circle'));
-});
+function dirStat(): StatResult {
+  return { size: 0, isFile: () => false, isDirectory: () => true };
+}
 
-afterAll(async () => {
-  await rm(fixturePath, { recursive: true, force: true });
-});
+class SymlinkMockFileSystem extends IFileSystem {
+  public cwd(): string {
+    return ROOT;
+  }
+
+  public homedir(): string {
+    return '/home/user';
+  }
+
+  public async exists(): Promise<boolean> {
+    return false;
+  }
+
+  public async readFile(): Promise<string> {
+    throw new Error('not implemented');
+  }
+
+  public async writeFile(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  public async deleteFile(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  public async deleteDirectory(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  public async appendFile(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  public async stat(path: string): Promise<StatResult> {
+    const dirs = new Set([ROOT, `${ROOT}/real-dir`, `${ROOT}/dir-link`, `${ROOT}/other-dir`, `${ROOT}/other-link`, `${ROOT}/circle`]);
+    const files = new Set([`${ROOT}/real-file.txt`, `${ROOT}/file-link.txt`, `${ROOT}/real-dir/inner.txt`, `${ROOT}/dir-link/inner.txt`, `${ROOT}/other-dir/other.txt`, `${ROOT}/other-link/other.txt`]);
+    if (dirs.has(path)) {
+      return dirStat();
+    }
+    if (files.has(path)) {
+      return fileStat();
+    }
+    const err = new Error(`ENOENT: no such file or directory, stat '${path}'`) as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  }
+
+  public async readdir(path: string): Promise<IFileEntry[]> {
+    const real = await this.realpath(path);
+    if (real === ROOT) {
+      // dir-link before real-dir; other-link before other-dir — see JSDoc above
+      return [makeSymlink('circle'), makeSymlink('dir-link'), makeSymlink('file-link.txt'), makeSymlink('other-link'), makeDir('other-dir'), makeDir('real-dir'), makeFile('real-file.txt')];
+    }
+    if (real === `${ROOT}/real-dir`) {
+      return [makeFile('inner.txt')];
+    }
+    if (real === `${ROOT}/other-dir`) {
+      return [makeFile('other.txt')];
+    }
+    const err = new Error(`ENOENT: no such file or directory, scandir '${path}'`) as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  }
+
+  public async realpath(path: string): Promise<string> {
+    const symlinks = new Map<string, string>([
+      [`${ROOT}/circle`, ROOT],
+      [`${ROOT}/dir-link`, `${ROOT}/real-dir`],
+      [`${ROOT}/file-link.txt`, `${ROOT}/real-file.txt`],
+      [`${ROOT}/other-link`, `${ROOT}/other-dir`],
+    ]);
+    return symlinks.get(path) ?? path;
+  }
+}
 
 describe('createFind — symlinks', () => {
   it('discovers files that are symlinks', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath });
-    const expected = join(fixturePath, 'file-link.txt');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT });
+    const expected = join(ROOT, 'file-link.txt');
     expect(actual.values).toContain(expected);
   });
 
   it('discovers files inside symlinked directories', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath });
-    const expected = join(fixturePath, 'dir-link', 'inner.txt');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT });
+    const expected = join(ROOT, 'dir-link', 'inner.txt');
     expect(actual.values).toContain(expected);
   });
 
   it('does not loop infinitely on circular symlinks', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await Promise.race([call(Find, { path: fixturePath }), new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out after 5000ms')), 5000))]);
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT });
     const expected = 'files';
     expect(actual.type).toBe(expected);
   });
 
   it('symlinked files match pattern filters', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath, pattern: '\\.txt$' });
-    const expected = join(fixturePath, 'file-link.txt');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT, pattern: '\\.txt$' });
+    const expected = join(ROOT, 'file-link.txt');
     expect(actual.values).toContain(expected);
   });
 
   it('symlinked directories are found when type is directory', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath, type: 'directory' });
-    const expected = join(fixturePath, 'dir-link');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT, type: 'directory' });
+    const expected = join(ROOT, 'dir-link');
     expect(actual.values).toContain(expected);
   });
 
   it('does not recurse into symlinked directories when followSymlinks is false', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath, followSymlinks: false });
-    const expected = join(fixturePath, 'dir-link', 'inner.txt');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT, followSymlinks: false });
+    const expected = join(ROOT, 'dir-link', 'inner.txt');
     expect(actual.values).not.toContain(expected);
   });
 
   it('still returns symlinked files when followSymlinks is false', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath, followSymlinks: false });
-    const expected = join(fixturePath, 'file-link.txt');
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT, followSymlinks: false });
+    const expected = join(ROOT, 'file-link.txt');
     expect(actual.values).toContain(expected);
   });
 
   it('exclude list applies to symlinked directory names', async () => {
-    const Find = createFind(new NodeFileSystem());
-    const actual = await call(Find, { path: fixturePath, exclude: ['other-link'] });
-    const values = (actual as { type: 'files'; values: string[] }).values;
-    const expected = join(fixturePath, 'dir-link', 'inner.txt');
-    expect(values).toContain(expected);
+    const Find = createFind(new SymlinkMockFileSystem());
+    const actual = await call(Find, { path: ROOT, exclude: ['other-link'] });
+    const expected = join(ROOT, 'dir-link', 'inner.txt');
+    expect(actual.values).toContain(expected);
+    expect(actual.values).not.toContain(join(ROOT, 'other-link', 'other.txt'));
   });
 });

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -1,0 +1,83 @@
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createFind } from '../src/Find/Find';
+import { NodeFileSystem } from '../src/fs/NodeFileSystem';
+import { call } from './helpers';
+
+let fixturePath: string;
+
+beforeAll(async () => {
+  fixturePath = join(tmpdir(), `find-symlinks-${Date.now()}`);
+  await mkdir(fixturePath, { recursive: true });
+
+  // A regular file and a symlink pointing to it
+  await writeFile(join(fixturePath, 'real-file.txt'), 'real content');
+  await symlink(join(fixturePath, 'real-file.txt'), join(fixturePath, 'file-link.txt'));
+
+  // A real directory with a file, and a symlink to that directory
+  await mkdir(join(fixturePath, 'real-dir'));
+  await writeFile(join(fixturePath, 'real-dir', 'inner.txt'), 'inner content');
+  await symlink(join(fixturePath, 'real-dir'), join(fixturePath, 'dir-link'));
+
+  // Another directory and its symlink, for testing exclude by name
+  await mkdir(join(fixturePath, 'other-dir'));
+  await writeFile(join(fixturePath, 'other-dir', 'other.txt'), 'other content');
+  await symlink(join(fixturePath, 'other-dir'), join(fixturePath, 'other-link'));
+
+  // A circular symlink: points back to the fixture root
+  await symlink(fixturePath, join(fixturePath, 'circle'));
+});
+
+afterAll(async () => {
+  await rm(fixturePath, { recursive: true, force: true });
+});
+
+describe('createFind — symlinks', () => {
+  it('discovers files that are symlinks', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath });
+    const expected = join(fixturePath, 'file-link.txt');
+    expect(actual.values).toContain(expected);
+  });
+
+  it('discovers files inside symlinked directories', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath });
+    const expected = join(fixturePath, 'dir-link', 'inner.txt');
+    expect(actual.values).toContain(expected);
+  });
+
+  it('does not loop infinitely on circular symlinks', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await Promise.race([
+      call(Find, { path: fixturePath }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out after 5000ms')), 5000)),
+    ]);
+    const expected = 'files';
+    expect(actual.type).toBe(expected);
+  });
+
+  it('symlinked files match pattern filters', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath, pattern: '\\.txt$' });
+    const expected = join(fixturePath, 'file-link.txt');
+    expect(actual.values).toContain(expected);
+  });
+
+  it('symlinked directories are found when type is directory', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath, type: 'directory' });
+    const expected = join(fixturePath, 'dir-link');
+    expect(actual.values).toContain(expected);
+  });
+
+  it('exclude list applies to symlinked directory names', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath, exclude: ['other-link'] });
+    const values = (actual as { type: 'files'; values: string[] }).values;
+    const expected = join(fixturePath, 'dir-link', 'inner.txt');
+    expect(values).toContain(expected);
+  });
+});

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -70,6 +70,20 @@ describe('createFind — symlinks', () => {
     expect(actual.values).toContain(expected);
   });
 
+  it('does not recurse into symlinked directories when followSymlinks is false', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath, followSymlinks: false });
+    const expected = join(fixturePath, 'dir-link', 'inner.txt');
+    expect(actual.values).not.toContain(expected);
+  });
+
+  it('still returns symlinked files when followSymlinks is false', async () => {
+    const Find = createFind(new NodeFileSystem());
+    const actual = await call(Find, { path: fixturePath, followSymlinks: false });
+    const expected = join(fixturePath, 'file-link.txt');
+    expect(actual.values).toContain(expected);
+  });
+
   it('exclude list applies to symlinked directory names', async () => {
     const Find = createFind(new NodeFileSystem());
     const actual = await call(Find, { path: fixturePath, exclude: ['other-link'] });

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -51,10 +51,7 @@ describe('createFind — symlinks', () => {
 
   it('does not loop infinitely on circular symlinks', async () => {
     const Find = createFind(new NodeFileSystem());
-    const actual = await Promise.race([
-      call(Find, { path: fixturePath }),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out after 5000ms')), 5000)),
-    ]);
+    const actual = await Promise.race([call(Find, { path: fixturePath }), new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out after 5000ms')), 5000))]);
     const expected = 'files';
     expect(actual.type).toBe(expected);
   });


### PR DESCRIPTION
## Summary

- Status bar model line now includes the cwd basename
- Distinguishes parallel CLI instances running in separate worktrees

Closes #244