### PR TITLE
EditFile accepts tilde paths that resolve to the staged file

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -23,3 +23,36 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 ## mcp-exec cli.spec.ts PATH issue
 
 `test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
+
+
+# 04:18
+
+## Mission: Fix #285 — EditFile rejects tilde paths
+
+Bug: `PreviewEdit` stores `file` as the expanded path (e.g. `/home/user/file.ts`) because it calls `expandPath(input.file, fs)` at the top of its handler. When `EditFile` receives a tilde path (`~/file.ts`), it compares the raw input string against the stored expanded string — they don't match, so it throws a file mismatch error.
+
+## What was already there
+
+- `expandPath` was already imported and used in `EditFile.ts` (the PreviewEdit tool). `filePath = expandPath(input.file, fs)` at the top of the handler meant the stored `chained.file` was always an expanded absolute path.
+- The `previousPatchId` comparison in `EditFile.ts` (`prev.file !== filePath`) was already correct because both sides are expanded by construction.
+- The broken comparison was only in `ConfirmEditFile.ts` (the EditFile tool): `file !== chained.file` where `file` is raw user input and `chained.file` is expanded.
+
+## Changes made
+
+**`ConfirmEditFile.ts`**: Added `import { expandPath }`, changed `file !== chained.file` to `expandPath(file, fs) !== chained.file`. The `fs` instance was already available — `createEditFile` takes `fs: IFileSystem` as a parameter.
+
+**`EditFile.ts`**: Normalized `prev.file` in the `previousPatchId` comparison: `expandPath(prev.file, fs) !== filePath`. Technically a no-op (prev.file is always stored expanded) but makes the code explicitly safe.
+
+**`EditFile.spec.ts`**: Added two tests to the `createEditFile — applying` describe block:
+1. Stage with expanded path, apply with tilde — the regression case.
+2. Stage with tilde, apply with tilde — belt and suspenders.
+
+## Key structural understanding
+
+`createEditFilePair` creates a shared `store: Map<string, PreviewEditOutputType>` and passes it to both `createPreviewEdit` and `createEditFile`. The `store` key is the `patchId` UUID. The stored value always has `file` as an expanded absolute path (guaranteed by PreviewEdit). The fix only needed to touch the input side of `ConfirmEditFile.ts`.
+
+## State
+
+Phase 1 complete. Three files staged. Branch is 1 commit behind `origin/main` (a main commit landed after the branch was cut) — normal, Courier will handle.
+
+Proposed commit message: `EditFile accepts tilde paths that resolve to the staged file`

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -24,35 +24,14 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 
 `test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
 
+# 04:26
 
-# 04:18
+## Fix #285 — EditFile rejects tilde paths
 
-## Mission: Fix #285 — EditFile rejects tilde paths
+**The actual bug location:** Only `ConfirmEditFile.ts` needed the fix. `EditFile.ts` (the `PreviewEdit` handler) already called `expandPath(input.file, fs)` at the top, so `chained.file` is always stored as an absolute path. The broken comparison was only on the input side of `ConfirmEditFile.ts`.
 
-Bug: `PreviewEdit` stores `file` as the expanded path (e.g. `/home/user/file.ts`) because it calls `expandPath(input.file, fs)` at the top of its handler. When `EditFile` receives a tilde path (`~/file.ts`), it compares the raw input string against the stored expanded string — they don't match, so it throws a file mismatch error.
+**The `previousPatchId` path in `EditFile.ts`** (`prev.file !== filePath`) was already comparing two expanded values. Adding `expandPath(prev.file, fs)` there is a no-op by construction. Worth doing for explicitness.
 
-## What was already there
+**`fs` was already in scope:** `createEditFile` already takes `IFileSystem` as a parameter. The plan said "thread it through from `createEditFilePair`" but nothing needed threading.
 
-- `expandPath` was already imported and used in `EditFile.ts` (the PreviewEdit tool). `filePath = expandPath(input.file, fs)` at the top of the handler meant the stored `chained.file` was always an expanded absolute path.
-- The `previousPatchId` comparison in `EditFile.ts` (`prev.file !== filePath`) was already correct because both sides are expanded by construction.
-- The broken comparison was only in `ConfirmEditFile.ts` (the EditFile tool): `file !== chained.file` where `file` is raw user input and `chained.file` is expanded.
-
-## Changes made
-
-**`ConfirmEditFile.ts`**: Added `import { expandPath }`, changed `file !== chained.file` to `expandPath(file, fs) !== chained.file`. The `fs` instance was already available — `createEditFile` takes `fs: IFileSystem` as a parameter.
-
-**`EditFile.ts`**: Normalized `prev.file` in the `previousPatchId` comparison: `expandPath(prev.file, fs) !== filePath`. Technically a no-op (prev.file is always stored expanded) but makes the code explicitly safe.
-
-**`EditFile.spec.ts`**: Added two tests to the `createEditFile — applying` describe block:
-1. Stage with expanded path, apply with tilde — the regression case.
-2. Stage with tilde, apply with tilde — belt and suspenders.
-
-## Key structural understanding
-
-`createEditFilePair` creates a shared `store: Map<string, PreviewEditOutputType>` and passes it to both `createPreviewEdit` and `createEditFile`. The `store` key is the `patchId` UUID. The stored value always has `file` as an expanded absolute path (guaranteed by PreviewEdit). The fix only needed to touch the input side of `ConfirmEditFile.ts`.
-
-## State
-
-Phase 1 complete. Three files staged. Branch is 1 commit behind `origin/main` (a main commit landed after the branch was cut) — normal, Courier will handle.
-
-Proposed commit message: `EditFile accepts tilde paths that resolve to the staged file`
+**Store architecture:** The shared `store: Map<string, PreviewEditOutputType>` is keyed by `patchId` UUID. The `file` field in stored values is always an expanded absolute path (PreviewEdit guarantees this). Only the input side of the apply step ever receives a raw tilde path.

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -11,3 +11,4 @@
 {"description":"Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry","category":"added"}
 {"description":"Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem","category":"added"}
 {"description":"Add TypeScript language tools: ts_diagnostics, ts_hover, ts_references, ts_definition","category":"added"}
+{"description":"Normalise tilde and environment variable paths in EditFile","category":"fixed"}

--- a/packages/claude-sdk-tools/src/EditFile/ConfirmEditFile.ts
+++ b/packages/claude-sdk-tools/src/EditFile/ConfirmEditFile.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { defineTool } from '@shellicar/claude-sdk';
+import { expandPath } from '../expandPath';
 import type { IFileSystem } from '../fs/IFileSystem';
 import { EditFileInputSchema, EditFileOutputSchema } from './schema';
 import type { PreviewEditOutputType } from './types';
@@ -21,7 +22,7 @@ export function createEditFile(fs: IFileSystem, store: Map<string, PreviewEditOu
       if (chained == null) {
         throw new Error('Staged preview not found. The patch store is in-memory — please run PreviewEdit again.');
       }
-      if (file !== chained.file) {
+      if (expandPath(file, fs) !== chained.file) {
         throw new Error(`File mismatch: input has "${file}" but patch is for "${chained.file}"`);
       }
       const currentContent = await fs.readFile(chained.file);

--- a/packages/claude-sdk-tools/src/EditFile/EditFile.ts
+++ b/packages/claude-sdk-tools/src/EditFile/EditFile.ts
@@ -103,7 +103,7 @@ export function createPreviewEdit(fs: IFileSystem, store: Map<string, PreviewEdi
         if (!prev) {
           throw new Error('Previous patch not found. The patch store is in-memory \u2014 please run PreviewEdit again.');
         }
-        if (prev.file !== filePath) {
+        if (expandPath(prev.file, fs) !== filePath) {
           throw new Error(`File mismatch: previousPatchId is for "${prev.file}" but this edit targets "${filePath}"`);
         }
         baseContent = prev.newContent;

--- a/packages/claude-sdk-tools/test/EditFile.spec.ts
+++ b/packages/claude-sdk-tools/test/EditFile.spec.ts
@@ -77,6 +77,24 @@ describe('createEditFile — applying', () => {
     const { editFile } = createEditFilePair(fs);
     await expect(call(editFile, { patchId: '00000000-0000-4000-8000-000000000000', file: '/any.ts' })).rejects.toThrow('Staged preview not found');
   });
+
+  it('accepts a ~ path when the patch was staged with the expanded path', async () => {
+    const fs = new MemoryFileSystem({ '/home/testuser/file.ts': originalContent }, '/home/testuser');
+    const { previewEdit, editFile } = createEditFilePair(fs);
+    const staged = await call(previewEdit, { file: '/home/testuser/file.ts', lineEdits: [{ action: 'replace', startLine: 1, endLine: 1, content: 'line ONE' }] });
+    const confirmed = await call(editFile, { patchId: staged.patchId, file: '~/file.ts' });
+    expect(confirmed).toMatchObject({ linesAdded: 1, linesRemoved: 1 });
+    expect(await fs.readFile('/home/testuser/file.ts')).toBe('line ONE\nline two\nline three');
+  });
+
+  it('accepts a ~ path when both preview and edit use ~', async () => {
+    const fs = new MemoryFileSystem({ '/home/testuser/file.ts': originalContent }, '/home/testuser');
+    const { previewEdit, editFile } = createEditFilePair(fs);
+    const staged = await call(previewEdit, { file: '~/file.ts', lineEdits: [{ action: 'replace', startLine: 1, endLine: 1, content: 'line ONE' }] });
+    const confirmed = await call(editFile, { patchId: staged.patchId, file: '~/file.ts' });
+    expect(confirmed).toMatchObject({ linesAdded: 1, linesRemoved: 1 });
+    expect(await fs.readFile('/home/testuser/file.ts')).toBe('line ONE\nline two\nline three');
+  });
 });
 
 describe('regex_text action', () => {


### PR DESCRIPTION
## Summary

- Fix file mismatch when EditFile receives a tilde path and the patch was staged with an expanded path
- Normalise the input path in ConfirmEditFile before comparing against the stored patch

Closes #285