### PR TITLE
Opus 4.7 migration

### DIFF
--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -80,3 +80,25 @@ Role: Courier. Branch: `feature/config-origin`.
 Distilled the Phase 1 and Phase 2 entries above. Cut the mechanical "what was built" file lists (visible in the diff), the verification numbers, the test contract (tests now pass so the contract is in the code), and the "For future readers" note about the src/Config/ layout rename (the renamed filenames no longer appear anywhere in the distilled text so the note has no referent).
 
 Smoke test passed: diff touches `packages/claude-core/` and `apps/claude-sdk-cli/` only; `apps/claude-cli/` is untouched, matching the Phase 2 amendment.
+
+# 21:53
+
+## Phase 1 — Opus 4.7 thinking display fix
+
+Role: Maker. Branch: `feature/opus-4-7-migration`. Repo path: `@shellicar/claude-cli--opus-4-7-migration`.
+
+The branch existed and was clean at origin/main. `pnpm install` was needed (node_modules missing).
+
+### What changed
+
+`RequestBuilder.ts` line 168: added `display: 'summarized'` to the thinking object. The `BetaThinkingConfigAdaptive` type already had the field; no type work needed.
+
+`RequestBuilder.spec.ts`: replaced the existing thinking test with one that checks both `type` and `display`. The old test used an intermediate `expected` variable and a separate cast; the new test follows the pattern from the mission spec directly.
+
+### Why it matters
+
+Opus 4.7 changed the default thinking display from `"summarized"` to `"omitted"`. With `"omitted"`, thinking blocks arrive in the stream with an empty `thinking` field. The CLI renders thinking text as it streams, so users see a long pause with nothing visible. Pinning `display: 'summarized'` restores the previous behaviour across all models.
+
+### Verification
+
+`pnpm build`, `pnpm type-check`, `pnpm test` all passed. Turbo hit build cache for most packages; only the SDK test ran fresh.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -85,36 +85,22 @@ Smoke test passed: diff touches `packages/claude-core/` and `apps/claude-sdk-cli
 
 ## Phase 1 — Opus 4.7 thinking display fix
 
-Role: Maker. Branch: `feature/opus-4-7-migration`. Repo path: `@shellicar/claude-cli--opus-4-7-migration`.
+Opus 4.7 changed the default thinking display from `"summarized"` to `"omitted"`. With `"omitted"`, thinking blocks still arrive in the stream but with an empty `thinking` field. The CLI renders thinking as it streams, so users see a long pause with nothing visible.
 
-The branch existed and was clean at origin/main. `pnpm install` was needed (node_modules missing).
-
-### What changed
-
-`RequestBuilder.ts` line 168: added `display: 'summarized'` to the thinking object. The `BetaThinkingConfigAdaptive` type already had the field; no type work needed.
-
-`RequestBuilder.spec.ts`: replaced the existing thinking test with one that checks both `type` and `display`. The old test used an intermediate `expected` variable and a separate cast; the new test follows the pattern from the mission spec directly.
-
-### Why it matters
-
-Opus 4.7 changed the default thinking display from `"summarized"` to `"omitted"`. With `"omitted"`, thinking blocks arrive in the stream with an empty `thinking` field. The CLI renders thinking text as it streams, so users see a long pause with nothing visible. Pinning `display: 'summarized'` restores the previous behaviour across all models.
-
-### Verification
-
-`pnpm build`, `pnpm type-check`, `pnpm test` all passed. Turbo hit build cache for most packages; only the SDK test ran fresh.
+`RequestBuilder.ts` (line 168): added `display: 'summarized'` to the thinking object. `BetaThinkingConfigAdaptive` already had the field, no type work needed. `RequestBuilder.spec.ts`: updated the thinking test to assert both `type` and `display`.
 
 # 22:07
 
 ## Phase 2 — Opus 4.7 pricing and enum cleanup
 
-Role: Maker. Branch: `feature/opus-4-7-migration`.
+`pricing.ts`: added `claude-opus-4-7` to the top of `PRICING` at Opus 4.6 rates ($5/$25 per MTok). Added `claude-opus-4-6`, `claude-opus-4-7`, and `claude-sonnet-4-6` to `CONTEXT_WINDOW` at 1_000_000. These three model IDs carry a version suffix that is not a date suffix, so `stripDateSuffix` does not strip them; without explicit entries they fall through to the 200k default instead of matching the short-name fallback.
 
-### What changed
+`enums.ts`: removed `InterleavedThinking` and its JSDoc. Nothing referenced it, and Opus 4.7 adaptive thinking enables interleaved thinking automatically.
 
-`pricing.ts`: Added `claude-opus-4-7` at the top of the `PRICING` map with the same rates as `claude-opus-4-6` ($5/$25 per MTok). Added three entries to `CONTEXT_WINDOW`: `claude-opus-4-7`, `claude-opus-4-6`, and `claude-sonnet-4-6` all at 1_000_000. These three model IDs include a version suffix that is not a date suffix, so `stripDateSuffix` does not strip them — they require explicit entries rather than relying on the short-name fallback.
+# 22:20
 
-`enums.ts`: Removed `InterleavedThinking = 'interleaved-thinking-2025-05-14'` and its JSDoc comment from `AnthropicBeta`. Nothing in the codebase referenced it; Opus 4.7 adaptive thinking enables interleaved thinking automatically.
+## Phase 3 — Courier
 
-### Verification
+Branch was clean, 2 ahead and 1 behind `origin/main`. The 1-behind commit is `f5a1116` (PR #306, session marker) which touches unrelated files. Used `git diff origin/main...HEAD` (three-dot) to verify our branch-only diff: the four mission files plus testament, no drift.
 
-`pnpm build`, `pnpm type-check`, `pnpm test` all passed. Turbo hit build cache; the SDK package was not re-built (no output files changed from turbo's perspective since these are source-only changes — type-check and test ran fresh).
+Appended four entries to `packages/claude-sdk/changes.jsonl`. Validator passes. Distilled phases 1 and 2 above.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -1,138 +1,59 @@
-# Error handling
+# 2026-04-21
 
-## What changed
+Four missions landed today: error handling, config loader (issue #301), save timing (issue #273), Opus 4.7 migration. Retelling by topic, not by phase.
 
-**`main.ts`** — `uncaughtException` and `unhandledRejection` handlers added after the signal handlers. `uncaughtException` logs and returns; no exit, no cleanup, no special cases. `unhandledRejection` logs only. Two-stage SIGINT: first Ctrl-C calls `cleanup()` (which exits via `process.exit(0)` internally); second Ctrl-C calls `process.exit(1)` as an escape hatch if cleanup hangs. `process.title` set to `'claude-sdk-cli'` at module level before `parseArgs`.
+## Error handling (`main.ts` + process launchers)
 
-**`NodeProcessLauncher.ts`** — `launch()` was `spawn(...).unref()`. Extracted to variable, added `error` listener before `unref()`. ENOENT on a fire-and-forget hook no longer crashes the CLI.
+`uncaughtException` logs and returns. No cleanup, no exit, no special cases. Calling `cleanup()` from an unknown process state is unsafe; SIGINT owns graceful shutdown. `unhandledRejection` logs only.
 
-**`execPipeline.ts`** — `error` listener on `next.stdin` in both the `merge_stderr` and direct pipe paths inside the connection loop. `error` listener on `stream` in the redirect block.
+Two-stage SIGINT: first Ctrl-C sets `sigintReceived = true` and calls `cleanup()` (which exits via `process.exit(0)` internally). Second Ctrl-C hits `process.exit(1)` as an escape hatch if cleanup hangs. Both paths terminate.
 
-**`execCommand.ts`** — same redirect pattern: `error` listener on `stream` after `createWriteStream`.
+Fire-and-forget spawns need an `error` listener **before** `.unref()` or ENOENT crashes the CLI. This bit `NodeProcessLauncher.launch()`. Same pattern for `execPipeline` (`error` on `next.stdin` in both the `merge_stderr` and direct-pipe paths, and on `stream` in the redirect block) and `execCommand` (`error` on `stream` after `createWriteStream`). `TsServerService.start()` needs `stdin?.on('error')` and `proc.on('error')` after the stdout data handler.
 
-**`TsServerService.ts`** — `stdin?.on('error')` and `proc.on('error')` in `start()`, after the stdout data handler.
+`process.title = 'claude-sdk-cli'` is set at module level before `parseArgs`.
 
-## Key decisions
+## Config loader (`@shellicar/claude-core/Config`)
 
-The `uncaughtException` handler does not call `cleanup()` or exit. Calling cleanup from an unknown process state is unsafe. The handler exists to keep the process alive after an unexpected error. SIGINT owns graceful shutdown.
+Consumer imports: `@shellicar/claude-core/Config/ConfigLoader`, likewise `NodeConfigFileReader` and `NodeConfigWatcher`.
 
-The SC corrected Phase 1: the original handler swallowed EPIPE and crashed on everything else, which defeated the purpose. Phase 2 simplified it to log-and-return unconditionally.
+**Tsup trap.** Do **not** set `options.entryNames = '[name]'` in `esbuildOptions`. It flattens JS output (`dist/esm/ConfigLoader.js`) while DTS preserves the directory structure (`dist/esm/Config/ConfigLoader.d.ts`), and the mismatch breaks type resolution for subpath imports. Let both emit under `Config/`. Top-level `src/*.ts` files are unaffected because they have no parent segment.
 
-`cleanup()` calls `process.exit(0)` as its last step. With the two-stage SIGINT pattern, `sigintReceived` is set to `true` before calling `cleanup()`, so a second Ctrl-C during the (brief) cleanup window hits `process.exit(1)`. Both paths terminate the process.
+`load()` vs `#reload()` are deliberately asymmetric:
 
-# 19:37
+- `load()` tolerates parse errors per file: skip the file, contribute nothing to `sources` or the merge, push a warning. Caller decides whether to surface.
+- `#reload()` aborts on **any** parse or schema error. `config`, `sources`, `warnings` stay intact from the last good state. A transient broken edit must not drop the user back to schema defaults or clear origin tracking.
 
-## Phase 1 — Config loader scaffold (issue #301)
+`ConfigSource = { path, raw }` holds raw JSON before the schema, not parsed config. Parsed content erases "explicitly set" vs "defaulted by schema", which origin tracking needs. Consumers walk sources in reverse for last-writer-wins.
 
-Role: Scaffolder. Branch: `feature/config-origin`.
+Debounce lives in the loader (default 100ms; `0` reloads synchronously for tests). Diff via `JSON.stringify` suppresses no-op emissions. Keeps every `IConfigWatcher` implementation trivial.
 
-### Key design decisions
+`MergeOptions.additivePaths` is still wired through to `mergeRawConfigs` because legacy `claude-cli` uses it for `execPermissions.approve`.
 
-1. **Sync reader, async watcher.** The reader is synchronous because startup load happens once and the existing `loadConfig` was sync. The watcher is callback-based (async-by-nature) since file watching is event-driven.
+## Save timing (`ConversationSession`)
 
-2. **Loader owns debounce and diff.** The watcher just fires raw events. `ConfigLoader` debounces (default 100ms; 0 for tests) and compares parsed configs via `JSON.stringify` to suppress no-op emissions. Keeping this in the loader means every `IConfigWatcher` implementation stays trivial.
+`save()` was split into two methods:
 
-3. **`load()` separate from `start()`.** Constructor stores options only. `load()` performs the initial read. `start()` begins watching. `dispose()` stops. This lets tests check post-load state without triggering a watcher at all, and makes reload-on-change a simple re-call of `load()` internally.
+- `saveSession()`: marker + session history. Idempotent.
+- `saveConversation()`: conversation jsonl only.
 
-4. **Sources preserve raw JSON, not parsed config.** `ConfigSource = { path, raw }` where `raw` is the object from `JSON.parse` before the schema runs. This matches the mission's rationale: parsed content erases "explicitly set" vs "defaulted by schema". Consumers walk sources in reverse for last-writer-wins origin tracking.
+`main.ts` calls `saveSession()` immediately after `turnInProgress = true`, before `runAgent`. `saveConversation()` runs after the turn completes. A mid-response crash now leaves a project-level trace that the session ran.
 
-5. **Logger is a minimal local type.** `ConfigLoaderLogger` has just `warn(message, meta?)`. Not reusing `ILogger` from claude-sdk because claude-core should not depend on claude-sdk.
+`load()` reads the marker to find the conversation file, so any restore test must run `saveSession()` before `saveConversation()` or `load()` generates a fresh UUID and finds nothing.
 
-6. **`MergeOptions.additivePaths` preserved.** The existing option is still used by the legacy `claude-cli` via `loadConfig(..., { additivePaths: ['execPermissions.approve'] })`. The new `ConfigLoader` accepts `mergeOptions` and routes it through to `mergeRawConfigs`.
+## Opus 4.7 migration
 
-# 20:11
+`RequestBuilder.ts`: `{ type: 'adaptive', display: 'summarized' }`. 4.7 changed the default thinking display to `"omitted"`, which ships empty thinking blocks and makes the CLI look frozen while the model reasons. `BetaThinkingConfigAdaptive` already had the field.
 
-## Phase 2 — Config loader implementation (issue #301)
+`pricing.ts` `CONTEXT_WINDOW` map: `claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6` need **explicit** 1M entries. Their version suffix is not a date suffix, so `stripDateSuffix` is a no-op and the short-name fallback (`claude-opus-4`, `claude-sonnet-4`) doesn't match. Without explicit entries they silently default to 200k. Easy to miss: the 200k fallback doesn't throw.
 
-Role: Builder. Branch: `feature/config-origin`.
+`pricing.ts` `PRICING` map: `claude-opus-4-7` at Opus 4.6 rates ($5/$25 per MTok, placed above 4.6).
 
-### Scaffold breakage
+`InterleavedThinking` removed from `AnthropicBeta`. 4.7 adaptive thinking enables interleaved thinking automatically without the beta header.
 
-The Phase 1 scaffold was committed in a broken state — `types.ts` had a duplicate `ConfigLoaderLogger` interface declaration, a self-import of it, and imports from nonexistent paths `../IConfigFileReader` and `../IConfigWatcher` (because files were reorganised into `src/Config/` after the testament was written but imports weren't updated). `interfaces.ts` also imported `ConfigWatchHandle` but didn't re-export it, so `test/MemoryConfigWatcher.ts` failed to compile.
+## General tricks
 
-Rewrote `types.ts` cleanly (single `ConfigLoaderLogger`, correct imports from `./interfaces`), added `export type { ConfigWatchHandle } from './types'` to `interfaces.ts` so Memory fakes can import from one place.
+**Branch-only diff when behind origin/main.** `git diff origin/main...HEAD` (three-dot) shows only your commits' changes. Two-dot includes the inverse of whatever landed on main in the meantime, which looks like spurious extra files in the smoke test.
 
-### tsup entry + layout
+**PR creation.** Use `~/.claude/skills/github-pr/scripts/create-github-pr.sh` (pipe JSON in). Don't `gh pr create` directly, the script enforces required fields. The `github-pr` skill schema only lists `assignee`, so add the reviewer (`bananabot9000`) via `gh pr edit --add-reviewer` afterwards.
 
-`tsup.config.ts` needed two changes:
-- Added `src/Config/*.ts` to `entry`.
-- **Removed** `options.entryNames = '[name]'` from `esbuildOptions`. That override flattened the directory structure for JS output (`dist/esm/ConfigLoader.js`) while the DTS emitter preserved it (`dist/esm/Config/ConfigLoader.d.ts`). Mismatch broke `@shellicar/claude-core/Config/ConfigLoader` type resolution. Dropping the override makes both JS and DTS emit under `Config/`. Top-level `src/*.ts` files are unaffected because they have no parent segment.
-
-Consumer import path is now `@shellicar/claude-core/Config/ConfigLoader` (likewise for `NodeConfigFileReader`, `NodeConfigWatcher`).
-
-### Load vs reload semantics
-
-- **`load()`**: parse errors tolerated per file. A file that fails JSON parse is skipped, contributes nothing to `sources` or the merge, and adds an entry to `warnings`. Caller decides whether to surface the warnings.
-- **`#reload()`**: any parse error aborts the reload. Previous `config`, `sources`, and `warnings` stay intact. A transient broken edit must not drop the user back to schema defaults or clear origin tracking. Schema validation errors also abort.
-- **Diff**: `JSON.stringify(previousConfig) === JSON.stringify(parsed)` suppresses emission when the parsed result is semantically identical (different whitespace in the file, etc.).
-- **Debounce**: default 100ms; `0` reloads synchronously (used by tests).
-
-### Pre-existing CI failure
-
-`pnpm run ci` reports `.claude/sdk-config.json` missing a trailing newline. Reproduces on `origin/main` without any of my changes. Out of mission scope.
-
-# 20:25
-
-## Phase 3 — Courier (issue #301)
-
-Role: Courier. Branch: `feature/config-origin`.
-
-Distilled the Phase 1 and Phase 2 entries above. Cut the mechanical "what was built" file lists (visible in the diff), the verification numbers, the test contract (tests now pass so the contract is in the code), and the "For future readers" note about the src/Config/ layout rename (the renamed filenames no longer appear anywhere in the distilled text so the note has no referent).
-
-Smoke test passed: diff touches `packages/claude-core/` and `apps/claude-sdk-cli/` only; `apps/claude-cli/` is untouched, matching the Phase 2 amendment.
-
-# 21:53
-
-## Phase 1 — Opus 4.7 thinking display fix
-
-Opus 4.7 changed the default thinking display from `"summarized"` to `"omitted"`. With `"omitted"`, thinking blocks still arrive in the stream but with an empty `thinking` field. The CLI renders thinking as it streams, so users see a long pause with nothing visible.
-
-`RequestBuilder.ts` (line 168): added `display: 'summarized'` to the thinking object. `BetaThinkingConfigAdaptive` already had the field, no type work needed. `RequestBuilder.spec.ts`: updated the thinking test to assert both `type` and `display`.
-
-# 22:07
-
-## Phase 2 — Opus 4.7 pricing and enum cleanup
-
-`pricing.ts`: added `claude-opus-4-7` to the top of `PRICING` at Opus 4.6 rates ($5/$25 per MTok). Added `claude-opus-4-6`, `claude-opus-4-7`, and `claude-sonnet-4-6` to `CONTEXT_WINDOW` at 1_000_000. These three model IDs carry a version suffix that is not a date suffix, so `stripDateSuffix` does not strip them; without explicit entries they fall through to the 200k default instead of matching the short-name fallback.
-
-`enums.ts`: removed `InterleavedThinking` and its JSDoc. Nothing referenced it, and Opus 4.7 adaptive thinking enables interleaved thinking automatically.
-
-# 22:20
-
-## Phase 3 — Courier
-
-Branch was clean, 2 ahead and 1 behind `origin/main`. The 1-behind commit is `f5a1116` (PR #306, session marker) which touches unrelated files. Used `git diff origin/main...HEAD` (three-dot) to verify our branch-only diff: the four mission files plus testament, no drift.
-
-Appended four entries to `packages/claude-sdk/changes.jsonl`. Validator passes. Distilled phases 1 and 2 above.
-
-# 21:49
-
-## Phase 1 — Save timing fix (issue #273)
-
-Role: Builder. Branch: `fix/save-timing`.
-
-### What the change does
-
-`ConversationSession.save()` was doing three things: writing the conversation jsonl, writing the marker file, and appending to the session history. All three happened after the API response. A mid-response crash left no project-level trace the session ran at all.
-
-Split into two methods:
-
-- `saveSession()` — marker + session history. Idempotent (deduplication was already in `#appendToHistory()`).
-- `saveConversation()` — conversation jsonl only.
-
-`createNew()` calls both internally (same as the old `save()` did). `save()` removed.
-
-In `main.ts`, `saveSession()` is called immediately after `turnInProgress = true`, before `runAgent`. `saveConversation()` is called after the turn completes, where `save()` was.
-
-### Test changes
-
-`'writes history that load can restore'` is the only test that needed both methods. The `load()` call on the restored session reads the marker to find the conversation file, so `saveSession()` must run first to write the marker — otherwise `load()` generates a fresh UUID and finds nothing. All other save-describe tests use only `saveSession()` (marker/history tests) or only `saveConversation()` (none directly; that path is covered via the round-trip test).
-
-
-# 22:05
-
-## Phase 2 — Courier (issue #273)
-
-Role: Courier. Branch: `fix/save-timing`.
-
-Smoke test passed: diff touches `apps/claude-sdk-cli/src/entry/main.ts`, `apps/claude-sdk-cli/src/model/ConversationSession.ts`, `apps/claude-sdk-cli/test/ConversationSession.spec.ts`, and the testament. Nothing unexpected.
+**Project PR convention.** Assignee `shellicar`, reviewer `bananabot9000`, milestone `1.0`, one of `bug`/`enhancement`/`documentation`, one `pkg:` label per touched package. Auto-merge with `gh pr merge --auto --squash`.

--- a/.claude/testament/2026-04-21.md
+++ b/.claude/testament/2026-04-21.md
@@ -102,3 +102,19 @@ Opus 4.7 changed the default thinking display from `"summarized"` to `"omitted"`
 ### Verification
 
 `pnpm build`, `pnpm type-check`, `pnpm test` all passed. Turbo hit build cache for most packages; only the SDK test ran fresh.
+
+# 22:07
+
+## Phase 2 — Opus 4.7 pricing and enum cleanup
+
+Role: Maker. Branch: `feature/opus-4-7-migration`.
+
+### What changed
+
+`pricing.ts`: Added `claude-opus-4-7` at the top of the `PRICING` map with the same rates as `claude-opus-4-6` ($5/$25 per MTok). Added three entries to `CONTEXT_WINDOW`: `claude-opus-4-7`, `claude-opus-4-6`, and `claude-sonnet-4-6` all at 1_000_000. These three model IDs include a version suffix that is not a date suffix, so `stripDateSuffix` does not strip them — they require explicit entries rather than relying on the short-name fallback.
+
+`enums.ts`: Removed `InterleavedThinking = 'interleaved-thinking-2025-05-14'` and its JSDoc comment from `AnthropicBeta`. Nothing in the codebase referenced it; Opus 4.7 adaptive thinking enables interleaved thinking automatically.
+
+### Verification
+
+`pnpm build`, `pnpm type-check`, `pnpm test` all passed. Turbo hit build cache; the SDK package was not re-built (no output files changed from turbo's perspective since these are source-only changes — type-check and test ran fresh).

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -7,3 +7,7 @@
 {"description":"Omit empty `context_management` from request body instead of sending empty edits array","category":"changed"}
 {"description":"Support tool search for on-demand tool discovery","category":"added"}
 {"description":"Support tool use examples in tool definitions","category":"added"}
+{"description":"Show thinking text when using Opus 4.7","category":"fixed"}
+{"description":"Calculate costs for Opus 4.7","category":"fixed"}
+{"description":"Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)","category":"fixed"}
+{"description":"Remove deprecated InterleavedThinking beta header","category":"removed"}

--- a/packages/claude-sdk/src/private/RequestBuilder.ts
+++ b/packages/claude-sdk/src/private/RequestBuilder.ts
@@ -165,7 +165,7 @@ export function buildRequestParams(options: RequestBuilderOptions, messages: Ant
     body.cache_control = { type: 'ephemeral', scope: 'global' } as BetaCacheControlEphemeral;
   }
   if (options.thinking === true) {
-    body.thinking = { type: 'adaptive' };
+    body.thinking = { type: 'adaptive', display: 'summarized' };
   }
 
   const betaStrings = Object.entries(betas)

--- a/packages/claude-sdk/src/private/pricing.ts
+++ b/packages/claude-sdk/src/private/pricing.ts
@@ -11,6 +11,7 @@ type ModelRates = {
 const M = 1_000_000;
 
 const PRICING: Record<string, ModelRates> = {
+  'claude-opus-4-7': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-6': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-5': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-1': { input: 15 / M, cacheWrite5m: 18.75 / M, cacheWrite1h: 30 / M, cacheRead: 1.5 / M, output: 75 / M },
@@ -26,6 +27,9 @@ const PRICING: Record<string, ModelRates> = {
 };
 
 const CONTEXT_WINDOW: Record<string, number> = {
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-sonnet-4-6': 1_000_000,
   'claude-opus-4': 200_000,
   'claude-sonnet-4': 200_000,
   'claude-haiku-4-5': 200_000,

--- a/packages/claude-sdk/src/public/enums.ts
+++ b/packages/claude-sdk/src/public/enums.ts
@@ -9,12 +9,6 @@ export const COMPACT_BETA = 'compact-2026-01-12';
 export enum AnthropicBeta {
   ClaudeCodeAuth = 'oauth-2025-04-20',
   /**
-   * @see https://platform.claude.com/docs/en/build-with-claude/extended-thinking#interleaved-thinking
-   * @deprecated
-   */
-  InterleavedThinking = 'interleaved-thinking-2025-05-14',
-
-  /**
    * @see https://platform.claude.com/docs/en/build-with-claude/context-editing#server-side-strategies
    */
   ContextManagement = 'context-management-2025-06-27',

--- a/packages/claude-sdk/test/RequestBuilder.spec.ts
+++ b/packages/claude-sdk/test/RequestBuilder.spec.ts
@@ -254,12 +254,13 @@ describe('buildRequestParams — PromptCachingScope beta', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildRequestParams — thinking', () => {
-  it('body.thinking is set to adaptive when thinking is true', () => {
-    const expected = 'adaptive';
+  it('body.thinking is set to adaptive with summarized display when thinking is true', () => {
     const { body } = buildRequestParams(makeOptions({ thinking: true }), noMessages);
-    const actual = (body.thinking as { type?: string } | undefined)?.type;
-    expect(actual).toBe(expected);
+    const thinking = body.thinking as { type?: string; display?: string } | undefined;
+    expect(thinking?.type).toBe('adaptive');
+    expect(thinking?.display).toBe('summarized');
   });
+
 
   it('body.thinking is absent when thinking is not set', () => {
     const expected = undefined;

--- a/packages/claude-sdk/test/RequestBuilder.spec.ts
+++ b/packages/claude-sdk/test/RequestBuilder.spec.ts
@@ -261,7 +261,6 @@ describe('buildRequestParams — thinking', () => {
     expect(thinking?.display).toBe('summarized');
   });
 
-
   it('body.thinking is absent when thinking is not set', () => {
     const expected = undefined;
     const { body } = buildRequestParams(makeOptions(), noMessages);


### PR DESCRIPTION
## Summary

- Show thinking text when using Opus 4.7 (summarized display)
- Add Opus 4.7 pricing ($5/$25 per MTok)
- Fix 1M context window for Opus 4.6, Opus 4.7, and Sonnet 4.6
- Remove deprecated InterleavedThinking beta header