### PR TITLE
Add --file flag to start with a file as the first message

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -23,3 +23,46 @@ The `toWireTool` comment said `buildRequestParams` gates `input_examples` on ATU
 ## mcp-exec cli.spec.ts PATH issue
 
 `test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
+
+
+# 04:28
+
+## Mission
+
+Add `--file` flag to the CLI. When provided, the file is attached as the first message and submitted automatically. Session resume is skipped (fresh start).
+
+## What I built
+
+Two files changed:
+
+**`ConversationSession.ts`**: Added `startFresh()` method. Generates a new UUID and writes it to the marker file (`.claude/.sdk-conversation-id`), without loading or saving any existing history. This is distinct from `createNew()` which saves the current conversation before resetting, and `load()` which reads an existing marker. `startFresh()` is safe to call at startup before any history exists.
+
+**`main.ts`**: Four changes:
+1. Added `file: { type: 'string' }` to `parseArgs` options.
+2. Resolved the flag value to an absolute path at module top level (after the early-exit checks), using `typeof values.file === 'string'` as the guard. `strict: false` in `parseArgs` widens option values to `string | boolean`, so `!= null` is not sufficient as a type guard for `.replace()`.
+3. In `main()`, the session is initialized via `startFresh()` when `--file` is present, `load()` otherwise.
+4. In the main loop, `pendingFile` holds the path for the first iteration. When set, the file is stat'd and a `UserInput` is built directly using `buildSubmitText` with a `FileAttachment`. `waitForInput()` is skipped for that iteration only.
+
+## Design notes
+
+Skipping `waitForInput()` for the first iteration is safe because `AppLayout` starts in `'editor'` mode by default, and `startStreaming()` (called by `runAgent`) handles the transition unconditionally. After `completeStreaming()` returns, the layout is back in a clean editor state and the next `waitForInput()` call works normally.
+
+The `buildSubmitText` + inline `FileAttachment` approach mirrors exactly what the `f` key does in command mode (via `CommandModeState.addFile` then `takeAttachments`), just without going through the `CommandModeState` state machine since there is no user interaction to manage.
+
+## Gotcha: biome formatting
+
+Biome has a strong opinion about where ternary line breaks go. A multi-line `const x =\n  condition ? a : b` form triggers a formatting error; biome reformats it to a single line if it fits. Ran `pnpm ci:fix` twice to let it settle.
+
+## Pre-existing CI failure
+
+`packages/claude-core/src/reflow.ts:123` fails `noControlCharactersInRegex`. Present before my changes.
+
+
+## IFileSystem abstraction leak — needs a sweep
+
+`IFileSystem.stat()` returns `StatResult = { size: number }` only — no `isDirectory`. As a result, two files in `apps/claude-sdk-cli/src/` import `stat` from `node:fs/promises` directly instead of going through `nodeFs`:
+
+- `AppLayout.ts` — uses `stat` to distinguish file vs directory when attaching via the `f` key
+- `entry/main.ts` — `buildFileInput` does the same for `--file`
+
+The `IFileSystem` abstraction exists precisely so filesystem calls can be injected and tested. These direct imports bypass it. SC noted this is a broader issue to fix across the board. The fix is to extend `StatResult` to include `isDirectory: boolean`, update `NodeFileSystem.stat()` to populate it, then replace both direct `stat` imports with `nodeFs.stat()`.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -13,3 +13,4 @@
 {"description":"Default `compact.enabled` to `false`","category":"fixed"}
 {"description":"Preserve editor content when starting a new conversation","category":"fixed"}
 {"description":"Restore cursor visibility after exiting the CLI","category":"fixed","metadata":{"issue":277}}
+{"description":"Add --file flag to start with a file as the first message","category":"added"}

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -1,9 +1,11 @@
+import { stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import type { BetaToolSearchToolBm25_20251119, BetaToolSearchToolRegex20251119 } from '@anthropic-ai/sdk/resources/beta.mjs';
 import { AnthropicAuth, AnthropicBeta, AnthropicClient, ApprovalCoordinator, type BetaToolUnion, CacheTtl, ControlChannel, Conversation, type DurableConfig, QueryRunner, type SdkMessage, StreamProcessor, ToolRegistry, TurnRunner } from '@shellicar/claude-sdk';
 import { nodeFs } from '@shellicar/claude-sdk-tools/fs';
 import { TsServerService } from '@shellicar/claude-sdk-tools/TsService';
-import { AppLayout } from '../AppLayout.js';
+import { AppLayout, type UserInput } from '../AppLayout.js';
 import { AuditWriter } from '../AuditWriter.js';
 import { buildAtuTransform } from '../buildAtuTransform.js';
 import { buildServerTools } from '../buildServerTools.js';
@@ -15,6 +17,7 @@ import { createAppTools } from '../createAppTools.js';
 import { GitStateMonitor } from '../GitStateMonitor.js';
 import { printUsage, printVersion, printVersionInfo, startupBannerText } from '../help.js';
 import { logger } from '../logger.js';
+import { buildSubmitText } from '../model/buildSubmitText.js';
 import { ConversationSession } from '../model/ConversationSession.js';
 import { StatusState } from '../model/StatusState.js';
 import { ReadLine } from '../ReadLine.js';
@@ -28,6 +31,7 @@ const { values } = parseArgs({
     'version-info': { type: 'boolean', default: false },
     'init-config': { type: 'boolean', default: false },
     help: { type: 'boolean', short: 'h', default: false },
+    file: { type: 'string' },
   },
   strict: false,
 });
@@ -61,6 +65,28 @@ if (!process.stdin.isTTY) {
   process.exit(1);
 }
 
+const initialFilePath = typeof values.file === 'string' ? resolve(values.file.replace(/^~(?=\/|$)/, process.env.HOME ?? '')) : null;
+
+async function buildFileInput(filePath: string): Promise<UserInput> {
+  let fileType: 'file' | 'dir' | 'missing' = 'missing';
+  let sizeBytes: number | undefined;
+  try {
+    const fileInfo = await stat(filePath);
+    if (fileInfo.isDirectory()) {
+      fileType = 'dir';
+    } else {
+      fileType = 'file';
+      sizeBytes = fileInfo.size;
+    }
+  } catch {
+    fileType = 'missing';
+  }
+  return {
+    text: buildSubmitText('', [{ kind: 'file', path: filePath, fileType, sizeBytes }]),
+    images: [],
+  };
+}
+
 const main = async () => {
   const auth = new AnthropicAuth({ redirect: 'local' });
   await auth.getCredentials();
@@ -73,7 +99,11 @@ const main = async () => {
   const statusState = new StatusState();
   const conversation = new Conversation();
   const session = new ConversationSession(nodeFs, conversation);
-  await session.load();
+  if (initialFilePath != null) {
+    await session.startFresh();
+  } else {
+    await session.load();
+  }
   const layout = new AppLayout(statusState, session);
 
   let turnInProgress = false;
@@ -220,8 +250,7 @@ const main = async () => {
   const gitMonitor = new GitStateMonitor();
   const claudeMdLoader = new ClaudeMdLoader(nodeFs);
 
-  while (true) {
-    const userInput = await layout.waitForInput();
+  const runTurn = async (userInput: UserInput) => {
     const claudeMdContent = watcher.config.claudeMd.enabled ? await claudeMdLoader.getContent() : null;
 
     // Update durable config with current values before each query
@@ -244,6 +273,14 @@ const main = async () => {
     statusState.setModel(watcher.config.model);
     layout.render();
     await session.save();
+  };
+
+  if (initialFilePath != null) {
+    await runTurn(await buildFileInput(initialFilePath));
+  }
+
+  while (true) {
+    await runTurn(await layout.waitForInput());
   }
 };
 await main();

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -16,6 +16,12 @@ export class ConversationSession {
     return this.#id;
   }
 
+  public async startFresh(): Promise<void> {
+    this.#id = randomUUID();
+    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
+    await this.#fs.writeFile(markerPath, this.#id);
+  }
+
   public async load(): Promise<void> {
     const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
     const markerExists = await this.#fs.exists(markerPath);


### PR DESCRIPTION
## Summary

- Accept --file path on startup, attach the file as the first message, and submit automatically
- Skip session resume when --file is provided; always start fresh
- Enter interactive mode normally after the initial submit

Closes #278