### PR TITLE
Write session ID marker on save, track session history

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -172,3 +172,24 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **CI:** 248 tests pass, type-check passes, biome lint passes.
 
 **For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
+
+# 07:05
+
+## Phase 1: move marker write to save()
+
+**The change:** Three places wrote the marker file (`.claude/.sdk-conversation-id`) immediately on UUID generation: `load()` (else branch), `startFresh()`, and `createNew()`. All three now only set `this.#id`. A new private method `#writeMarker()` does the write. `save()` calls it after writing the history file.
+
+**Why it matters:** Before this change, loading the app with no prior session would immediately overwrite the marker. If a prior valid session ID existed in the marker, it was clobbered before any message was sent. The marker should only exist when a real conversation does.
+
+**`createNew()` detail:** When `createNew()` is called, it calls `save()` first (to persist the old session). That save writes the marker with the old ID. Then the new UUID is set but not written. So after `createNew()` but before the next `save()`, the marker file holds the old ID. The test `does not write new ID to marker before save` asserts exactly this: reads the marker after `createNew()` and confirms it still contains the old ID.
+
+**`#writeMarker` visibility:** Private method using the TC39 `#` syntax, consistent with the private fields (`#id`, `#fs`, `#conversation`) already in the class.
+
+**Test structure:** The existing test suite uses `expected`/`actual` pattern throughout. Matched that. New tests added:
+- load describe: `does not write marker file on load when no marker exists`
+- createNew describe: `does not write new ID to marker before save`, `writes new ID to marker after save`
+- save describe: `writes marker file on save` (added before the existing `writes history that load can restore`)
+
+**`writes history that load can restore` still passes:** save() now writes marker + history. Second load() finds the marker, reads the history. The test is unchanged and passes.
+
+**Counts:** 9 ConversationSession tests, 465 total. All pass.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -209,3 +209,31 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **Third test (`history file contains IDs from multiple sessions`):** Calls `createNew()` between the two saves. `createNew()` internally calls `save()` for the first session, so after both explicit saves the history file has two entries. Confirmed both `firstId` and `secondId` are distinct (`createNew` generates a new UUID) and both are present.
 
 **Test count:** 12 ConversationSession tests (was 9). All pass.
+
+# 08:13
+
+## Session ID marker and history (issues #272, #273)
+
+### The marker write was in three places
+
+`load()` (else branch), `startFresh()`, and `createNew()` all wrote the marker immediately on UUID generation. All three now only set `this.#id`. A new `#writeMarker()` private method does the write. `save()` calls it before writing history.
+
+### createNew() writes the old ID before switching
+
+`createNew()` calls `save()` internally to persist the current conversation before generating a new UUID. After `createNew()` but before the next `save()`, the marker file holds the **old** ID. The test `does not write new ID to marker before save` asserts this: reads the marker after `createNew()` and confirms it still contains the old ID. This is correct and intentional.
+
+### History file uses appendFile, not writeFile
+
+`#appendToHistory()` uses `IFileSystem.appendFile`. `MemoryFileSystem.appendFile` handles the missing-file case with `?? ''` so no create-first step is needed. Using `writeFile` would truncate the file each time.
+
+### Duplicate check pattern
+
+Read the file (empty string if missing), split by newline, filter empty strings, check `includes(this.#id)`. Return early if already present. Otherwise append `${this.#id}\n`.
+
+### Third test: createNew() triggers save() internally
+
+The `history file contains IDs from multiple sessions` test calls `session.createNew()` between two explicit saves. Because `createNew()` calls `save()` internally, the first session's ID is written during `createNew()`, not during the second explicit `save()`. The test uses `firstId` and `secondId` (captured before `createNew()`) and confirms both are present in the history file.
+
+### pnpm ci:fix reverts reflow.ts
+
+Every run of `pnpm ci:fix` converts `new RegExp('...', 'g')` back to a literal in `reflow.ts`, re-triggering a pre-existing `noControlCharactersInRegex` lint error. Restore `reflow.ts` manually after every `ci:fix` run. Do not stage it.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -193,3 +193,19 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **`writes history that load can restore` still passes:** save() now writes marker + history. Second load() finds the marker, reads the history. The test is unchanged and passes.
 
 **Counts:** 9 ConversationSession tests, 465 total. All pass.
+
+# 07:19
+
+## Phase 2: session ID history file
+
+**The change:** Added `#appendToHistory()` private method to `ConversationSession`. Called from `save()` after `#writeMarker()`. Writes `this.#id\n` to `${homedir}/.claude/session-history` unless the ID is already present.
+
+**Duplicate check:** Reads the file (empty string if not found, via `exists` guard), splits by newline, filters empty lines, checks `ids.includes(this.#id)`. If already there, returns early. Otherwise calls `appendFile` with `${this.#id}\n`. Using `appendFile` rather than `writeFile` is correct: the file accumulates across sessions.
+
+**`appendFile` vs `writeFile`:** `IFileSystem.appendFile` already existed and `MemoryFileSystem` handles the missing-file case with `?? ''`. No need to create the file first.
+
+**HISTORY_FILE constant in tests:** Added at the top of the spec file alongside `MARKER_FILE`. Path: `${HOME}/.claude/session-history`. All three new tests use it.
+
+**Third test (`history file contains IDs from multiple sessions`):** Calls `createNew()` between the two saves. `createNew()` internally calls `save()` for the first session, so after both explicit saves the history file has two entries. Confirmed both `firstId` and `secondId` are distinct (`createNew` generates a new UUID) and both are present.
+
+**Test count:** 12 ConversationSession tests (was 9). All pass.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -15,3 +15,5 @@
 {"description":"Restore cursor visibility after exiting the CLI","category":"fixed","metadata":{"issue":277}}
 {"description":"Show working directory name in status bar","category":"added"}
 {"description":"Add --file flag to start with a file as the first message","category":"added"}
+{"description":"Write session ID marker on save instead of on creation","category":"changed"}
+{"description":"Maintain session ID history file at ~/.claude/session-history","category":"added"}

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -18,8 +18,6 @@ export class ConversationSession {
 
   public async startFresh(): Promise<void> {
     this.#id = randomUUID();
-    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
-    await this.#fs.writeFile(markerPath, this.#id);
   }
 
   public async load(): Promise<void> {
@@ -40,21 +38,24 @@ export class ConversationSession {
       }
     } else {
       this.#id = randomUUID();
-      await this.#fs.writeFile(markerPath, this.#id);
     }
+  }
+
+  async #writeMarker(): Promise<void> {
+    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
+    await this.#fs.writeFile(markerPath, this.#id);
   }
 
   public async save(): Promise<void> {
     const historyPath = `${this.#fs.homedir()}/.claude/conversations/${this.#id}.jsonl`;
     const content = this.#conversation.messages.map((msg) => JSON.stringify(msg)).join('\n');
     await this.#fs.writeFile(historyPath, content);
+    await this.#writeMarker();
   }
 
   public async createNew(): Promise<void> {
     await this.save();
     this.#id = randomUUID();
-    const markerPath = `${this.#fs.cwd()}/.claude/.sdk-conversation-id`;
-    await this.#fs.writeFile(markerPath, this.#id);
     this.#conversation.setHistory([]);
   }
 }

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -46,11 +46,25 @@ export class ConversationSession {
     await this.#fs.writeFile(markerPath, this.#id);
   }
 
+  async #appendToHistory(): Promise<void> {
+    const historyPath = `${this.#fs.homedir()}/.claude/session-history`;
+    const historyExists = await this.#fs.exists(historyPath);
+    if (historyExists) {
+      const content = await this.#fs.readFile(historyPath);
+      const ids = content.split('\n').filter((line) => line.length > 0);
+      if (ids.includes(this.#id)) {
+        return;
+      }
+    }
+    await this.#fs.appendFile(historyPath, `${this.#id}\n`);
+  }
+
   public async save(): Promise<void> {
     const historyPath = `${this.#fs.homedir()}/.claude/conversations/${this.#id}.jsonl`;
     const content = this.#conversation.messages.map((msg) => JSON.stringify(msg)).join('\n');
     await this.#fs.writeFile(historyPath, content);
     await this.#writeMarker();
+    await this.#appendToHistory();
   }
 
   public async createNew(): Promise<void> {

--- a/apps/claude-sdk-cli/test/ConversationSession.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSession.spec.ts
@@ -22,6 +22,16 @@ describe('ConversationSession — load', () => {
     expect(actual).toBe(expected);
   });
 
+  it('does not write marker file on load when no marker exists', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+
+    const expected = false;
+    const actual = await fs.exists(MARKER_FILE);
+    expect(actual).toBe(expected);
+  });
+
   it('restores the same ID from a previous run', async () => {
     const savedId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
     const fs = new MemoryFileSystem({ [MARKER_FILE]: savedId }, HOME, CWD);
@@ -51,6 +61,31 @@ describe('ConversationSession — createNew', () => {
     expect(actual).toBe(expected);
   });
 
+  it('does not write new ID to marker before save', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    const firstId = session.id;
+    await session.createNew();
+
+    // marker exists (written by save() for the old session), but still holds the old ID
+    const markerContent = await fs.readFile(MARKER_FILE);
+    expect(markerContent).toBe(firstId);
+    expect(session.id).not.toBe(firstId);
+  });
+
+  it('writes new ID to marker after save', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    await session.createNew();
+    await session.save();
+
+    const expected = session.id;
+    const actual = await fs.readFile(MARKER_FILE);
+    expect(actual).toBe(expected);
+  });
+
   it('clears the conversation', async () => {
     const fs = new MemoryFileSystem({}, HOME, CWD);
     const conversation = new Conversation();
@@ -70,6 +105,17 @@ describe('ConversationSession — createNew', () => {
 // ---------------------------------------------------------------------------
 
 describe('ConversationSession — save', () => {
+  it('writes marker file on save', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    await session.save();
+
+    const expected = true;
+    const actual = await fs.exists(MARKER_FILE);
+    expect(actual).toBe(expected);
+  });
+
   it('writes history that load can restore', async () => {
     const fs = new MemoryFileSystem({}, HOME, CWD);
     const conversation = new Conversation();

--- a/apps/claude-sdk-cli/test/ConversationSession.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSession.spec.ts
@@ -6,6 +6,7 @@ import { ConversationSession } from '../src/model/ConversationSession.js';
 const HOME = '/home/user';
 const CWD = '/project';
 const MARKER_FILE = `${CWD}/.claude/.sdk-conversation-id`;
+const HISTORY_FILE = `${HOME}/.claude/session-history`;
 
 // ---------------------------------------------------------------------------
 // load
@@ -131,5 +132,47 @@ describe('ConversationSession — save', () => {
     const expected = 1;
     const actual = restoredConversation.messages.length;
     expect(actual).toBe(expected);
+  });
+
+  it('save appends session ID to history file', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    await session.save();
+
+    const expected = `${session.id}\n`;
+    const actual = await fs.readFile(HISTORY_FILE);
+    expect(actual).toBe(expected);
+  });
+
+  it('save does not duplicate session ID in history file', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    await session.save();
+    await session.save();
+
+    const content = await fs.readFile(HISTORY_FILE);
+    const ids = content.split('\n').filter((line) => line.length > 0);
+    const expected = 1;
+    const actual = ids.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('history file contains IDs from multiple sessions', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+    const session = new ConversationSession(fs, new Conversation());
+    await session.load();
+    const firstId = session.id;
+    await session.save();
+    await session.createNew();
+    const secondId = session.id;
+    await session.save();
+
+    const content = await fs.readFile(HISTORY_FILE);
+    const ids = content.split('\n').filter((line) => line.length > 0);
+    expect(ids).toContain(firstId);
+    expect(ids).toContain(secondId);
+    expect(ids.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- Delay marker file write until first save (was written immediately on session creation)
- Add `~/.claude/session-history` file that accumulates session IDs across sessions

Closes #272
Closes #273