### PR TITLE
Flash tool approval row when awaiting Y/N

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -1,215 +1,43 @@
-# Status bar cwd — what matters
+# Approval flash (#289)
 
-## IFileSystem is not optional
+## No existing render interval
 
-Do not call `path.basename(process.cwd())` or `process.cwd()` directly in renderers or state classes. The codebase has `IFileSystem` with a `cwd()` method. Everything that needs the cwd goes through it: `ClaudeMdLoader`, `AuditWriter`, `ConversationSession`, and now `StatusState`.
+The plan assumed `AppLayout` already had a `setInterval` driving periodic re-renders. It does not. The render loop is entirely event-driven: every `render()` call is triggered by a concrete event (keypress, streaming text, resize). When waiting for Y/N, nothing drives periodic re-renders.
 
-The pattern: take `IFileSystem` in the constructor, call `path.basename(fs.cwd())` once, store the result. The renderer reads the stored string. No direct `path` or `process` calls outside the constructor.
+The fix: `#startFlash()` / `#stopFlash()` in `AppLayout` manage a 500ms `setInterval`. The interval calls `toggleFlash()` on `ToolApprovalState` and then re-renders. At 500ms per toggle, `flashPhase` alternates every 500ms: one full visual cycle per second (1 Hz). This is within the ~1-2 Hz target.
 
-In `main.ts`, pass `nodeFs`. In tests, use `MemoryFileSystem({}, '/home/user', '/repos/my-project')` to get a deterministic basename of `my-project`.
+## Scope: full row, not just [Y/N]
 
-## Layout
+The prompt said to flash only the `[Y/N]` text. After seeing it running, the SC corrected this: the entire approval row should invert. A flashing label inside a static line is harder to catch in peripheral vision; a full-row flash is the point.
 
-The model line shows `⚡ <model>  <cwd-basename>`. When no model is set yet, it shows just the basename. The separator between model and basename is two spaces.
+Implementation: build the row string without ANSI, then wrap it in `\x1b[7m`...`\x1b[27m` when `hasPendingApprovals && state.flashPhase`. The `[Y/N]` label itself is plain text; the inversion comes from the row wrapper.
 
-## Earlier work in the same file (not this issue)
+## Where flash state lives
 
-The first two entries in today's testament cover unrelated work (`feature/advanced-tool-use` cleaner phase, `input_examples` gating, `mcp-exec` PATH). They are still relevant if you are tracing those decisions:
-- `BetaTextBlock.citations` became required in `@anthropic-ai/sdk@0.82.0`; `citations: null` satisfies it
-- `buildAtuTransform` always returns a function; when ATU is off it strips `input_examples` from wire tools
-- `cli.spec.ts` resolves `tsx` to an absolute path because the VS Code vitest extension doesn't inherit `node_modules/.bin` on PATH
-**Why gate it:** `input_examples` are only meaningful in ATU mode. Sending them when ATU is off is wasteful and exposes implementation detail to the API unnecessarily.
+`ToolApprovalState` owns `#flashPhase` (boolean, starts false). `toggleFlash()` flips it. There is no automatic reset when approvals resolve: the timer stops externally, and `renderToolApproval` only applies inversion when `hasPendingApprovals` is true, so the phase value at stop time is irrelevant.
 
-**Where it belongs:** CLI concern, not SDK concern. The SDK defines the shape (`toWireTool` always includes `input_examples`). The CLI's `transformTool` hook decides what reaches the wire. `buildRequestParams` should not contain logic about `input_examples`.
+`#startFlash()` is idempotent (no-ops if interval already running). Called from `requestApproval()`. `#stopFlash()` clears the interval and is called from `exit()`, `completeStreaming()`, and after Y/N when the approval queue empties.
 
-**Decision:** `buildAtuTransform` now always returns a function. When ATU is disabled the function strips `input_examples` using the same type guard pattern (`isToolWithInputExamples`) already used for `isNamedTool` in the file. No `as unknown as` anywhere.
+## Files changed
 
-## mcp-exec cli.spec.ts PATH issue
+- `apps/claude-sdk-cli/src/model/ToolApprovalState.ts` (flashPhase getter + toggleFlash)
+- `apps/claude-sdk-cli/src/view/renderToolApproval.ts` (full-row inversion)
+- `apps/claude-sdk-cli/src/AppLayout.ts` (#flashInterval, #startFlash, #stopFlash)
 
-`test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
+---
 
+# Earlier work on 2026-04-20 (unrelated to this issue)
 
-# 04:28
+The top section of today's testament before this rewrite covered several unrelated casts. Key points preserved below for traceability.
 
-## Mission
+## IFileSystem and StatusState
 
-Add `--file` flag to the CLI. When provided, the file is attached as the first message and submitted automatically. Session resume is skipped (fresh start).
+`StatusState` takes `IFileSystem` in its constructor; calls `path.basename(fs.cwd())` once and stores the result. Tests use `new MemoryFileSystem({}, '/home/user', '/repos/my-project')`. Making `fs` optional with a `process.cwd()` fallback was tried and reverted by the SC.
 
-## What I built
+## ci:fix reverts reflow.ts
 
-Two files changed:
+Running `pnpm ci:fix` converts `new RegExp('...', 'g')` back to a regex literal in `reflow.ts`, re-triggering `noControlCharactersInRegex`. Restore manually after every `ci:fix` run. Pre-existing; do not stage `reflow.ts` unless intentional.
 
-**`ConversationSession.ts`**: Added `startFresh()` method. Generates a new UUID and writes it to the marker file (`.claude/.sdk-conversation-id`), without loading or saving any existing history. This is distinct from `createNew()` which saves the current conversation before resetting, and `load()` which reads an existing marker. `startFresh()` is safe to call at startup before any history exists.
+## Preflight branch-vs-origin gap
 
-**`main.ts`**: Four changes:
-1. Added `file: { type: 'string' }` to `parseArgs` options.
-2. Resolved the flag value to an absolute path at module top level (after the early-exit checks), using `typeof values.file === 'string'` as the guard. `strict: false` in `parseArgs` widens option values to `string | boolean`, so `!= null` is not sufficient as a type guard for `.replace()`.
-3. In `main()`, the session is initialized via `startFresh()` when `--file` is present, `load()` otherwise.
-4. In the main loop, `pendingFile` holds the path for the first iteration. When set, the file is stat'd and a `UserInput` is built directly using `buildSubmitText` with a `FileAttachment`. `waitForInput()` is skipped for that iteration only.
-
-## Design notes
-
-Skipping `waitForInput()` for the first iteration is safe because `AppLayout` starts in `'editor'` mode by default, and `startStreaming()` (called by `runAgent`) handles the transition unconditionally. After `completeStreaming()` returns, the layout is back in a clean editor state and the next `waitForInput()` call works normally.
-
-The `buildSubmitText` + inline `FileAttachment` approach mirrors exactly what the `f` key does in command mode (via `CommandModeState.addFile` then `takeAttachments`), just without going through the `CommandModeState` state machine since there is no user interaction to manage.
-
-## Gotcha: biome formatting
-
-Biome has a strong opinion about where ternary line breaks go. A multi-line `const x =\n  condition ? a : b` form triggers a formatting error; biome reformats it to a single line if it fits. Ran `pnpm ci:fix` twice to let it settle.
-
-## Pre-existing CI failure
-
-`packages/claude-core/src/reflow.ts:123` fails `noControlCharactersInRegex`. Present before my changes.
-
-
-## IFileSystem abstraction leak — needs a sweep
-
-`IFileSystem.stat()` returns `StatResult = { size: number }` only — no `isDirectory`. As a result, two files in `apps/claude-sdk-cli/src/` import `stat` from `node:fs/promises` directly instead of going through `nodeFs`:
-
-- `AppLayout.ts` — uses `stat` to distinguish file vs directory when attaching via the `f` key
-- `entry/main.ts` — `buildFileInput` does the same for `--file`
-
-The `IFileSystem` abstraction exists precisely so filesystem calls can be injected and tested. These direct imports bypass it. SC noted this is a broader issue to fix across the board. The fix is to extend `StatResult` to include `isDirectory: boolean`, update `NodeFileSystem.stat()` to populate it, then replace both direct `stat` imports with `nodeFs.stat()`.
-# 04:26
-
-## Fix #285 — EditFile rejects tilde paths
-
-**The actual bug location:** Only `ConfirmEditFile.ts` needed the fix. `EditFile.ts` (the `PreviewEdit` handler) already called `expandPath(input.file, fs)` at the top, so `chained.file` is always stored as an absolute path. The broken comparison was only on the input side of `ConfirmEditFile.ts`.
-
-**The `previousPatchId` path in `EditFile.ts`** (`prev.file !== filePath`) was already comparing two expanded values. Adding `expandPath(prev.file, fs)` there is a no-op by construction. Worth doing for explicitness.
-
-**`fs` was already in scope:** `createEditFile` already takes `IFileSystem` as a parameter. The plan said "thread it through from `createEditFilePair`" but nothing needed threading.
-
-**Store architecture:** The shared `store: Map<string, PreviewEditOutputType>` is keyed by `patchId` UUID. The `file` field in stored values is always an expanded absolute path (PreviewEdit guarantees this). Only the input side of the apply step ever receives a raw tilde path.
-# 03:36
-
-## find-symlinks: symlink following with cycle detection
-
-**The traversal ordering surprise.** `visited` is keyed on `realpath`, not the path passed to `walk`. When `dir-link` (a symlink to `real-dir`) is alphabetically sorted before `real-dir`, following the symlink resolves to `real-dir`'s real path and adds it to `visited`. When `real-dir` is reached directly, it's already visited and returns empty. Result: `dir-link/inner.txt` appears in results; `real-dir/inner.txt` does not. The tests assert by the symlinked path, so this is correct behaviour, not a bug.
-
-**`followSymlinks: false` only gates directory recursion.** The option controls whether symlinked directories are entered, not whether symlinks appear in results at all. Symlinked files are always returned. A previous version gated the entire symlink block, making symlinks invisible when `followSymlinks: false`. The correct boundary: only the `walk()` call inside the directory branch is conditional.
-
-**`ci:fix` has a reach problem.** Running `pnpm ci:fix` to fix formatting in `find-symlinks.spec.ts` also modified `reflow.ts` (reverted a `new RegExp(...)` lint workaround back to a literal, which re-triggers a lint error). That change has to be manually restored after every `ci:fix` run. `Find.ts` and `Find.spec.ts` changes (removing unnecessary `\\` in `'\\.ts$'` patterns) are legitimate and safe to stage.
-
-**Don't cast on suspicion.** Phase 1 added `as { type: 'files'; values: string[] }` casts throughout the tests before checking whether the compiler actually needed them. It didn't. The types flow correctly through `call()`. Rule: write the code, run TsDiagnostics, cast only when the compiler complains.
-
-**The output metadata gap is a separate problem.** This PR adds symlink traversal. It does not (and cannot without a breaking schema change) expose whether a returned path is a symlink. The `{ type: 'files', values: string[] }` pipe format carries no per-path metadata. `returnSymlinks` as a filter, or type-annotation on entries, requires changing the element type in `values` -- a breaking change that touches every downstream consumer (Grep, SearchFiles, DeleteFile, DeleteDirectory). That work is not here.
-
-
-# 04:00
-
-## Phase 3: IFileSystem abstraction refactor
-
-**The circular import non-problem.** `IFileSystem.ts` imports from `walk.ts`, and `walk.ts` imports types from `IFileSystem.ts`. This looks like a circular dependency but isn't at runtime. `walk.ts` uses `import type { ... }` — type-only imports are erased at compile time. The runtime module graph has no cycle. This is a well-known TypeScript pattern. Don't avoid it by duplicating type definitions.
-
-**`find` moved from abstract to concrete on `IFileSystem`.** Both `NodeFileSystem` and `MemoryFileSystem` had identical one-liner `find` methods calling `walk`. Making it concrete on the base class removes that duplication. Subclasses now only implement the primitives: `readdir`, `realpath`, `stat`.
-
-**`MemoryFileSystem.readdir` derives directory contents from the flat file Map.** Directories are implicit — a file at `/a/b/c` implies `/a/b` is a directory. `readdir('/a')` scans the Map, takes the first path component under `/a/`, and classifies it as file (1 component) or directory (multiple). Nothing is a symlink in MemoryFS, so `isSymbolicLink` always returns false.
-
-**`ci:fix` reverts `reflow.ts` — restore it manually.** Every time `pnpm ci:fix` runs, biome converts `new RegExp('...', 'g')` back to a literal, which re-triggers the `noControlCharactersInRegex` lint error. The revert is a one-liner. This is a pre-existing pattern documented by the previous operator — do not stage `reflow.ts` unless you need to; restore it before committing.
-
-**Mock design: alphabetical readdir ordering matters.** `walk` uses `realpath` for cycle detection: the first call to walk a path adds its realpath to `visited`. If `dir-link` (→ `real-dir`) is processed before `real-dir` in readdir order, then `dir-link/inner.txt` appears in results and `real-dir` returns empty (already visited). If the order were reversed, `real-dir/inner.txt` would appear and `dir-link` would return empty. Tests assert by the symlink path, so the mock must return entries in alphabetical order to make the assertions correct. This is intentional and documented in the mock's JSDoc comment.
-
-**`stat` in MemoryFS: always `isFile: true`.** Directories are implicit and have no stat entry in the Map. `stat('/src')` would throw ENOENT. That's acceptable because `walk` only calls `stat` on symlink entries, and MemoryFS has no symlinks. No test exercises `stat` on a MemoryFS directory.
-
-
-# 04:40
-
-## Preflight does not check branch-vs-origin/main
-
-`default_divergence` in the preflight output compares *local main* against *origin/main*. This is useless: after `git fetch`, `origin/main` is current, so the only thing it detects is whether you have run `git pull` on your local main checkout. SC flagged this as a regression from a previous version.
-
-The check that actually matters is missing: is the current feature branch behind `origin/main`? It isn't checked at all. The Maker's testament for this cast noted the branch was one commit behind main; there was no mechanism to act on it.
-
-A second commit landed on main between Phase 1 and Phase 2, so even a correct preflight in Phase 1 wouldn't have been enough. The Courier also needs to check and merge (or rebase) before pushing.
-
-
-# 05:46
-
-## Phase 3: StatusState constructor — update tests, not the constructor
-
-**The failure.** Phase 1 changed `StatusState` constructor from no-arg to `constructor(fs: IFileSystem)`. All existing tests called `new StatusState()` with no argument. CI failed on type-check with TS2554 (expected 1 argument, got 0).
-
-**Wrong fix: making `fs` optional.** My first instinct was to make the parameter optional with a `process.cwd()` fallback. The SC reverted this. The correct approach is below.
-
-**Correct fix: update the tests.** The tests should pass `MemoryFileSystem` to construct `StatusState`, not work around the constructor. The Phase 1 testament even documented this: "In tests, use `MemoryFileSystem({}, '/home/user', '/repos/my-project')`". I had the information and used the wrong fix anyway.
-
-`StatusState.spec.ts` now has a `makeState()` factory using `testFs = new MemoryFileSystem({}, '/home/user', '/repos/my-project')`. `AgentMessageHandler.spec.ts` passes `new MemoryFileSystem({}, '/home/user', '/test')` at each call site.
-
-**`turbo.json` `outputLogs` added.** `build: "new-only"`, `test: "errors-only"`, `type-check: "errors-only"`. On cache hits, turbo now suppresses replayed logs entirely. Makes the verify output much less noisy.
-
-**`pnpm ci:fix` reverted `reflow.ts` again.** Same problem documented above. Restored manually. This is now three operators in a row.
-
-**Import ordering in `renderStatus.spec.ts`.** `@shellicar/claude-sdk-tools/fs` before `vitest` is what biome wants. `ci:fix` sorted it.
-# 04:24
-
-## Phase 1 Scaffold: append operation for EditFile/PreviewEdit
-
-**Where append lives:** The `append` parameter goes on `PreviewEditInputSchema`, not `EditFileInputSchema`. The mission says "EditFile input schema" but tests 4 and 5 check mutual exclusion with `lineEdits` and `textEdits`, which only exist on `PreviewEditInputSchema`. The append-via-PreviewEdit approach means the append goes through the same diff/stage/apply flow as all other edits.
-
-**Stub strategy:** `if (input.append != null) throw new Error('not implemented')` is the first check in the handler, before any file I/O. This makes tests 1-3 fail because the await throws. Tests 4-5 use `.rejects.toThrow('append')` so the 'not implemented' message doesn't match. Test 6 uses `.rejects.toThrow('ENOENT')` so same mismatch. All 6 fail as required.
-
-**Schema refine:** Updated from `lineEdits.length > 0 || textEdits.length > 0` to also allow `append != null`. Without this, `call(previewEdit, { file, append: '...' })` would throw a Zod validation error before reaching the handler.
-
-**Test file:** `EditFile-append.spec.ts` in `test/`. Imports and patterns match `EditFile.spec.ts` exactly. One `expect` per `it`. Uses `expected`/`actual` variables throughout.
-
-**For the builder:** Implement in `EditFile.ts` handler. After the `if (input.append != null)` guard, read the file, concatenate, generate diff, store patch. Add the mutual exclusion check before the not-implemented throw (or replace it). The error message should contain the word 'append' for tests 4-5. The file must exist for test 6 to produce ENOENT naturally (read the file before writing). No changes to the test file should be needed.
-
-# 04:34
-
-## Phase 2 Build: append operation
-
-**What was implemented:** Replaced the `not implemented` stub in the `PreviewEdit` handler with the full append logic. The implementation is in the `if (input.append != null)` guard that was already in place.
-
-**Mutual exclusion check:** `lineEdits.length > 0` and `textEdits.length > 0` are checked before any I/O. Both error messages contain 'append', satisfying the `.rejects.toThrow('append')` assertions in tests 4 and 5.
-
-**ENOENT path:** The append branch calls `fs.readFile(filePath)` before writing, which throws ENOENT naturally from `MemoryFileSystem` when the file doesn't exist. Test 6 passes without any explicit error handling.
-
-**Concatenation:** `newContent = baseContent + input.append`. Simple and correct for all cases (existing content, empty file).
-
-**No test changes needed:** The scaffold tests were written with the right expectations. The error messages ('append is mutually exclusive with lineEdits/textEdits') contain 'append'. The ENOENT propagates naturally. All 6 new tests pass.
-
-**CI:** 248 tests pass, type-check passes, biome lint passes.
-
-**For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
-
-# 07:06
-
-## Mission: #289 approval flash
-
-Flash `[Y/N]` with inverted colours (~1-2 Hz) when there's a pending tool approval.
-
-## Key finding: no interval existed
-
-The plan assumed `AppLayout` already had a `setInterval` render loop. It does not. Renders are event-driven: every `render()` call is triggered by something concrete (key press, streaming text, resize, etc.). When waiting for Y/N input, nothing drives periodic re-renders.
-
-To make the flash work, I added `#startFlash()` / `#stopFlash()` methods in `AppLayout` that manage a 500ms `setInterval`. At 500ms per toggle, `flashPhase` alternates true/false every 500ms, giving one full visual cycle per second (1 Hz).
-
-## What changed
-
-**`ToolApprovalState`**: added `#flashPhase = false`, `flashPhase` getter, `toggleFlash()` method. No automatic reset on resolve — the timer stops externally, so the phase value at stop time is irrelevant (render only applies inversion when `hasPendingApprovals` is true).
-
-**`renderToolApproval`**: when `hasPendingApprovals`, picks `\x1b[7m[Y/N]\x1b[27m` (reversed) or `[Y/N]` (normal) based on `state.flashPhase`.
-
-**`AppLayout`**: added `#flashInterval` field, `#startFlash()` (idempotent, called from `requestApproval()`), `#stopFlash()` (called from `exit()`, `completeStreaming()`, and after Y/N when the approval queue empties).
-
-## Flash rate
-
-500ms interval = 1 Hz visual flash. The plan asked for ~1-2 Hz so this is in range. The SC can adjust the 500ms constant if they want faster.
-
-## Files staged
-
-- `apps/claude-sdk-cli/src/model/ToolApprovalState.ts`
-- `apps/claude-sdk-cli/src/view/renderToolApproval.ts`
-- `apps/claude-sdk-cli/src/AppLayout.ts`
-
-All pass: `pnpm type-check`, `pnpm build`, `pnpm run ci`.
-
-Proposed commit: `Flash [Y/N] approval prompt with inverted colours`
-
-
-## Correction: entire row flashes, not just [Y/N]
-
-The original prompt specified flashing only the `[Y/N]` text. The SC corrected this after seeing it running: the entire approval row should invert, not just the label. A flashing label inside a static line is harder to catch in peripheral vision; a flashing full row is the point.
-
-`renderToolApproval` was updated: the row string is built first without any ANSI, then wrapped in `\x1b[7m`...`\x1b[27m` as a unit when `hasPendingApprovals && flashPhase`. The `[Y/N]` label itself is unchanged — plain text, the inversion comes from the row wrapper.
+The preflight script checks local main vs origin/main, not the current feature branch vs origin/main. It will not catch "your branch is behind main." Check manually or merge origin/main before pushing.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -1,43 +1,208 @@
-# Approval flash (#289)
+# Status bar cwd — what matters
 
-## No existing render interval
+## IFileSystem is not optional
 
-The plan assumed `AppLayout` already had a `setInterval` driving periodic re-renders. It does not. The render loop is entirely event-driven: every `render()` call is triggered by a concrete event (keypress, streaming text, resize). When waiting for Y/N, nothing drives periodic re-renders.
+Do not call `path.basename(process.cwd())` or `process.cwd()` directly in renderers or state classes. The codebase has `IFileSystem` with a `cwd()` method. Everything that needs the cwd goes through it: `ClaudeMdLoader`, `AuditWriter`, `ConversationSession`, and now `StatusState`.
 
-The fix: `#startFlash()` / `#stopFlash()` in `AppLayout` manage a 500ms `setInterval`. The interval calls `toggleFlash()` on `ToolApprovalState` and then re-renders. At 500ms per toggle, `flashPhase` alternates every 500ms: one full visual cycle per second (1 Hz). This is within the ~1-2 Hz target.
+The pattern: take `IFileSystem` in the constructor, call `path.basename(fs.cwd())` once, store the result. The renderer reads the stored string. No direct `path` or `process` calls outside the constructor.
 
-## Scope: full row, not just [Y/N]
+In `main.ts`, pass `nodeFs`. In tests, use `MemoryFileSystem({}, '/home/user', '/repos/my-project')` to get a deterministic basename of `my-project`.
 
-The prompt said to flash only the `[Y/N]` text. After seeing it running, the SC corrected this: the entire approval row should invert. A flashing label inside a static line is harder to catch in peripheral vision; a full-row flash is the point.
+## Layout
 
-Implementation: build the row string without ANSI, then wrap it in `\x1b[7m`...`\x1b[27m` when `hasPendingApprovals && state.flashPhase`. The `[Y/N]` label itself is plain text; the inversion comes from the row wrapper.
+The model line shows `⚡ <model>  <cwd-basename>`. When no model is set yet, it shows just the basename. The separator between model and basename is two spaces.
 
-## Where flash state lives
+## Earlier work in the same file (not this issue)
 
-`ToolApprovalState` owns `#flashPhase` (boolean, starts false). `toggleFlash()` flips it. There is no automatic reset when approvals resolve: the timer stops externally, and `renderToolApproval` only applies inversion when `hasPendingApprovals` is true, so the phase value at stop time is irrelevant.
+The first two entries in today's testament cover unrelated work (`feature/advanced-tool-use` cleaner phase, `input_examples` gating, `mcp-exec` PATH). They are still relevant if you are tracing those decisions:
+- `BetaTextBlock.citations` became required in `@anthropic-ai/sdk@0.82.0`; `citations: null` satisfies it
+- `buildAtuTransform` always returns a function; when ATU is off it strips `input_examples` from wire tools
+- `cli.spec.ts` resolves `tsx` to an absolute path because the VS Code vitest extension doesn't inherit `node_modules/.bin` on PATH
 
-`#startFlash()` is idempotent (no-ops if interval already running). Called from `requestApproval()`. `#stopFlash()` clears the interval and is called from `exit()`, `completeStreaming()`, and after Y/N when the approval queue empties.
+**Why gate it:** `input_examples` are only meaningful in ATU mode. Sending them when ATU is off is wasteful and exposes implementation detail to the API unnecessarily.
 
-## Files changed
+**Where it belongs:** CLI concern, not SDK concern. The SDK defines the shape (`toWireTool` always includes `input_examples`). The CLI's `transformTool` hook decides what reaches the wire. `buildRequestParams` should not contain logic about `input_examples`.
 
-- `apps/claude-sdk-cli/src/model/ToolApprovalState.ts` (flashPhase getter + toggleFlash)
-- `apps/claude-sdk-cli/src/view/renderToolApproval.ts` (full-row inversion)
-- `apps/claude-sdk-cli/src/AppLayout.ts` (#flashInterval, #startFlash, #stopFlash)
+**Decision:** `buildAtuTransform` now always returns a function. When ATU is disabled the function strips `input_examples` using the same type guard pattern (`isToolWithInputExamples`) already used for `isNamedTool` in the file. No `as unknown as` anywhere.
 
----
+## mcp-exec cli.spec.ts PATH issue
 
-# Earlier work on 2026-04-20 (unrelated to this issue)
+`test/cli.spec.ts` spawns `tsx` by name via `StdioClientTransport`. Works under `pnpm test` because `node_modules/.bin` is on PATH. Fails in VS Code vitest extension which doesn't inherit that PATH. Pre-existing, unrelated to this work. Fix: resolve `tsx` to an absolute path via `path.join(packageRoot, '../../node_modules/.bin/tsx')`.
 
-The top section of today's testament before this rewrite covered several unrelated casts. Key points preserved below for traceability.
 
-## IFileSystem and StatusState
+# 04:28
 
-`StatusState` takes `IFileSystem` in its constructor; calls `path.basename(fs.cwd())` once and stores the result. Tests use `new MemoryFileSystem({}, '/home/user', '/repos/my-project')`. Making `fs` optional with a `process.cwd()` fallback was tried and reverted by the SC.
+## Mission
 
-## ci:fix reverts reflow.ts
+Add `--file` flag to the CLI. When provided, the file is attached as the first message and submitted automatically. Session resume is skipped (fresh start).
 
-Running `pnpm ci:fix` converts `new RegExp('...', 'g')` back to a regex literal in `reflow.ts`, re-triggering `noControlCharactersInRegex`. Restore manually after every `ci:fix` run. Pre-existing; do not stage `reflow.ts` unless intentional.
+## What I built
 
-## Preflight branch-vs-origin gap
+Two files changed:
 
-The preflight script checks local main vs origin/main, not the current feature branch vs origin/main. It will not catch "your branch is behind main." Check manually or merge origin/main before pushing.
+**`ConversationSession.ts`**: Added `startFresh()` method. Generates a new UUID and writes it to the marker file (`.claude/.sdk-conversation-id`), without loading or saving any existing history. This is distinct from `createNew()` which saves the current conversation before resetting, and `load()` which reads an existing marker. `startFresh()` is safe to call at startup before any history exists.
+
+**`main.ts`**: Four changes:
+1. Added `file: { type: 'string' }` to `parseArgs` options.
+2. Resolved the flag value to an absolute path at module top level (after the early-exit checks), using `typeof values.file === 'string'` as the guard. `strict: false` in `parseArgs` widens option values to `string | boolean`, so `!= null` is not sufficient as a type guard for `.replace()`.
+3. In `main()`, the session is initialized via `startFresh()` when `--file` is present, `load()` otherwise.
+4. In the main loop, `pendingFile` holds the path for the first iteration. When set, the file is stat'd and a `UserInput` is built directly using `buildSubmitText` with a `FileAttachment`. `waitForInput()` is skipped for that iteration only.
+
+## Design notes
+
+Skipping `waitForInput()` for the first iteration is safe because `AppLayout` starts in `'editor'` mode by default, and `startStreaming()` (called by `runAgent`) handles the transition unconditionally. After `completeStreaming()` returns, the layout is back in a clean editor state and the next `waitForInput()` call works normally.
+
+The `buildSubmitText` + inline `FileAttachment` approach mirrors exactly what the `f` key does in command mode (via `CommandModeState.addFile` then `takeAttachments`), just without going through the `CommandModeState` state machine since there is no user interaction to manage.
+
+## Gotcha: biome formatting
+
+Biome has a strong opinion about where ternary line breaks go. A multi-line `const x =\n  condition ? a : b` form triggers a formatting error; biome reformats it to a single line if it fits. Ran `pnpm ci:fix` twice to let it settle.
+
+## Pre-existing CI failure
+
+`packages/claude-core/src/reflow.ts:123` fails `noControlCharactersInRegex`. Present before my changes.
+
+
+## IFileSystem abstraction leak — needs a sweep
+
+`IFileSystem.stat()` returns `StatResult = { size: number }` only — no `isDirectory`. As a result, two files in `apps/claude-sdk-cli/src/` import `stat` from `node:fs/promises` directly instead of going through `nodeFs`:
+
+- `AppLayout.ts` — uses `stat` to distinguish file vs directory when attaching via the `f` key
+- `entry/main.ts` — `buildFileInput` does the same for `--file`
+
+The `IFileSystem` abstraction exists precisely so filesystem calls can be injected and tested. These direct imports bypass it. SC noted this is a broader issue to fix across the board. The fix is to extend `StatResult` to include `isDirectory: boolean`, update `NodeFileSystem.stat()` to populate it, then replace both direct `stat` imports with `nodeFs.stat()`.
+
+# 04:26
+
+## Fix #285 — EditFile rejects tilde paths
+
+**The actual bug location:** Only `ConfirmEditFile.ts` needed the fix. `EditFile.ts` (the `PreviewEdit` handler) already called `expandPath(input.file, fs)` at the top, so `chained.file` is always stored as an absolute path. The broken comparison was only on the input side of `ConfirmEditFile.ts`.
+
+**The `previousPatchId` path in `EditFile.ts`** (`prev.file !== filePath`) was already comparing two expanded values. Adding `expandPath(prev.file, fs)` there is a no-op by construction. Worth doing for explicitness.
+
+**`fs` was already in scope:** `createEditFile` already takes `IFileSystem` as a parameter. The plan said "thread it through from `createEditFilePair`" but nothing needed threading.
+
+**Store architecture:** The shared `store: Map<string, PreviewEditOutputType>` is keyed by `patchId` UUID. The `file` field in stored values is always an expanded absolute path (PreviewEdit guarantees this). Only the input side of the apply step ever receives a raw tilde path.
+
+# 03:36
+
+## find-symlinks: symlink following with cycle detection
+
+**The traversal ordering surprise.** `visited` is keyed on `realpath`, not the path passed to `walk`. When `dir-link` (a symlink to `real-dir`) is alphabetically sorted before `real-dir`, following the symlink resolves to `real-dir`'s real path and adds it to `visited`. When `real-dir` is reached directly, it's already visited and returns empty. Result: `dir-link/inner.txt` appears in results; `real-dir/inner.txt` does not. The tests assert by the symlinked path, so this is correct behaviour, not a bug.
+
+**`followSymlinks: false` only gates directory recursion.** The option controls whether symlinked directories are entered, not whether symlinks appear in results at all. Symlinked files are always returned. A previous version gated the entire symlink block, making symlinks invisible when `followSymlinks: false`. The correct boundary: only the `walk()` call inside the directory branch is conditional.
+
+**`ci:fix` has a reach problem.** Running `pnpm ci:fix` to fix formatting in `find-symlinks.spec.ts` also modified `reflow.ts` (reverted a `new RegExp(...)` lint workaround back to a literal, which re-triggers a lint error). That change has to be manually restored after every `ci:fix` run. `Find.ts` and `Find.spec.ts` changes (removing unnecessary `\\` in `'\\.ts$'` patterns) are legitimate and safe to stage.
+
+**Don't cast on suspicion.** Phase 1 added `as { type: 'files'; values: string[] }` casts throughout the tests before checking whether the compiler actually needed them. It didn't. The types flow correctly through `call()`. Rule: write the code, run TsDiagnostics, cast only when the compiler complains.
+
+**The output metadata gap is a separate problem.** This PR adds symlink traversal. It does not (and cannot without a breaking schema change) expose whether a returned path is a symlink. The `{ type: 'files', values: string[] }` pipe format carries no per-path metadata. `returnSymlinks` as a filter, or type-annotation on entries, requires changing the element type in `values` -- a breaking change that touches every downstream consumer (Grep, SearchFiles, DeleteFile, DeleteDirectory). That work is not here.
+
+
+# 04:00
+
+## Phase 3: IFileSystem abstraction refactor
+
+**The circular import non-problem.** `IFileSystem.ts` imports from `walk.ts`, and `walk.ts` imports types from `IFileSystem.ts`. This looks like a circular dependency but isn't at runtime. `walk.ts` uses `import type { ... }` — type-only imports are erased at compile time. The runtime module graph has no cycle. This is a well-known TypeScript pattern. Don't avoid it by duplicating type definitions.
+
+**`find` moved from abstract to concrete on `IFileSystem`.** Both `NodeFileSystem` and `MemoryFileSystem` had identical one-liner `find` methods calling `walk`. Making it concrete on the base class removes that duplication. Subclasses now only implement the primitives: `readdir`, `realpath`, `stat`.
+
+**`MemoryFileSystem.readdir` derives directory contents from the flat file Map.** Directories are implicit — a file at `/a/b/c` implies `/a/b` is a directory. `readdir('/a')` scans the Map, takes the first path component under `/a/`, and classifies it as file (1 component) or directory (multiple). Nothing is a symlink in MemoryFS, so `isSymbolicLink` always returns false.
+
+**`ci:fix` reverts `reflow.ts` — restore it manually.** Every time `pnpm ci:fix` runs, biome converts `new RegExp('...', 'g')` back to a literal, which re-triggers the `noControlCharactersInRegex` lint error. The revert is a one-liner. This is a pre-existing pattern documented by the previous operator — do not stage `reflow.ts` unless you need to; restore it before committing.
+
+**Mock design: alphabetical readdir ordering matters.** `walk` uses `realpath` for cycle detection: the first call to walk a path adds its realpath to `visited`. If `dir-link` (→ `real-dir`) is processed before `real-dir` in readdir order, then `dir-link/inner.txt` appears in results and `real-dir` returns empty (already visited). If the order were reversed, `real-dir/inner.txt` would appear and `dir-link` would return empty. Tests assert by the symlink path, so the mock must return entries in alphabetical order to make the assertions correct. This is intentional and documented in the mock's JSDoc comment.
+
+**`stat` in MemoryFS: always `isFile: true`.** Directories are implicit and have no stat entry in the Map. `stat('/src')` would throw ENOENT. That's acceptable because `walk` only calls `stat` on symlink entries, and MemoryFS has no symlinks. No test exercises `stat` on a MemoryFS directory.
+
+
+# 04:40
+
+## Preflight does not check branch-vs-origin/main
+
+`default_divergence` in the preflight output compares *local main* against *origin/main*. This is useless: after `git fetch`, `origin/main` is current, so the only thing it detects is whether you have run `git pull` on your local main checkout. SC flagged this as a regression from a previous version.
+
+The check that actually matters is missing: is the current feature branch behind `origin/main`? It isn't checked at all. The Maker's testament for this cast noted the branch was one commit behind main; there was no mechanism to act on it.
+
+A second commit landed on main between Phase 1 and Phase 2, so even a correct preflight in Phase 1 wouldn't have been enough. The Courier also needs to check and merge (or rebase) before pushing.
+
+
+# 05:46
+
+## Phase 3: StatusState constructor — update tests, not the constructor
+
+**The failure.** Phase 1 changed `StatusState` constructor from no-arg to `constructor(fs: IFileSystem)`. All existing tests called `new StatusState()` with no argument. CI failed on type-check with TS2554 (expected 1 argument, got 0).
+
+**Wrong fix: making `fs` optional.** My first instinct was to make the parameter optional with a `process.cwd()` fallback. The SC reverted this. The correct approach is below.
+
+**Correct fix: update the tests.** The tests should pass `MemoryFileSystem` to construct `StatusState`, not work around the constructor. The Phase 1 testament even documented this: "In tests, use `MemoryFileSystem({}, '/home/user', '/repos/my-project')`". I had the information and used the wrong fix anyway.
+
+`StatusState.spec.ts` now has a `makeState()` factory using `testFs = new MemoryFileSystem({}, '/home/user', '/repos/my-project')`. `AgentMessageHandler.spec.ts` passes `new MemoryFileSystem({}, '/home/user', '/test')` at each call site.
+
+**`turbo.json` `outputLogs` added.** `build: "new-only"`, `test: "errors-only"`, `type-check: "errors-only"`. On cache hits, turbo now suppresses replayed logs entirely. Makes the verify output much less noisy.
+
+**`pnpm ci:fix` reverted `reflow.ts` again.** Same problem documented above. Restored manually. This is now three operators in a row.
+
+**Import ordering in `renderStatus.spec.ts`.** `@shellicar/claude-sdk-tools/fs` before `vitest` is what biome wants. `ci:fix` sorted it.
+
+# 04:24
+
+## Phase 1 Scaffold: append operation for EditFile/PreviewEdit
+
+**Where append lives:** The `append` parameter goes on `PreviewEditInputSchema`, not `EditFileInputSchema`. The mission says "EditFile input schema" but tests 4 and 5 check mutual exclusion with `lineEdits` and `textEdits`, which only exist on `PreviewEditInputSchema`. The append-via-PreviewEdit approach means the append goes through the same diff/stage/apply flow as all other edits.
+
+**Stub strategy:** `if (input.append != null) throw new Error('not implemented')` is the first check in the handler, before any file I/O. This makes tests 1-3 fail because the await throws. Tests 4-5 use `.rejects.toThrow('append')` so the 'not implemented' message doesn't match. Test 6 uses `.rejects.toThrow('ENOENT')` so same mismatch. All 6 fail as required.
+
+**Schema refine:** Updated from `lineEdits.length > 0 || textEdits.length > 0` to also allow `append != null`. Without this, `call(previewEdit, { file, append: '...' })` would throw a Zod validation error before reaching the handler.
+
+**Test file:** `EditFile-append.spec.ts` in `test/`. Imports and patterns match `EditFile.spec.ts` exactly. One `expect` per `it`. Uses `expected`/`actual` variables throughout.
+
+**For the builder:** Implement in `EditFile.ts` handler. After the `if (input.append != null)` guard, read the file, concatenate, generate diff, store patch. Add the mutual exclusion check before the not-implemented throw (or replace it). The error message should contain the word 'append' for tests 4-5. The file must exist for test 6 to produce ENOENT naturally (read the file before writing). No changes to the test file should be needed.
+
+# 04:34
+
+## Phase 2 Build: append operation
+
+**What was implemented:** Replaced the `not implemented` stub in the `PreviewEdit` handler with the full append logic. The implementation is in the `if (input.append != null)` guard that was already in place.
+
+**Mutual exclusion check:** `lineEdits.length > 0` and `textEdits.length > 0` are checked before any I/O. Both error messages contain 'append', satisfying the `.rejects.toThrow('append')` assertions in tests 4 and 5.
+
+**ENOENT path:** The append branch calls `fs.readFile(filePath)` before writing, which throws ENOENT naturally from `MemoryFileSystem` when the file doesn't exist. Test 6 passes without any explicit error handling.
+
+**Concatenation:** `newContent = baseContent + input.append`. Simple and correct for all cases (existing content, empty file).
+
+**No test changes needed:** The scaffold tests were written with the right expectations. The error messages ('append is mutually exclusive with lineEdits/textEdits') contain 'append'. The ENOENT propagates naturally. All 6 new tests pass.
+
+**CI:** 248 tests pass, type-check passes, biome lint passes.
+
+**For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
+
+# 07:06
+
+## Mission: #289 approval flash
+
+Flash `[Y/N]` with inverted colours (~1-2 Hz) when there's a pending tool approval.
+
+## Key finding: no interval existed
+
+The plan assumed `AppLayout` already had a `setInterval` render loop. It does not. Renders are event-driven: every `render()` call is triggered by something concrete (key press, streaming text, resize, etc.). When waiting for Y/N input, nothing drives periodic re-renders.
+
+To make the flash work, I added `#startFlash()` / `#stopFlash()` methods in `AppLayout` that manage a 500ms `setInterval`. At 500ms per toggle, `flashPhase` alternates true/false every 500ms, giving one full visual cycle per second (1 Hz).
+
+## What changed
+
+**`ToolApprovalState`**: added `#flashPhase = false`, `flashPhase` getter, `toggleFlash()` method. No automatic reset on resolve — the timer stops externally, so the phase value at stop time is irrelevant (render only applies inversion when `hasPendingApprovals` is true).
+
+**`renderToolApproval`**: when `hasPendingApprovals`, picks `\x1b[7m[Y/N]\x1b[27m` (reversed) or `[Y/N]` (normal) based on `state.flashPhase`.
+
+**`AppLayout`**: added `#flashInterval` field, `#startFlash()` (idempotent, called from `requestApproval()`), `#stopFlash()` (called from `exit()`, `completeStreaming()`, and after Y/N when the approval queue empties).
+
+## Flash rate
+
+500ms interval = 1 Hz visual flash. The plan asked for ~1-2 Hz so this is in range. The SC can adjust the 500ms constant if they want faster.
+
+## Correction: entire row flashes, not just [Y/N]
+
+The original prompt specified flashing only the `[Y/N]` text. The SC corrected this after seeing it running: the entire approval row should invert, not just the label. A flashing label inside a static line is harder to catch in peripheral vision; a flashing full row is the point.
+
+`renderToolApproval` was updated: the row string is built first without any ANSI, then wrapped in `\x1b[7m`...`\x1b[27m` as a unit when `hasPendingApprovals && flashPhase`. The `[Y/N]` label itself is unchanged — plain text, the inversion comes from the row wrapper.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -172,3 +172,44 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **CI:** 248 tests pass, type-check passes, biome lint passes.
 
 **For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
+
+# 07:06
+
+## Mission: #289 approval flash
+
+Flash `[Y/N]` with inverted colours (~1-2 Hz) when there's a pending tool approval.
+
+## Key finding: no interval existed
+
+The plan assumed `AppLayout` already had a `setInterval` render loop. It does not. Renders are event-driven: every `render()` call is triggered by something concrete (key press, streaming text, resize, etc.). When waiting for Y/N input, nothing drives periodic re-renders.
+
+To make the flash work, I added `#startFlash()` / `#stopFlash()` methods in `AppLayout` that manage a 500ms `setInterval`. At 500ms per toggle, `flashPhase` alternates true/false every 500ms, giving one full visual cycle per second (1 Hz).
+
+## What changed
+
+**`ToolApprovalState`**: added `#flashPhase = false`, `flashPhase` getter, `toggleFlash()` method. No automatic reset on resolve — the timer stops externally, so the phase value at stop time is irrelevant (render only applies inversion when `hasPendingApprovals` is true).
+
+**`renderToolApproval`**: when `hasPendingApprovals`, picks `\x1b[7m[Y/N]\x1b[27m` (reversed) or `[Y/N]` (normal) based on `state.flashPhase`.
+
+**`AppLayout`**: added `#flashInterval` field, `#startFlash()` (idempotent, called from `requestApproval()`), `#stopFlash()` (called from `exit()`, `completeStreaming()`, and after Y/N when the approval queue empties).
+
+## Flash rate
+
+500ms interval = 1 Hz visual flash. The plan asked for ~1-2 Hz so this is in range. The SC can adjust the 500ms constant if they want faster.
+
+## Files staged
+
+- `apps/claude-sdk-cli/src/model/ToolApprovalState.ts`
+- `apps/claude-sdk-cli/src/view/renderToolApproval.ts`
+- `apps/claude-sdk-cli/src/AppLayout.ts`
+
+All pass: `pnpm type-check`, `pnpm build`, `pnpm run ci`.
+
+Proposed commit: `Flash [Y/N] approval prompt with inverted colours`
+
+
+## Correction: entire row flashes, not just [Y/N]
+
+The original prompt specified flashing only the `[Y/N]` text. The SC corrected this after seeing it running: the entire approval row should invert, not just the label. A flashing label inside a static line is harder to catch in peripheral vision; a flashing full row is the point.
+
+`renderToolApproval` was updated: the row string is built first without any ANSI, then wrapped in `\x1b[7m`...`\x1b[27m` as a unit when `hasPendingApprovals && flashPhase`. The `[Y/N]` label itself is unchanged — plain text, the inversion comes from the row wrapper.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -15,3 +15,4 @@
 {"description":"Restore cursor visibility after exiting the CLI","category":"fixed","metadata":{"issue":277}}
 {"description":"Show working directory name in status bar","category":"added"}
 {"description":"Add --file flag to start with a file as the first message","category":"added"}
+{"description":"Flash tool approval prompt with inverted colours when awaiting Y/N","category":"added"}

--- a/apps/claude-sdk-cli/src/AppLayout.ts
+++ b/apps/claude-sdk-cli/src/AppLayout.ts
@@ -57,6 +57,7 @@ export class AppLayout implements Disposable {
 
   #editorResolve: ((value: UserInput) => void) | null = null;
   #cancelFn: (() => void) | null = null;
+  #flashInterval: ReturnType<typeof setInterval> | undefined;
 
   readonly #statusState: StatusState;
   readonly #session: ConversationSession;
@@ -99,6 +100,7 @@ export class AppLayout implements Disposable {
   public exit(): void {
     this.#cleanupResize();
     clearTimeout(this.#resizeTimer);
+    this.#stopFlash();
     this.#screen.write(showCursor);
     this.#screen.exitAltBuffer();
   }
@@ -136,6 +138,7 @@ export class AppLayout implements Disposable {
   public completeStreaming(): void {
     this.#conversationState.completeActive();
     this.#toolApprovalState.clearTools();
+    this.#stopFlash();
     this.#mode = 'editor';
     this.#commandModeState.reset();
     this.#editorState.reset();
@@ -199,8 +202,28 @@ export class AppLayout implements Disposable {
    */
   public requestApproval(): Promise<boolean> {
     const promise = this.#toolApprovalState.requestApproval();
+    this.#startFlash();
     this.render();
     return promise;
+  }
+
+  /** Start the flash timer that toggles the approval indicator at ~1 Hz. No-op if already running. */
+  #startFlash(): void {
+    if (this.#flashInterval !== undefined) {
+      return;
+    }
+    this.#flashInterval = setInterval(() => {
+      this.#toolApprovalState.toggleFlash();
+      this.render();
+    }, 500);
+  }
+
+  /** Stop the flash timer and clear it. */
+  #stopFlash(): void {
+    if (this.#flashInterval !== undefined) {
+      clearInterval(this.#flashInterval);
+      this.#flashInterval = undefined;
+    }
   }
 
   /** Debounced render for key events — batches rapid input (paste) into one repaint. */
@@ -243,6 +266,9 @@ export class AppLayout implements Disposable {
       const ch = key.value.toUpperCase();
       if (ch === 'Y' || ch === 'N') {
         this.#toolApprovalState.resolveNextApproval(ch === 'Y');
+        if (!this.#toolApprovalState.hasPendingApprovals) {
+          this.#stopFlash();
+        }
         this.render();
         return;
       }

--- a/apps/claude-sdk-cli/src/model/ToolApprovalState.ts
+++ b/apps/claude-sdk-cli/src/model/ToolApprovalState.ts
@@ -17,6 +17,7 @@ export class ToolApprovalState {
   #selectedTool = 0;
   #toolExpanded = false;
   #pendingApprovals: Array<(approved: boolean) => void> = [];
+  #flashPhase = false;
 
   public get pendingTools(): ReadonlyArray<PendingTool> {
     return this.#pendingTools;
@@ -36,6 +37,10 @@ export class ToolApprovalState {
 
   public get hasPendingApprovals(): boolean {
     return this.#pendingApprovals.length > 0;
+  }
+
+  public get flashPhase(): boolean {
+    return this.#flashPhase;
   }
 
   /** Add a tool to the pending list. First tool resets selection to 0. */
@@ -83,6 +88,11 @@ export class ToolApprovalState {
     }
     resolve(approved);
     return true;
+  }
+
+  /** Toggle the flash phase for the pending approval indicator. Called by the flash timer. */
+  public toggleFlash(): void {
+    this.#flashPhase = !this.#flashPhase;
   }
 
   /** Toggle the expanded/collapsed state of the selected tool's input. */

--- a/apps/claude-sdk-cli/src/view/renderToolApproval.ts
+++ b/apps/claude-sdk-cli/src/view/renderToolApproval.ts
@@ -31,7 +31,8 @@ export function renderToolApproval(state: ToolApprovalState, cols: number, maxRo
     const prefix = state.hasPendingApprovals ? 'Allow ' : '';
     const approval = state.hasPendingApprovals ? '  [Y/N]' : '';
     const expand = state.toolExpanded ? ' [space: collapse]' : ' [space: expand]';
-    approvalRow = ` ${prefix}Tool: ${tool.name}${nav}${approval}${expand}`;
+    const row = ` ${prefix}Tool: ${tool.name}${nav}${approval}${expand}`;
+    approvalRow = state.hasPendingApprovals && state.flashPhase ? `\x1b[7m${row}\x1b[27m` : row;
   }
 
   // --- expanded rows ---


### PR DESCRIPTION
## Summary

- Flash the entire approval row with inverted colours while awaiting Y/N
- Toggle runs at 1 Hz via a 500ms interval started when approval is requested
- Interval is idempotent: started on each `requestApproval`, stopped on resolve, streaming complete, or exit

Closes #289