### PR TITLE
Add approval notification hook for tool approval prompts

### DIFF
--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -70,6 +70,7 @@ Biome has a strong opinion about where ternary line breaks go. A multi-line `con
 - `entry/main.ts` — `buildFileInput` does the same for `--file`
 
 The `IFileSystem` abstraction exists precisely so filesystem calls can be injected and tested. These direct imports bypass it. SC noted this is a broader issue to fix across the board. The fix is to extend `StatResult` to include `isDirectory: boolean`, update `NodeFileSystem.stat()` to populate it, then replace both direct `stat` imports with `nodeFs.stat()`.
+
 # 04:26
 
 ## Fix #285 — EditFile rejects tilde paths
@@ -81,6 +82,7 @@ The `IFileSystem` abstraction exists precisely so filesystem calls can be inject
 **`fs` was already in scope:** `createEditFile` already takes `IFileSystem` as a parameter. The plan said "thread it through from `createEditFilePair`" but nothing needed threading.
 
 **Store architecture:** The shared `store: Map<string, PreviewEditOutputType>` is keyed by `patchId` UUID. The `file` field in stored values is always an expanded absolute path (PreviewEdit guarantees this). Only the input side of the apply step ever receives a raw tilde path.
+
 # 03:36
 
 ## find-symlinks: symlink following with cycle detection
@@ -141,6 +143,7 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **`pnpm ci:fix` reverted `reflow.ts` again.** Same problem documented above. Restored manually. This is now three operators in a row.
 
 **Import ordering in `renderStatus.spec.ts`.** `@shellicar/claude-sdk-tools/fs` before `vitest` is what biome wants. `ci:fix` sorted it.
+
 # 04:24
 
 ## Phase 1 Scaffold: append operation for EditFile/PreviewEdit
@@ -173,47 +176,33 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 
 **For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
 
-# 07:09
+# 08:38
 
-## Phase 1 Scaffold: approval notification hook
+## Approval notification hook (#274)
 
-**Mission:** #274 — when a tool approval prompt appears and the user hasn't responded after a configurable delay, run a configurable external command. The approval request data is passed as a JSON string argument.
+### IProcessLauncher abstraction — the builder went further than the prompt
 
-**Schema placement:** Added `hooksSchema` at the bottom of `schema.ts`, just before `sdkConfigSchema`. Follows the same `.optional().default(...).catch(...)` triple pattern as every other sub-schema. The `approvalNotify` field inside is nullable/optional, defaulting to `null`. This means unconfigured = disabled, which is the right default for a feature that runs external commands.
+The prompt specified `vi.mock('node:child_process')` for tests. The builder instead introduced `IProcessLauncher` (abstract class in `src/model/`) + `NodeProcessLauncher` (concrete, wraps `spawn`), and injected it into `ApprovalNotifier`. Tests use concrete subclasses (`RecordingLauncher`, `ThrowingLauncher`) instead of module mocks.
 
-**Type export:** `ApprovalNotifyConfig` added to `types.ts` as `NonNullable<NonNullable<ResolvedSdkConfig['hooks']>['approvalNotify']>`. The Builder phase will use this as the constructor parameter type for `ApprovalNotifier`.
+This is strictly better: no hoisting surprises, no `vi.mocked()` casts, test doubles are explicit and self-documenting. `main.ts` creates `new NodeProcessLauncher()` and passes it to `ApprovalNotifier`. The constructor is `(config: ApprovalNotifyConfig | null, launcher: IProcessLauncher)`.
 
-**Stub:** `src/model/ApprovalNotifier.ts`. Constructor takes `ApprovalNotifyConfig | null`. Both `start` and `cancel` throw `new Error('not implemented')`. The private field `#config` is stored but unused (stub). The `_request` parameter in `start` has the underscore prefix to suppress unused-param lint.
+If you are wiring this from scratch: the notifier is created once in `main.ts` before `AgentMessageHandler`, passed as `notifier` in `AgentMessageHandlerOptions`.
 
-**Tests:** Use `vi.mock('node:child_process')` at module level (hoisted by vitest). `mockSpawn` is `vi.mocked(spawn)`. The `beforeEach` sets `vi.useFakeTimers()` and configures `mockSpawn.mockReturnValue({ unref: vi.fn() })`. The `afterEach` restores real timers and resets the mock. This mirrors what the Builder will implement: `spawn(command, [jsonArg], { detached: true, stdio: 'ignore' }).unref()`.
+### Schema two tests need updating when hooks is added
 
-**Existing test fixes — the two caught by CI:**
-1. `cli-config.spec.ts` "returns defaults for empty object": the `toEqual` assertion is a complete object snapshot. Adding `hooks` to the schema adds it to the snapshot too. Fixed by adding `hooks: { approvalNotify: null }`.
-2. `initConfig.spec.ts` "default config has all properties": the recursive `recurse()` function tries to unwrap object shapes and recurse into their values. It choked on `approvalNotify: null` — calling `expect(null).toHaveProperty(key)` triggers "Cannot convert undefined or null to object". Fixed by adding `&& obj[key] !== null` guard before recursing.
+Adding `hooks` to `sdkConfigSchema` breaks two existing tests:
 
-**JSON schema:** Regenerated automatically by `pnpm build` (via `build.ts` in `apps/claude-sdk-cli/`). The new `hooks`/`approvalNotify` properties appear in `schema/sdk-config.schema.json`.
+1. `cli-config.spec.ts` "returns defaults for empty object" — a `toEqual` snapshot of the full config object. Add `hooks: { approvalNotify: null }` to the expected value.
+2. `initConfig.spec.ts` "default config has all properties" — a recursive `recurse()` function iterates object shapes. It calls `expect(obj[key]).toHaveProperty(...)` which throws "Cannot convert undefined or null to object" when `obj[key]` is `null`. Fix: add `&& obj[key] !== null` guard before the recursive call.
 
-**For the Builder:** Implement `start` and `cancel` in `ApprovalNotifier.ts`. Wire the notifier into `AgentMessageHandler#toolApprovalRequest` — call `notifier.start(msg)` before awaiting `requestApproval()`, call `notifier.cancel()` after it resolves. Create the notifier instance from `config.hooks.approvalNotify` and pass it as a constructor parameter to `AgentMessageHandler`.
+### Wire location
 
-# 07:21
+`AgentMessageHandler#toolApprovalRequest`, `Ask` branch only. `notifier.start(msg)` before `await requestApproval()`, `notifier.cancel()` after. Not called for auto-approve or auto-deny paths.
 
-## Phase 2 Build: ApprovalNotifier implementation
+### Biome useBlockStatements
 
-**What was implemented:**
+`if (this.#config === null) return;` triggers an unsafe biome fix. Must be `if (this.#config === null) { return; }`. Write it correctly the first time; `ci:fix` won't fix unsafe rules.
 
-**`ApprovalNotifier.ts`**: Replaced both stubs. `start` stores a `setTimeout` handle; when it fires, calls `spawn(command, [JSON.stringify(request)], { detached: true, stdio: 'ignore' }).unref()` inside a try/catch (fire and forget). When config is null, returns early. `cancel` calls `clearTimeout` if the timer handle is set.
+### reflow.ts — still reverts on every ci:fix
 
-**`AgentMessageHandler.ts`**: Added `notifier: ApprovalNotifier` to `AgentMessageHandlerOptions`. Added `#notifier` private field stored from opts. In `#toolApprovalRequest`, in the `Ask` branch: `this.#notifier.start(msg)` before awaiting `requestApproval()`, `this.#notifier.cancel()` after it resolves. Notifier is not touched for auto-approve or auto-deny paths.
-
-**`main.ts`**: `const notifier = new ApprovalNotifier(watcher.config.hooks.approvalNotify)` created once before the handler, passed as `notifier` in `AgentMessageHandlerOptions`.
-
-**`AgentMessageHandler.spec.ts`**: Added `import { ApprovalNotifier }` and `notifier: new ApprovalNotifier(null)` to `makeOpts`. Existing tests were not modified otherwise.
-
-**Biome issues encountered:**
-1. Import ordering in `AgentMessageHandler.ts` and `AgentMessageHandler.spec.ts` — `ApprovalNotifier` import placed before `logger` import, biome wants alphabetical within the same `import type` group. Fixed by `pnpm ci:fix`.
-2. `useBlockStatements` in `ApprovalNotifier.ts` — the `if (this.#config === null) return;` form is flagged (unsafe fix). Fixed manually to `if (this.#config === null) { return; }`.
-3. `ci:fix` reverted `reflow.ts` again (same pre-existing pattern). Restored manually using the Edit tool.
-
-**Test count:** 466 (was 461 after phase 1 added 5, total now 466 — wait, 338 was the original baseline before the recent PR series; 461 was the phase 1 count including the 5 new scaffold tests). All pass.
-
-**For the Courier:** Four files staged. Proposed commit message: `implement ApprovalNotifier and wire into AgentMessageHandler`
+`packages/claude-core/src/reflow.ts:123` has a pre-existing `noControlCharactersInRegex` lint error. `pnpm ci:fix` converts the `new RegExp(...)` workaround back to a regex literal, re-triggering the error. Restore manually with the Edit tool after every `ci:fix` run. Do not stage `reflow.ts`.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -172,3 +172,25 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **CI:** 248 tests pass, type-check passes, biome lint passes.
 
 **For the Courier:** One file staged: `packages/claude-sdk-tools/src/EditFile/EditFile.ts`. Proposed commit message: `implement append operation for PreviewEdit`
+
+# 07:09
+
+## Phase 1 Scaffold: approval notification hook
+
+**Mission:** #274 — when a tool approval prompt appears and the user hasn't responded after a configurable delay, run a configurable external command. The approval request data is passed as a JSON string argument.
+
+**Schema placement:** Added `hooksSchema` at the bottom of `schema.ts`, just before `sdkConfigSchema`. Follows the same `.optional().default(...).catch(...)` triple pattern as every other sub-schema. The `approvalNotify` field inside is nullable/optional, defaulting to `null`. This means unconfigured = disabled, which is the right default for a feature that runs external commands.
+
+**Type export:** `ApprovalNotifyConfig` added to `types.ts` as `NonNullable<NonNullable<ResolvedSdkConfig['hooks']>['approvalNotify']>`. The Builder phase will use this as the constructor parameter type for `ApprovalNotifier`.
+
+**Stub:** `src/model/ApprovalNotifier.ts`. Constructor takes `ApprovalNotifyConfig | null`. Both `start` and `cancel` throw `new Error('not implemented')`. The private field `#config` is stored but unused (stub). The `_request` parameter in `start` has the underscore prefix to suppress unused-param lint.
+
+**Tests:** Use `vi.mock('node:child_process')` at module level (hoisted by vitest). `mockSpawn` is `vi.mocked(spawn)`. The `beforeEach` sets `vi.useFakeTimers()` and configures `mockSpawn.mockReturnValue({ unref: vi.fn() })`. The `afterEach` restores real timers and resets the mock. This mirrors what the Builder will implement: `spawn(command, [jsonArg], { detached: true, stdio: 'ignore' }).unref()`.
+
+**Existing test fixes — the two caught by CI:**
+1. `cli-config.spec.ts` "returns defaults for empty object": the `toEqual` assertion is a complete object snapshot. Adding `hooks` to the schema adds it to the snapshot too. Fixed by adding `hooks: { approvalNotify: null }`.
+2. `initConfig.spec.ts` "default config has all properties": the recursive `recurse()` function tries to unwrap object shapes and recurse into their values. It choked on `approvalNotify: null` — calling `expect(null).toHaveProperty(key)` triggers "Cannot convert undefined or null to object". Fixed by adding `&& obj[key] !== null` guard before recursing.
+
+**JSON schema:** Regenerated automatically by `pnpm build` (via `build.ts` in `apps/claude-sdk-cli/`). The new `hooks`/`approvalNotify` properties appear in `schema/sdk-config.schema.json`.
+
+**For the Builder:** Implement `start` and `cancel` in `ApprovalNotifier.ts`. Wire the notifier into `AgentMessageHandler#toolApprovalRequest` — call `notifier.start(msg)` before awaiting `requestApproval()`, call `notifier.cancel()` after it resolves. Create the notifier instance from `config.hooks.approvalNotify` and pass it as a constructor parameter to `AgentMessageHandler`.

--- a/.claude/testament/2026-04-20.md
+++ b/.claude/testament/2026-04-20.md
@@ -194,3 +194,26 @@ A second commit landed on main between Phase 1 and Phase 2, so even a correct pr
 **JSON schema:** Regenerated automatically by `pnpm build` (via `build.ts` in `apps/claude-sdk-cli/`). The new `hooks`/`approvalNotify` properties appear in `schema/sdk-config.schema.json`.
 
 **For the Builder:** Implement `start` and `cancel` in `ApprovalNotifier.ts`. Wire the notifier into `AgentMessageHandler#toolApprovalRequest` — call `notifier.start(msg)` before awaiting `requestApproval()`, call `notifier.cancel()` after it resolves. Create the notifier instance from `config.hooks.approvalNotify` and pass it as a constructor parameter to `AgentMessageHandler`.
+
+# 07:21
+
+## Phase 2 Build: ApprovalNotifier implementation
+
+**What was implemented:**
+
+**`ApprovalNotifier.ts`**: Replaced both stubs. `start` stores a `setTimeout` handle; when it fires, calls `spawn(command, [JSON.stringify(request)], { detached: true, stdio: 'ignore' }).unref()` inside a try/catch (fire and forget). When config is null, returns early. `cancel` calls `clearTimeout` if the timer handle is set.
+
+**`AgentMessageHandler.ts`**: Added `notifier: ApprovalNotifier` to `AgentMessageHandlerOptions`. Added `#notifier` private field stored from opts. In `#toolApprovalRequest`, in the `Ask` branch: `this.#notifier.start(msg)` before awaiting `requestApproval()`, `this.#notifier.cancel()` after it resolves. Notifier is not touched for auto-approve or auto-deny paths.
+
+**`main.ts`**: `const notifier = new ApprovalNotifier(watcher.config.hooks.approvalNotify)` created once before the handler, passed as `notifier` in `AgentMessageHandlerOptions`.
+
+**`AgentMessageHandler.spec.ts`**: Added `import { ApprovalNotifier }` and `notifier: new ApprovalNotifier(null)` to `makeOpts`. Existing tests were not modified otherwise.
+
+**Biome issues encountered:**
+1. Import ordering in `AgentMessageHandler.ts` and `AgentMessageHandler.spec.ts` — `ApprovalNotifier` import placed before `logger` import, biome wants alphabetical within the same `import type` group. Fixed by `pnpm ci:fix`.
+2. `useBlockStatements` in `ApprovalNotifier.ts` — the `if (this.#config === null) return;` form is flagged (unsafe fix). Fixed manually to `if (this.#config === null) { return; }`.
+3. `ci:fix` reverted `reflow.ts` again (same pre-existing pattern). Restored manually using the Edit tool.
+
+**Test count:** 466 (was 461 after phase 1 added 5, total now 466 — wait, 338 was the original baseline before the recent PR series; 461 was the phase 1 count including the 5 new scaffold tests). All pass.
+
+**For the Courier:** Four files staged. Proposed commit message: `implement ApprovalNotifier and wire into AgentMessageHandler`

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -15,3 +15,4 @@
 {"description":"Restore cursor visibility after exiting the CLI","category":"fixed","metadata":{"issue":277}}
 {"description":"Show working directory name in status bar","category":"added"}
 {"description":"Add --file flag to start with a file as the first message","category":"added"}
+{"description":"Add approval notification hook: run a command when tool approval is pending","category":"added"}

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -84,6 +84,22 @@ const serverToolsSchema = z
   })
   .describe('Server-side tool configuration');
 
+const hooksSchema = z
+  .object({
+    approvalNotify: z
+      .object({
+        command: z.string().describe('Command to run when approval is pending'),
+        delayMs: z.number().int().nonnegative().optional().default(0).catch(0).describe('Milliseconds to wait before running the command. 0 means immediate'),
+      })
+      .nullable()
+      .optional()
+      .default(null)
+      .catch(null),
+  })
+  .optional()
+  .default({ approvalNotify: null })
+  .catch({ approvalNotify: null });
+
 export const sdkConfigSchema = z
   .object({
     $schema: z.string().optional().describe('JSON Schema reference for editor autocomplete'),
@@ -93,5 +109,6 @@ export const sdkConfigSchema = z
     compact: compactSchema.describe('Compaction configuration'),
     advancedTools: advancedToolsSchema.describe('Advanced tool use configuration'),
     serverTools: serverToolsSchema,
+    hooks: hooksSchema.describe('Hook configuration'),
   })
   .meta({ title: 'Claude SDK CLI Configuration', description: 'Configuration for @shellicar/claude-sdk-cli' });

--- a/apps/claude-sdk-cli/src/cli-config/types.ts
+++ b/apps/claude-sdk-cli/src/cli-config/types.ts
@@ -3,3 +3,4 @@ import type { sdkConfigSchema } from './schema';
 
 export type ResolvedSdkConfig = Omit<z.infer<typeof sdkConfigSchema>, '$schema'>;
 export type HistoryReplayConfig = NonNullable<ResolvedSdkConfig['historyReplay']>;
+export type ApprovalNotifyConfig = NonNullable<NonNullable<ResolvedSdkConfig['hooks']>['approvalNotify']>;

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -4,6 +4,7 @@ import { CacheTtl, calculateCost, type DurableConfig, type SdkMessage, type SdkM
 import type { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
 import type { AppLayout } from '../AppLayout.js';
 import type { logger } from '../logger.js';
+import type { ApprovalNotifier } from '../model/ApprovalNotifier.js';
 import type { StatusState } from '../model/StatusState.js';
 import type { PendingTool } from '../model/ToolApprovalState.js';
 import { getPermission, PermissionAction } from '../permissions.js';
@@ -85,6 +86,7 @@ export interface AgentMessageHandlerOptions {
   cwd: string;
   store: RefStore;
   statusState: StatusState;
+  notifier: ApprovalNotifier;
 }
 
 // ---- class ---------------------------------------------------------------
@@ -107,6 +109,7 @@ export class AgentMessageHandler {
   #lastUsage: SdkMessageUsage | null = null;
   #usageBeforeTools: SdkMessageUsage | null = null;
   #statusState: StatusState;
+  #notifier: ApprovalNotifier;
 
   public constructor(layout: AppLayout, log: typeof logger, opts: AgentMessageHandlerOptions) {
     this.#layout = layout;
@@ -116,6 +119,7 @@ export class AgentMessageHandler {
     this.#cwd = opts.cwd;
     this.#store = opts.store;
     this.#statusState = opts.statusState;
+    this.#notifier = opts.notifier;
   }
 
   public handle(msg: SdkMessage): void {
@@ -228,7 +232,9 @@ export class AgentMessageHandler {
         this.#logger.info('Auto denying', { name: msg.name });
         approved = false;
       } else {
+        this.#notifier.start(msg);
         approved = await this.#layout.requestApproval();
+        this.#notifier.cancel();
       }
       this.#port.postMessage({ type: 'tool_approval_response', requestId: msg.requestId, approved });
       this.#layout.removePendingTool(msg.requestId);

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -17,8 +17,10 @@ import { createAppTools } from '../createAppTools.js';
 import { GitStateMonitor } from '../GitStateMonitor.js';
 import { printUsage, printVersion, printVersionInfo, startupBannerText } from '../help.js';
 import { logger } from '../logger.js';
+import { ApprovalNotifier } from '../model/ApprovalNotifier.js';
 import { buildSubmitText } from '../model/buildSubmitText.js';
 import { ConversationSession } from '../model/ConversationSession.js';
+import { NodeProcessLauncher } from '../model/NodeProcessLauncher.js';
 import { StatusState } from '../model/StatusState.js';
 import { ReadLine } from '../ReadLine.js';
 import { replayHistory } from '../replayHistory.js';
@@ -223,12 +225,14 @@ const main = async () => {
   // The handler listens on the consumer port for all events (stream events
   // forwarded above, plus SDK-level events sent by the QueryRunner) and
   // posts approval responses back on the same port.
+  const notifier = new ApprovalNotifier(watcher.config.hooks.approvalNotify, new NodeProcessLauncher());
   const handler = new AgentMessageHandler(layout, logger, {
     config: durableConfig,
     port: channel.consumerPort,
     cwd,
     store,
     statusState,
+    notifier,
   });
   channel.consumerPort.on('message', (msg: SdkMessage) => {
     handler.handle(msg);

--- a/apps/claude-sdk-cli/src/model/ApprovalNotifier.ts
+++ b/apps/claude-sdk-cli/src/model/ApprovalNotifier.ts
@@ -1,18 +1,36 @@
 import type { SdkToolApprovalRequest } from '@shellicar/claude-sdk';
 import type { ApprovalNotifyConfig } from '../cli-config/types.js';
+import type { IProcessLauncher } from './IProcessLauncher.js';
 
 export class ApprovalNotifier {
   readonly #config: ApprovalNotifyConfig | null;
+  readonly #launcher: IProcessLauncher;
+  #timer: ReturnType<typeof setTimeout> | null = null;
 
-  public constructor(config: ApprovalNotifyConfig | null) {
+  public constructor(config: ApprovalNotifyConfig | null, launcher: IProcessLauncher) {
     this.#config = config;
+    this.#launcher = launcher;
   }
 
-  public start(_request: SdkToolApprovalRequest): void {
-    throw new Error('not implemented');
+  public start(request: SdkToolApprovalRequest): void {
+    if (this.#config === null) {
+      return;
+    }
+    const { command, delayMs } = this.#config;
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      try {
+        this.#launcher.launch(command, [JSON.stringify(request)]);
+      } catch {
+        // fire and forget
+      }
+    }, delayMs);
   }
 
   public cancel(): void {
-    throw new Error('not implemented');
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
   }
 }

--- a/apps/claude-sdk-cli/src/model/ApprovalNotifier.ts
+++ b/apps/claude-sdk-cli/src/model/ApprovalNotifier.ts
@@ -1,0 +1,18 @@
+import type { SdkToolApprovalRequest } from '@shellicar/claude-sdk';
+import type { ApprovalNotifyConfig } from '../cli-config/types.js';
+
+export class ApprovalNotifier {
+  readonly #config: ApprovalNotifyConfig | null;
+
+  public constructor(config: ApprovalNotifyConfig | null) {
+    this.#config = config;
+  }
+
+  public start(_request: SdkToolApprovalRequest): void {
+    throw new Error('not implemented');
+  }
+
+  public cancel(): void {
+    throw new Error('not implemented');
+  }
+}

--- a/apps/claude-sdk-cli/src/model/IProcessLauncher.ts
+++ b/apps/claude-sdk-cli/src/model/IProcessLauncher.ts
@@ -1,0 +1,3 @@
+export abstract class IProcessLauncher {
+  public abstract launch(command: string, args: string[]): void;
+}

--- a/apps/claude-sdk-cli/src/model/NodeProcessLauncher.ts
+++ b/apps/claude-sdk-cli/src/model/NodeProcessLauncher.ts
@@ -1,0 +1,8 @@
+import { spawn } from 'node:child_process';
+import { IProcessLauncher } from './IProcessLauncher.js';
+
+export class NodeProcessLauncher extends IProcessLauncher {
+  public launch(command: string, args: string[]): void {
+    spawn(command, args, { detached: true, stdio: 'ignore' }).unref();
+  }
+}

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -6,7 +6,13 @@ import { z } from 'zod';
 import type { AppLayout } from '../src/AppLayout.js';
 import { AgentMessageHandler, type AgentMessageHandlerOptions } from '../src/controller/AgentMessageHandler.js';
 import { logger } from '../src/logger.js';
+import { ApprovalNotifier } from '../src/model/ApprovalNotifier.js';
+import { IProcessLauncher } from '../src/model/IProcessLauncher.js';
 import { StatusState } from '../src/model/StatusState.js';
+
+class NoopLauncher extends IProcessLauncher {
+  public launch(): void {}
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -40,6 +46,7 @@ function makeOpts(overrides: { config?: Partial<DurableConfig>; cwd?: string; st
     cwd: overrides.cwd ?? '/test',
     store: overrides.store ?? ({ get: vi.fn(), getHint: vi.fn() } as unknown as AgentMessageHandlerOptions['store']),
     statusState: overrides.statusState ?? new StatusState(new MemoryFileSystem({}, '/home/user', '/test')),
+    notifier: new ApprovalNotifier(null, new NoopLauncher()),
   };
 }
 

--- a/apps/claude-sdk-cli/test/ApprovalNotifier.spec.ts
+++ b/apps/claude-sdk-cli/test/ApprovalNotifier.spec.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process';
+import type { SdkToolApprovalRequest } from '@shellicar/claude-sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApprovalNotifier } from '../src/model/ApprovalNotifier.js';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(spawn);
+
+const testRequest: SdkToolApprovalRequest = {
+  type: 'tool_approval_request',
+  requestId: 'req-1',
+  name: 'DeleteFile',
+  input: { path: '/tmp/test.ts' },
+};
+
+const testConfig = { command: '/path/to/script.sh', delayMs: 1000 };
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockSpawn.mockReturnValue({ unref: vi.fn() } as ReturnType<typeof spawn>);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  mockSpawn.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// ApprovalNotifier
+// ---------------------------------------------------------------------------
+
+describe('ApprovalNotifier — runs after delay', () => {
+  it('runs the command after the delay when approval is pending', () => {
+    const notifier = new ApprovalNotifier(testConfig);
+    notifier.start(testRequest);
+    vi.advanceTimersByTime(testConfig.delayMs);
+    const expected = 1;
+    const actual = mockSpawn.mock.calls.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ApprovalNotifier — cancel before delay', () => {
+  it('cancels the timer when approval is resolved before the delay', () => {
+    const notifier = new ApprovalNotifier(testConfig);
+    notifier.start(testRequest);
+    notifier.cancel();
+    vi.advanceTimersByTime(testConfig.delayMs);
+    const expected = 0;
+    const actual = mockSpawn.mock.calls.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ApprovalNotifier — null config', () => {
+  it('does nothing when approvalNotify is null (not configured)', () => {
+    const notifier = new ApprovalNotifier(null);
+    notifier.start(testRequest);
+    vi.advanceTimersByTime(10_000);
+    const expected = 0;
+    const actual = mockSpawn.mock.calls.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ApprovalNotifier — passes request as JSON', () => {
+  it('passes the approval request as a JSON string argument to the command', () => {
+    const notifier = new ApprovalNotifier(testConfig);
+    notifier.start(testRequest);
+    vi.advanceTimersByTime(testConfig.delayMs);
+    const expected = JSON.stringify(testRequest);
+    const actual = mockSpawn.mock.calls[0]?.[1]?.[0];
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ApprovalNotifier — fire and forget', () => {
+  it('does not throw if the command fails', () => {
+    mockSpawn.mockImplementation(() => {
+      throw new Error('spawn failed');
+    });
+    const notifier = new ApprovalNotifier(testConfig);
+    notifier.start(testRequest);
+    const actual = () => vi.advanceTimersByTime(testConfig.delayMs);
+    expect(actual).not.toThrow();
+  });
+});

--- a/apps/claude-sdk-cli/test/ApprovalNotifier.spec.ts
+++ b/apps/claude-sdk-cli/test/ApprovalNotifier.spec.ts
@@ -1,13 +1,29 @@
-import { spawn } from 'node:child_process';
 import type { SdkToolApprovalRequest } from '@shellicar/claude-sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApprovalNotifier } from '../src/model/ApprovalNotifier.js';
+import { IProcessLauncher } from '../src/model/IProcessLauncher.js';
 
-vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
-}));
+// ---------------------------------------------------------------------------
+// Test launchers
+// ---------------------------------------------------------------------------
 
-const mockSpawn = vi.mocked(spawn);
+class RecordingLauncher extends IProcessLauncher {
+  public calls: Array<{ command: string; args: string[] }> = [];
+
+  public launch(command: string, args: string[]): void {
+    this.calls.push({ command, args });
+  }
+}
+
+class ThrowingLauncher extends IProcessLauncher {
+  public launch(): void {
+    throw new Error('spawn failed');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
 
 const testRequest: SdkToolApprovalRequest = {
   type: 'tool_approval_request',
@@ -24,12 +40,10 @@ const testConfig = { command: '/path/to/script.sh', delayMs: 1000 };
 
 beforeEach(() => {
   vi.useFakeTimers();
-  mockSpawn.mockReturnValue({ unref: vi.fn() } as ReturnType<typeof spawn>);
 });
 
 afterEach(() => {
   vi.useRealTimers();
-  mockSpawn.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -38,55 +52,56 @@ afterEach(() => {
 
 describe('ApprovalNotifier — runs after delay', () => {
   it('runs the command after the delay when approval is pending', () => {
-    const notifier = new ApprovalNotifier(testConfig);
+    const launcher = new RecordingLauncher();
+    const notifier = new ApprovalNotifier(testConfig, launcher);
     notifier.start(testRequest);
     vi.advanceTimersByTime(testConfig.delayMs);
     const expected = 1;
-    const actual = mockSpawn.mock.calls.length;
+    const actual = launcher.calls.length;
     expect(actual).toBe(expected);
   });
 });
 
 describe('ApprovalNotifier — cancel before delay', () => {
   it('cancels the timer when approval is resolved before the delay', () => {
-    const notifier = new ApprovalNotifier(testConfig);
+    const launcher = new RecordingLauncher();
+    const notifier = new ApprovalNotifier(testConfig, launcher);
     notifier.start(testRequest);
     notifier.cancel();
     vi.advanceTimersByTime(testConfig.delayMs);
     const expected = 0;
-    const actual = mockSpawn.mock.calls.length;
+    const actual = launcher.calls.length;
     expect(actual).toBe(expected);
   });
 });
 
 describe('ApprovalNotifier — null config', () => {
   it('does nothing when approvalNotify is null (not configured)', () => {
-    const notifier = new ApprovalNotifier(null);
+    const launcher = new RecordingLauncher();
+    const notifier = new ApprovalNotifier(null, launcher);
     notifier.start(testRequest);
     vi.advanceTimersByTime(10_000);
     const expected = 0;
-    const actual = mockSpawn.mock.calls.length;
+    const actual = launcher.calls.length;
     expect(actual).toBe(expected);
   });
 });
 
 describe('ApprovalNotifier — passes request as JSON', () => {
   it('passes the approval request as a JSON string argument to the command', () => {
-    const notifier = new ApprovalNotifier(testConfig);
+    const launcher = new RecordingLauncher();
+    const notifier = new ApprovalNotifier(testConfig, launcher);
     notifier.start(testRequest);
     vi.advanceTimersByTime(testConfig.delayMs);
     const expected = JSON.stringify(testRequest);
-    const actual = mockSpawn.mock.calls[0]?.[1]?.[0];
+    const actual = launcher.calls[0]?.args[0];
     expect(actual).toBe(expected);
   });
 });
 
 describe('ApprovalNotifier — fire and forget', () => {
   it('does not throw if the command fails', () => {
-    mockSpawn.mockImplementation(() => {
-      throw new Error('spawn failed');
-    });
-    const notifier = new ApprovalNotifier(testConfig);
+    const notifier = new ApprovalNotifier(testConfig, new ThrowingLauncher());
     notifier.start(testRequest);
     const actual = () => vi.advanceTimersByTime(testConfig.delayMs);
     expect(actual).not.toThrow();

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -19,6 +19,7 @@ describe('sdkConfigSchema', () => {
           webSearch: { enabled: true, version: 'web_search_20260209', allowedCallers: ['direct'] },
           webFetch: { enabled: true, version: 'web_fetch_20260209', allowedCallers: ['direct'] },
         },
+        hooks: { approvalNotify: null },
       });
     });
 

--- a/apps/claude-sdk-cli/test/initConfig.spec.ts
+++ b/apps/claude-sdk-cli/test/initConfig.spec.ts
@@ -21,7 +21,7 @@ describe('defaultConfig', () => {
       for (const [key, value] of Object.entries(shape)) {
         expect(obj).toHaveProperty(key);
         const unwrapped = unwrapToObject(value);
-        if (unwrapped) {
+        if (unwrapped && obj[key] !== null) {
           recurse(unwrapped.shape, obj[key] as Record<string, unknown>);
         }
       }

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -238,6 +238,41 @@
           }
         }
       }
+    },
+    "hooks": {
+      "default": {
+        "approvalNotify": null
+      },
+      "description": "Hook configuration",
+      "type": "object",
+      "properties": {
+        "approvalNotify": {
+          "default": null,
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "description": "Command to run when approval is pending"
+                },
+                "delayMs": {
+                  "default": 0,
+                  "description": "Milliseconds to wait before running the command. 0 means immediate",
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "command"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
   },
   "title": "Claude SDK CLI Configuration",


### PR DESCRIPTION
## Summary

- Add `hooks.approvalNotify` config: command + delay
- Run the command with the approval request as a JSON argument when the delay elapses
- Cancel the notification if the user responds before the delay
- Wire into `AgentMessageHandler` for the interactive approval path only

Closes #274