### PR TITLE
Add append operation to EditFile

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -79,3 +79,21 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 **Test file:** `EditFile-append.spec.ts` in `test/`. Imports and patterns match `EditFile.spec.ts` exactly. One `expect` per `it`. Uses `expected`/`actual` variables throughout.
 
 **For the builder:** Implement in `EditFile.ts` handler. After the `if (input.append != null)` guard, read the file, concatenate, generate diff, store patch. Add the mutual exclusion check before the not-implemented throw (or replace it). The error message should contain the word 'append' for tests 4-5. The file must exist for test 6 to produce ENOENT naturally (read the file before writing). No changes to the test file should be needed.
+
+# 04:34
+
+## Phase 2 Build: append operation
+
+**What was implemented:** Replaced the `not implemented` stub in the `PreviewEdit` handler with the full append logic. The implementation is in the `if (input.append != null)` guard that was already in place.
+
+**Mutual exclusion check:** `lineEdits.length > 0` and `textEdits.length > 0` are checked before any I/O. Both error messages contain 'append', satisfying the `.rejects.toThrow('append')` assertions in tests 4 and 5.
+
+**ENOENT path:** The append branch calls `fs.readFile(filePath)` before writing, which throws ENOENT naturally from `MemoryFileSystem` when the file doesn't exist. Test 6 passes without any explicit error handling.
+
+**Concatenation:** `newContent = baseContent + input.append`. Simple and correct for all cases (existing content, empty file).
+
+**No test changes needed:** The scaffold tests were written with the right expectations. The error messages ('append is mutually exclusive with lineEdits/textEdits') contain 'append'. The ENOENT propagates naturally. All 6 new tests pass.
+
+**CI:** 248 tests pass, type-check passes, biome lint passes.
+
+**For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -65,3 +65,17 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 **Mock design: alphabetical readdir ordering matters.** `walk` uses `realpath` for cycle detection: the first call to walk a path adds its realpath to `visited`. If `dir-link` (→ `real-dir`) is processed before `real-dir` in readdir order, then `dir-link/inner.txt` appears in results and `real-dir` returns empty (already visited). If the order were reversed, `real-dir/inner.txt` would appear and `dir-link` would return empty. Tests assert by the symlink path, so the mock must return entries in alphabetical order to make the assertions correct. This is intentional and documented in the mock's JSDoc comment.
 
 **`stat` in MemoryFS: always `isFile: true`.** Directories are implicit and have no stat entry in the Map. `stat('/src')` would throw ENOENT. That's acceptable because `walk` only calls `stat` on symlink entries, and MemoryFS has no symlinks. No test exercises `stat` on a MemoryFS directory.
+
+# 04:24
+
+## Phase 1 Scaffold: append operation for EditFile/PreviewEdit
+
+**Where append lives:** The `append` parameter goes on `PreviewEditInputSchema`, not `EditFileInputSchema`. The mission says "EditFile input schema" but tests 4 and 5 check mutual exclusion with `lineEdits` and `textEdits`, which only exist on `PreviewEditInputSchema`. The append-via-PreviewEdit approach means the append goes through the same diff/stage/apply flow as all other edits.
+
+**Stub strategy:** `if (input.append != null) throw new Error('not implemented')` is the first check in the handler, before any file I/O. This makes tests 1-3 fail because the await throws. Tests 4-5 use `.rejects.toThrow('append')` so the 'not implemented' message doesn't match. Test 6 uses `.rejects.toThrow('ENOENT')` so same mismatch. All 6 fail as required.
+
+**Schema refine:** Updated from `lineEdits.length > 0 || textEdits.length > 0` to also allow `append != null`. Without this, `call(previewEdit, { file, append: '...' })` would throw a Zod validation error before reaching the handler.
+
+**Test file:** `EditFile-append.spec.ts` in `test/`. Imports and patterns match `EditFile.spec.ts` exactly. One `expect` per `it`. Uses `expected`/`actual` variables throughout.
+
+**For the builder:** Implement in `EditFile.ts` handler. After the `if (input.append != null)` guard, read the file, concatenate, generate diff, store patch. Add the mutual exclusion check before the not-implemented throw (or replace it). The error message should contain the word 'append' for tests 4-5. The file must exist for test 6 to produce ENOENT naturally (read the file before writing). No changes to the test file should be needed.

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -13,3 +13,4 @@
 {"description":"Add TypeScript language tools: ts_diagnostics, ts_hover, ts_references, ts_definition","category":"added"}
 {"description":"Normalise tilde and environment variable paths in EditFile","category":"fixed"}
 {"description":"Find tool follows symlinks with cycle detection","category":"fixed"}
+{"description":"Add append operation to EditFile","category":"added"}

--- a/packages/claude-sdk-tools/src/EditFile/EditFile.ts
+++ b/packages/claude-sdk-tools/src/EditFile/EditFile.ts
@@ -95,7 +95,26 @@ export function createPreviewEdit(fs: IFileSystem, store: Map<string, PreviewEdi
     ],
     handler: async (input) => {
       if (input.append != null) {
-        throw new Error('not implemented');
+        if (input.lineEdits.length > 0) {
+          throw new Error('append is mutually exclusive with lineEdits');
+        }
+        if (input.textEdits.length > 0) {
+          throw new Error('append is mutually exclusive with textEdits');
+        }
+        const filePath = expandPath(input.file, fs);
+        const baseContent = await fs.readFile(filePath);
+        const originalHash = createHash('sha256').update(baseContent).digest('hex');
+        const newContent = baseContent + input.append;
+        const diff = generateDiff(toDisplayPath(filePath), baseContent, newContent);
+        const output = PreviewEditOutputSchema.parse({
+          patchId: randomUUID(),
+          diff,
+          file: filePath,
+          newContent,
+          originalHash,
+        });
+        store.set(output.patchId, output);
+        return output;
       }
 
       const filePath = expandPath(input.file, fs);

--- a/packages/claude-sdk-tools/src/EditFile/EditFile.ts
+++ b/packages/claude-sdk-tools/src/EditFile/EditFile.ts
@@ -94,6 +94,10 @@ export function createPreviewEdit(fs: IFileSystem, store: Map<string, PreviewEdi
       },
     ],
     handler: async (input) => {
+      if (input.append != null) {
+        throw new Error('not implemented');
+      }
+
       const filePath = expandPath(input.file, fs);
 
       let baseContent: string;

--- a/packages/claude-sdk-tools/src/EditFile/schema.ts
+++ b/packages/claude-sdk-tools/src/EditFile/schema.ts
@@ -55,9 +55,10 @@ export const PreviewEditInputSchema = z
       .describe(
         "If provided, chain this preview onto a previous staged patch. The previous patch\u2019s result is used as the base instead of reading from disk, and the diff shown is incremental (only the changes introduced by this preview). To apply the full accumulated result, call EditFile with the final patchId in the chain — do not call EditFile on intermediate patches before the final one, as each patch validates against the original disk state rather than the previous patch's result.",
       ),
+    append: z.string().optional().describe('Append content to the end of the file. Mutually exclusive with lineEdits and textEdits.'),
   })
-  .refine((input) => input.lineEdits.length > 0 || input.textEdits.length > 0, {
-    message: 'At least one edit must be provided (lineEdits or textEdits)',
+  .refine((input) => input.lineEdits.length > 0 || input.textEdits.length > 0 || input.append != null, {
+    message: 'At least one edit must be provided (lineEdits, textEdits, or append)',
   });
 
 export const PreviewEditOutputSchema = z.object({

--- a/packages/claude-sdk-tools/test/EditFile-append.spec.ts
+++ b/packages/claude-sdk-tools/test/EditFile-append.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { createEditFilePair } from '../src/EditFile/createEditFilePair';
+import { MemoryFileSystem } from '../src/fs/MemoryFileSystem';
+import { call } from './helpers';
+
+describe('append operation', () => {
+  it('append adds content after the last line of an existing file', async () => {
+    const fs = new MemoryFileSystem({ '/file.jsonl': 'line one\nline two' });
+    const { previewEdit, editFile } = createEditFilePair(fs);
+    const staged = await call(previewEdit, { file: '/file.jsonl', append: '\nline three' });
+    await call(editFile, { patchId: staged.patchId, file: staged.file });
+    const actual = await fs.readFile('/file.jsonl');
+    const expected = 'line one\nline two\nline three';
+    expect(actual).toBe(expected);
+  });
+
+  it('append to an empty file writes the content', async () => {
+    const fs = new MemoryFileSystem({ '/file.jsonl': '' });
+    const { previewEdit, editFile } = createEditFilePair(fs);
+    const staged = await call(previewEdit, { file: '/file.jsonl', append: 'new content' });
+    await call(editFile, { patchId: staged.patchId, file: staged.file });
+    const actual = await fs.readFile('/file.jsonl');
+    const expected = 'new content';
+    expect(actual).toBe(expected);
+  });
+
+  it('existing file content is unchanged when appending', async () => {
+    const original = 'line one\nline two';
+    const fs = new MemoryFileSystem({ '/file.jsonl': original });
+    const { previewEdit, editFile } = createEditFilePair(fs);
+    const staged = await call(previewEdit, { file: '/file.jsonl', append: '\nline three' });
+    await call(editFile, { patchId: staged.patchId, file: staged.file });
+    const actual = await fs.readFile('/file.jsonl');
+    expect(actual.slice(0, original.length)).toBe(original);
+  });
+
+  it('providing both append and lineEdits produces an error', async () => {
+    const fs = new MemoryFileSystem({ '/file.jsonl': 'line one' });
+    const { previewEdit } = createEditFilePair(fs);
+    const actual = call(previewEdit, {
+      file: '/file.jsonl',
+      append: '\nline two',
+      lineEdits: [{ action: 'insert', after_line: 0, content: 'header' }],
+    });
+    await expect(actual).rejects.toThrow('append');
+  });
+
+  it('providing both append and textEdits produces an error', async () => {
+    const fs = new MemoryFileSystem({ '/file.jsonl': 'line one' });
+    const { previewEdit } = createEditFilePair(fs);
+    const actual = call(previewEdit, {
+      file: '/file.jsonl',
+      append: '\nline two',
+      textEdits: [{ action: 'replace_text', oldString: 'line one', replacement: 'LINE ONE' }],
+    });
+    await expect(actual).rejects.toThrow('append');
+  });
+
+  it('append to a nonexistent file produces an error', async () => {
+    const fs = new MemoryFileSystem({});
+    const { previewEdit } = createEditFilePair(fs);
+    const actual = call(previewEdit, { file: '/nonexistent.jsonl', append: '\nnew line' });
+    await expect(actual).rejects.toThrow('ENOENT');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `append` parameter to `PreviewEdit` for single-step file appending
- Mutually exclusive with `lineEdits` and `textEdits`
- Append to nonexistent file produces an error (not a create)

Closes #259