### PR TITLE
Prevent crashes from unhandled process and socket errors

### DIFF
--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -1,0 +1,23 @@
+# 18:25
+
+Phase 1 of the error-handling mission. Five locations patched for unhandled errors.
+
+## What was done
+
+**`main.ts`** — added `uncaughtException` and `unhandledRejection` handlers after the SIGINT/SIGTERM handlers. EPIPE is swallowed (log and return); all other uncaught exceptions log, call `cleanup()`, then `process.exit(1)`. Unhandled rejections log only, no exit.
+
+**`NodeProcessLauncher.ts`** — `launch()` was a one-liner: `spawn(...).unref()`. Extracted to variable, added `error` listener before `unref()`. Fire-and-forget spawns that fail (ENOENT etc.) no longer crash the CLI.
+
+**`execPipeline.ts`** — two changes: (1) added `error` listener on `next.stdin` in both the merge_stderr and direct pipe paths inside the connection loop; (2) added `error` listener on `stream` right after `createWriteStream` in the redirect block.
+
+**`execCommand.ts`** — same redirect pattern: `error` listener on `stream` right after `createWriteStream`.
+
+**`TsServerService.ts`** — added `stdin?.on('error')` and `proc.on('error')` in `start()`, after the stdout data handler.
+
+## One thing worth noting
+
+`cleanup()` calls `process.exit(0)` internally, so the `process.exit(1)` after it in the `uncaughtException` handler is unreachable. The mission explicitly specified this pattern. The cleanup teardown (tsServer.stop, watcher.dispose, layout.exit) still runs before exit, which is what matters.
+
+## No surprises
+
+All five files matched the mission description exactly. Build, type-check, test, and biome CI all passed on the first run.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -21,3 +21,19 @@ Phase 1 of the error-handling mission. Five locations patched for unhandled erro
 ## No surprises
 
 All five files matched the mission description exactly. Build, type-check, test, and biome CI all passed on the first run.
+
+# 18:50
+
+Phase 2 of the error-handling mission. Three changes to `main.ts` only.
+
+## What was done
+
+**`process.title`** — set to `'claude-sdk-cli'` at module level, before `parseArgs`. This appears in `ps` output and macOS Activity Monitor instead of `node`.
+
+**Two-stage SIGINT** — introduced a `sigintReceived` boolean. First Ctrl-C sets the flag and calls `cleanup()` (which exits via `process.exit(0)` inside). Second Ctrl-C calls `process.exit(1)` directly, escaping a hung cleanup. SIGTERM is unchanged.
+
+**`uncaughtException` simplified** — Phase 1 had special-case EPIPE logic and called `cleanup()` + `process.exit(1)`. The amendment corrects this: the handler now just logs and returns. No exit, no cleanup, no special cases. The reasoning: calling cleanup from an uncaught exception handler is unsafe (the process is in an unknown state), and crashing on non-EPIPE errors was the opposite of what the global handler is for.
+
+## Note on cleanup() exit behaviour
+
+`cleanup()` calls `process.exit(0)` as its last step. With the two-stage SIGINT pattern, the first Ctrl-C calls `cleanup()` which exits — the `sigintReceived = true` line before it is set regardless, so a second Ctrl-C during the (extremely brief) window before exit would also hit `process.exit(1)`. This is fine; both paths terminate the process.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -37,3 +37,25 @@ Phase 2 of the error-handling mission. Three changes to `main.ts` only.
 ## Note on cleanup() exit behaviour
 
 `cleanup()` calls `process.exit(0)` as its last step. With the two-stage SIGINT pattern, the first Ctrl-C calls `cleanup()` which exits — the `sigintReceived = true` line before it is set regardless, so a second Ctrl-C during the (extremely brief) window before exit would also hit `process.exit(1)`. This is fine; both paths terminate the process.
+
+# 19:00
+
+Phase 3 Courier for error-handling mission.
+
+## What was built
+
+Two commits on `fix/error-handling`:
+
+1. **Add global error handling** (Phase 1): `uncaughtException` + `unhandledRejection` handlers in `main.ts`; `error` listeners on child process stdin and pipes in `execPipeline.ts`, `execCommand.ts`, `TsServerService.ts`, `NodeProcessLauncher.ts`.
+
+2. **Set process title, and don't exit on uncaught exception** (Phase 2): `process.title = 'claude-sdk-cli'`; two-stage SIGINT (first graceful, second force-exit); `uncaughtException` simplified to log-and-return with no exit.
+
+## Key decisions
+
+The `uncaughtException` handler does not call `cleanup()` or exit. Calling cleanup from an unknown process state is unsafe. The handler's job is to keep the process alive after an unexpected error, not to shut it down cleanly. The SIGINT handler owns graceful shutdown.
+
+`cleanup()` calls `process.exit(0)` internally, so the `process.exit(1)` line after it in the Phase 1 handler was unreachable. Phase 2 removed the exit entirely.
+
+## Packages touched
+
+`claude-sdk-cli`, `claude-sdk-tools`.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -1,61 +1,21 @@
-# 18:25
+# Error handling
 
-Phase 1 of the error-handling mission. Five locations patched for unhandled errors.
+## What changed
 
-## What was done
+**`main.ts`** — `uncaughtException` and `unhandledRejection` handlers added after the signal handlers. `uncaughtException` logs and returns; no exit, no cleanup, no special cases. `unhandledRejection` logs only. Two-stage SIGINT: first Ctrl-C calls `cleanup()` (which exits via `process.exit(0)` internally); second Ctrl-C calls `process.exit(1)` as an escape hatch if cleanup hangs. `process.title` set to `'claude-sdk-cli'` at module level before `parseArgs`.
 
-**`main.ts`** — added `uncaughtException` and `unhandledRejection` handlers after the SIGINT/SIGTERM handlers. EPIPE is swallowed (log and return); all other uncaught exceptions log, call `cleanup()`, then `process.exit(1)`. Unhandled rejections log only, no exit.
+**`NodeProcessLauncher.ts`** — `launch()` was `spawn(...).unref()`. Extracted to variable, added `error` listener before `unref()`. ENOENT on a fire-and-forget hook no longer crashes the CLI.
 
-**`NodeProcessLauncher.ts`** — `launch()` was a one-liner: `spawn(...).unref()`. Extracted to variable, added `error` listener before `unref()`. Fire-and-forget spawns that fail (ENOENT etc.) no longer crash the CLI.
+**`execPipeline.ts`** — `error` listener on `next.stdin` in both the `merge_stderr` and direct pipe paths inside the connection loop. `error` listener on `stream` in the redirect block.
 
-**`execPipeline.ts`** — two changes: (1) added `error` listener on `next.stdin` in both the merge_stderr and direct pipe paths inside the connection loop; (2) added `error` listener on `stream` right after `createWriteStream` in the redirect block.
+**`execCommand.ts`** — same redirect pattern: `error` listener on `stream` after `createWriteStream`.
 
-**`execCommand.ts`** — same redirect pattern: `error` listener on `stream` right after `createWriteStream`.
-
-**`TsServerService.ts`** — added `stdin?.on('error')` and `proc.on('error')` in `start()`, after the stdout data handler.
-
-## One thing worth noting
-
-`cleanup()` calls `process.exit(0)` internally, so the `process.exit(1)` after it in the `uncaughtException` handler is unreachable. The mission explicitly specified this pattern. The cleanup teardown (tsServer.stop, watcher.dispose, layout.exit) still runs before exit, which is what matters.
-
-## No surprises
-
-All five files matched the mission description exactly. Build, type-check, test, and biome CI all passed on the first run.
-
-# 18:50
-
-Phase 2 of the error-handling mission. Three changes to `main.ts` only.
-
-## What was done
-
-**`process.title`** — set to `'claude-sdk-cli'` at module level, before `parseArgs`. This appears in `ps` output and macOS Activity Monitor instead of `node`.
-
-**Two-stage SIGINT** — introduced a `sigintReceived` boolean. First Ctrl-C sets the flag and calls `cleanup()` (which exits via `process.exit(0)` inside). Second Ctrl-C calls `process.exit(1)` directly, escaping a hung cleanup. SIGTERM is unchanged.
-
-**`uncaughtException` simplified** — Phase 1 had special-case EPIPE logic and called `cleanup()` + `process.exit(1)`. The amendment corrects this: the handler now just logs and returns. No exit, no cleanup, no special cases. The reasoning: calling cleanup from an uncaught exception handler is unsafe (the process is in an unknown state), and crashing on non-EPIPE errors was the opposite of what the global handler is for.
-
-## Note on cleanup() exit behaviour
-
-`cleanup()` calls `process.exit(0)` as its last step. With the two-stage SIGINT pattern, the first Ctrl-C calls `cleanup()` which exits — the `sigintReceived = true` line before it is set regardless, so a second Ctrl-C during the (extremely brief) window before exit would also hit `process.exit(1)`. This is fine; both paths terminate the process.
-
-# 19:00
-
-Phase 3 Courier for error-handling mission.
-
-## What was built
-
-Two commits on `fix/error-handling`:
-
-1. **Add global error handling** (Phase 1): `uncaughtException` + `unhandledRejection` handlers in `main.ts`; `error` listeners on child process stdin and pipes in `execPipeline.ts`, `execCommand.ts`, `TsServerService.ts`, `NodeProcessLauncher.ts`.
-
-2. **Set process title, and don't exit on uncaught exception** (Phase 2): `process.title = 'claude-sdk-cli'`; two-stage SIGINT (first graceful, second force-exit); `uncaughtException` simplified to log-and-return with no exit.
+**`TsServerService.ts`** — `stdin?.on('error')` and `proc.on('error')` in `start()`, after the stdout data handler.
 
 ## Key decisions
 
-The `uncaughtException` handler does not call `cleanup()` or exit. Calling cleanup from an unknown process state is unsafe. The handler's job is to keep the process alive after an unexpected error, not to shut it down cleanly. The SIGINT handler owns graceful shutdown.
+The `uncaughtException` handler does not call `cleanup()` or exit. Calling cleanup from an unknown process state is unsafe. The handler exists to keep the process alive after an unexpected error. SIGINT owns graceful shutdown.
 
-`cleanup()` calls `process.exit(0)` internally, so the `process.exit(1)` line after it in the Phase 1 handler was unreachable. Phase 2 removed the exit entirely.
+The SC corrected Phase 1: the original handler swallowed EPIPE and crashed on everything else, which defeated the purpose. Phase 2 simplified it to log-and-return unconditionally.
 
-## Packages touched
-
-`claude-sdk-cli`, `claude-sdk-tools`.
+`cleanup()` calls `process.exit(0)` as its last step. With the two-stage SIGINT pattern, `sigintReceived` is set to `true` before calling `cleanup()`, so a second Ctrl-C during the (brief) cleanup window hits `process.exit(1)`. Both paths terminate the process.

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add --file flag to start with a file as the first message
 - Flash tool approval prompt with inverted colours when awaiting Y/N
 - Add approval notification hook: run a command when tool approval is pending
-- Maintain session ID history file at ~/.claude/session-history
+- Track session history per working directory for future session picker
 
 ### Changed
 

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -20,3 +20,4 @@
 {"description":"Write session ID marker on save instead of on creation","category":"changed"}
 {"description":"Track session history per working directory for future session picker","category":"added"}
 {"description":"Apply biome formatting fixes","category":"fixed"}
+{"description":"Prevent crashes from unhandled child process and socket errors","category":"fixed"}

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -129,6 +129,18 @@ const main = async () => {
   };
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
+  process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') {
+      logger.error('uncaughtException: EPIPE (swallowed)', err);
+      return;
+    }
+    logger.error('uncaughtException', err);
+    cleanup();
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    logger.error('unhandledRejection', reason);
+  });
 
   rl.setLayout(layout);
   layout.enter();

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -27,6 +27,8 @@ import { replayHistory } from '../replayHistory.js';
 import { buildRunAgentInput, runAgent } from '../runAgent.js';
 import { systemPrompts } from '../systemPrompts.js';
 
+process.title = 'claude-sdk-cli';
+
 const { values } = parseArgs({
   options: {
     version: { type: 'boolean', short: 'v', default: false },
@@ -127,16 +129,17 @@ const main = async () => {
     layout.exit();
     process.exit(0);
   };
-  process.on('SIGINT', cleanup);
+  let sigintReceived = false;
+  process.on('SIGINT', () => {
+    if (sigintReceived) {
+      process.exit(1);
+    }
+    sigintReceived = true;
+    cleanup();
+  });
   process.on('SIGTERM', cleanup);
   process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
-    if (err.code === 'EPIPE') {
-      logger.error('uncaughtException: EPIPE (swallowed)', err);
-      return;
-    }
     logger.error('uncaughtException', err);
-    cleanup();
-    process.exit(1);
   });
   process.on('unhandledRejection', (reason) => {
     logger.error('unhandledRejection', reason);

--- a/apps/claude-sdk-cli/src/model/NodeProcessLauncher.ts
+++ b/apps/claude-sdk-cli/src/model/NodeProcessLauncher.ts
@@ -3,6 +3,11 @@ import { IProcessLauncher } from './IProcessLauncher.js';
 
 export class NodeProcessLauncher extends IProcessLauncher {
   public launch(command: string, args: string[]): void {
-    spawn(command, args, { detached: true, stdio: 'ignore' }).unref();
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+    child.on('error', () => {
+      // Swallow spawn failures (e.g. ENOENT). The hook is fire-and-forget;
+      // a missing or invalid command should not crash the CLI.
+    });
+    child.unref();
   }
 }

--- a/packages/claude-sdk-tools/src/Exec/execCommand.ts
+++ b/packages/claude-sdk-tools/src/Exec/execCommand.ts
@@ -47,6 +47,9 @@ export function execCommand(cmd: Command, cwd: string, timeoutMs?: number): Prom
     if (cmd.redirect) {
       const flags = cmd.redirect.append ? 'a' : 'w';
       const stream = createWriteStream(cmd.redirect.path, { flags });
+      stream.on('error', () => {
+        // Swallow redirect write errors; the redirect failing should not crash the process.
+      });
       const target = cmd.redirect.stream;
       if (target === 'stdout' || target === 'both') {
         child.stdout.pipe(stream);

--- a/packages/claude-sdk-tools/src/Exec/execPipeline.ts
+++ b/packages/claude-sdk-tools/src/Exec/execPipeline.ts
@@ -51,8 +51,14 @@ export async function execPipeline(commands: PipelineCommands, cwd: string, time
           curr.stdout.pipe(merged);
           curr.stderr.pipe(merged);
           merged.pipe(next.stdin);
+          next.stdin.on('error', () => {
+            // No-op: expected when downstream process exits before upstream finishes.
+          });
         } else {
           curr.stdout.pipe(next.stdin);
+          next.stdin.on('error', () => {
+            // No-op: expected when downstream process exits before upstream finishes.
+          });
         }
       }
     }
@@ -89,6 +95,9 @@ export async function execPipeline(commands: PipelineCommands, cwd: string, time
     if (lastCmd.redirect) {
       const flags = lastCmd.redirect.append ? 'a' : 'w';
       const stream = createWriteStream(lastCmd.redirect.path, { flags });
+      stream.on('error', () => {
+        // Swallow redirect write errors; the redirect failing should not crash the process.
+      });
       const target = lastCmd.redirect.stream;
       if (target === 'stdout' || target === 'both') {
         lastChild.stdout.pipe(stream);

--- a/packages/claude-sdk-tools/src/typescript/TsServerService.ts
+++ b/packages/claude-sdk-tools/src/typescript/TsServerService.ts
@@ -82,6 +82,16 @@ export class TsServerService extends ITypeScriptService {
       this.#processBuffer();
     });
 
+    this.#proc.stdin?.on('error', () => {
+      // Swallow EPIPE when tsserver exits unexpectedly.
+      // The 'exit' handler on the process rejects all pending requests.
+    });
+
+    this.#proc.on('error', () => {
+      // Process-level error (e.g. unexpected kill). The 'exit' handler
+      // covers cleanup of pending requests.
+    });
+
     this.#proc.on('exit', (code) => {
       // Reject all pending requests on unexpected exit
       for (const [seq, pending] of this.#pending) {


### PR DESCRIPTION
## Summary

- Handle `uncaughtException` and `unhandledRejection` at the process level so socket errors don't crash the CLI
- Silence EPIPE and spawn errors on child process pipes, tsserver stdin, and fire-and-forget spawns
- Two-stage Ctrl-C: first press attempts graceful shutdown, second press forces exit
- Set `process.title` so the process appears as `claude-sdk-cli` in process listings

Closes #302