### PR TITLE
Fix four rendering bugs: ANSI continuation colour, divider width, emoji cursor

### DIFF
--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -1,80 +1,49 @@
 # 17:58
 
-## PR #312 distillation: binary file support and tool output layer
+## PR #312: binary file support and tool output layer
 
-The PR name "Add PDF and image support to ReadFile" undersells it. The real work was restructuring how tool handlers deliver results so binary content can travel through the system without corruption. ReadFile was the driver; the tool output layer was the scope.
+Handlers return `{ textContent, attachments? }`. ToolRegistry passes only `textContent` through the ref-swap transform; attachment blocks go directly into `tool_result.content`. This keeps binary data out of the transform path.
 
-### The system problem
+### Traps
 
-Tool handlers previously returned raw values. The ToolRegistry ran a `transform` hook on that value to ref-swap large outputs. Binary data through the transform gets ref'd. A 5MB PDF base64 string would become a ref token, useless to the API. The handler output had to be restructured so binary data is extracted before `transform` ever sees it.
+**`ToolHandler<never>` is intentional.** Contravariance: any specifically-typed handler is assignable to `ToolHandler<never>` because `never` is a subtype of everything. Changing to `ToolHandler<unknown>` breaks the tools package. A JSDoc comment explains this. Do not change it.
 
-The fix: handlers return `{ textContent, attachments? }`. ToolRegistry destructures first, passes only `textContent` through the transform, then appends attachment blocks inside `tool_result.content`. `BetaToolResultBlockParam.content` already accepts document and image blocks. No new delivery path needed.
+**`output_schema` on `ToolDefinition` is required for DTS.** Without it, tsup DTS workers compute conflicting representations of the handler return union (TS2719). All 20 handlers wrap their return in `{ textContent: result }`.
 
-### Traps to remember
+**`ToolResultBlock.content` is always an array of blocks**, never a plain string.
 
-**`ToolHandler<never>` is intentional.** `AnyToolDefinition.handler` is typed as `ToolHandler<never>`. This is contravariance: any specifically-typed handler is assignable to `ToolHandler<never>` because `never` is a subtype of everything. Changing it to `ToolHandler<unknown>` breaks the tools package. A JSDoc comment explains this. Do not change it.
+**`InputMimeTypeSchema` and `SupportedMimeTypeSchema` are separate schemas.** Same values now but different purposes; they will diverge.
 
-**`output_schema` on `ToolDefinition` is required for DTS.** tsup runs DTS workers in parallel. Without `output_schema`, workers compute conflicting representations of the handler return union from the handler body (TS2719). The schema gives TypeScript a single concrete inference site. All 20 handlers wrap their return in `{ textContent: result }`.
+**ASCII-only magic bytes in MemoryFileSystem tests.** `Buffer.from(str)` interprets as UTF-8. `\xff` (U+00FF) becomes two bytes `[0xC3, 0xBF]`. Use ASCII-safe content. GIF magic bytes (`GIF89a`) are safe; JPEG magic bytes (`\xff\xd8\xff`) are not.
 
-**Content is always an array of blocks.** `ToolResultBlock.content` is `ToolResultBlockContent[] | undefined`, never a plain string. Error paths that previously set `content: 'some string'` were changed to `content: [{ type: 'text', text: '...' }]`. Consumers don't branch on type.
-
-**`InputMimeTypeSchema` and `SupportedMimeTypeSchema` are separate schemas.** They happen to share values right now, but they serve different purposes. `InputMimeTypeSchema` is caller intent. `SupportedMimeTypeSchema` is what the system can detect. They will diverge.
-
-**`detectBlock` returns a discriminated union where text is just another case.** `case undefined` (file-type returned nothing) is the text path. No separate `if (!type)` branch. If you find yourself reaching for a separate code path for the text case, unify it into the switch instead.
-
-**ASCII-only magic bytes in MemoryFileSystem tests.** `Buffer.from(str)` with default encoding interprets the string as UTF-8. `\xff` (U+00FF) becomes two bytes `[0xC3, 0xBF]`, not `[0xFF]`. Tests that depend on specific byte values must use ASCII-only content. GIF magic bytes (`GIF89a`) are ASCII-safe; JPEG magic bytes (`\xff\xd8\xff`) are not.
-
-### Owned types replacing SDK types
-
-`BetaToolResultBlockParam` is gone from production code. We own what we build. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours. The SDK types are wide interfaces covering every source variant; we only construct base64 variants. Narrow types eliminated `as any` in tests and made the spec helpers (`getTextBlock`, `getDocumentBlock`) type-clean.
-
+**Owned types.** `BetaToolResultBlockParam` is gone. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours.
 
 # 22:28
 
 ## Four rendering bug fixes: W-1, A-1, D-1, D-2
 
-Mission: fix four bugs identified by a Scout investigation. All four are in the active CLI only. Legacy CLI is frozen.
+### W-1: ANSI state on continuation lines
 
-### W-1: ANSI state not re-established on continuation lines
+`wrapLine` now tracks `activeAnsiState` (accumulated SGR since last reset). At each line break, the current line closes with `RESET`, and the continuation starts with `preState + pendingAnsi + segment`.
 
-The root cause: `wrapLine` in `packages/claude-core/src/reflow.ts` did not track which SGR sequences were active at line-break time. Continuation chunks had no colour prefix, relying on the terminal to carry state across newlines.
+Key subtlety: save `preState = activeAnsiState` BEFORE calling `applyToState(pendingAnsi)`. The continuation re-establishes context with `preState`, then emits `pendingAnsi`, then the character. If `pendingAnsi` contains a reset, the re-establishment is immediately cancelled (correct). Only SGR sequences (ending in 'm') affect state.
 
-The fix adds `activeAnsiState` (accumulated SGR since last reset) and an `applyToState` helper inside `wrapLine`. At each line break, the current line is closed with `RESET` (if state is non-empty), and the continuation starts with `preState + pendingAnsi + segment`. `preState` is the state BEFORE `pendingAnsi` was applied, because the break happened at that point.
-
-Key subtlety: at a break, save `preState = activeAnsiState` BEFORE calling `applyToState(pendingAnsi)`. The continuation line starts with the pre-pendingAnsi state (to re-establish context), then emits `pendingAnsi` (which may modify it), then the character. If `pendingAnsi` contains a reset, the continuation is `preState + RESET + char`: the re-establishment is immediately cancelled. A subsequent wrap boundary will have empty `activeAnsiState` (correct).
-
-Only SGR sequences (ending in 'm') affect state. Non-SGR CSI (cursor moves etc.) are skipped.
-
-Existing tests needed updating: the "does not count ANSI color codes toward visible width" and "does not count mid-line cursor sequence" tests had expected values from the old behaviour. Both updated to reflect reset/re-establishment.
+Two existing reflow tests had expected values from the old behaviour; both updated.
 
 ### A-1: Resolved by W-1
 
-Once every continuation line carries its own colour prefix, slicing `allContent` in `renderConversation.ts` is safe. No separate code change.
+Once every continuation line carries its own colour prefix, slicing `allContent` is safe. No separate code change needed.
 
-### D-1: buildDivider uses code-unit length
+### D-1: buildDivider width
 
-One-line fix in `renderConversation.ts`: `prefix.length` to `stringWidth(prefix)`. Added `string-width` as a direct dependency of `claude-sdk-cli` via `pnpm add`.
+`prefix.length` to `stringWidth(prefix)`. Added `string-width` as a direct dependency via `pnpm add`.
 
-### D-2: Editor cursor on emoji produces lone surrogates
+### D-2: Emoji cursor
 
-Two sub-fixes:
+`EditorState.ts`: `graphemeBoundaryBefore`/`graphemeBoundaryAfter` helpers using `Intl.Segmenter`. `cursorCol` stays a code-unit index; only movement is grapheme-aware.
 
-1. `EditorState.ts` left/right: added `graphemeBoundaryBefore` and `graphemeBoundaryAfter` helpers using `Intl.Segmenter`. `cursorCol` remains a code-unit index; only movement becomes grapheme-aware. `char` insertion (`cursorCol += key.value.length`) was already correct.
-
-2. `renderEditor.ts`: replaced `line[cursorCol]` (one code unit) with a segmenter lookup to get the full grapheme cluster under the cursor. `line.slice(cursorCol + 1)` became `line.slice(cursorCol + charUnder.length)`.
+`renderEditor.ts`: segmenter lookup replaces `line[cursorCol]` to get the full grapheme cluster under the cursor.
 
 ### Test trap: lone-surrogate regex
 
-The renderEditor test initially used `/[\uD800-\uDFFF]/` which matches ANY surrogate, including the legitimate pair in '🎉'. The correct regex for lone surrogates: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/`.
-
-### Files changed
-
-- `packages/claude-core/src/reflow.ts` — W-1 fix
-- `packages/claude-core/test/reflow.spec.ts` — W-1 tests (updated 2 existing, added 5 new)
-- `apps/claude-sdk-cli/src/view/renderConversation.ts` — D-1 fix
-- `apps/claude-sdk-cli/src/model/EditorState.ts` — D-2 fix (grapheme helpers + left/right)
-- `apps/claude-sdk-cli/src/view/renderEditor.ts` — D-2 fix (full grapheme under cursor)
-- `apps/claude-sdk-cli/test/renderConversation.spec.ts` — D-1 test
-- `apps/claude-sdk-cli/test/EditorState.spec.ts` — D-2 tests
-- `apps/claude-sdk-cli/test/renderEditor.spec.ts` — D-2 tests
-- `apps/claude-sdk-cli/package.json` + `pnpm-lock.yaml` — added string-width dependency
+`/[\uD800-\uDFFF]/` matches ANY surrogate including the legitimate pair in '🎉'. Correct regex for lone surrogates: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/`.

--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -27,3 +27,54 @@ The fix: handlers return `{ textContent, attachments? }`. ToolRegistry destructu
 ### Owned types replacing SDK types
 
 `BetaToolResultBlockParam` is gone from production code. We own what we build. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours. The SDK types are wide interfaces covering every source variant; we only construct base64 variants. Narrow types eliminated `as any` in tests and made the spec helpers (`getTextBlock`, `getDocumentBlock`) type-clean.
+
+
+# 22:28
+
+## Four rendering bug fixes: W-1, A-1, D-1, D-2
+
+Mission: fix four bugs identified by a Scout investigation. All four are in the active CLI only. Legacy CLI is frozen.
+
+### W-1: ANSI state not re-established on continuation lines
+
+The root cause: `wrapLine` in `packages/claude-core/src/reflow.ts` did not track which SGR sequences were active at line-break time. Continuation chunks had no colour prefix, relying on the terminal to carry state across newlines.
+
+The fix adds `activeAnsiState` (accumulated SGR since last reset) and an `applyToState` helper inside `wrapLine`. At each line break, the current line is closed with `RESET` (if state is non-empty), and the continuation starts with `preState + pendingAnsi + segment`. `preState` is the state BEFORE `pendingAnsi` was applied, because the break happened at that point.
+
+Key subtlety: at a break, save `preState = activeAnsiState` BEFORE calling `applyToState(pendingAnsi)`. The continuation line starts with the pre-pendingAnsi state (to re-establish context), then emits `pendingAnsi` (which may modify it), then the character. If `pendingAnsi` contains a reset, the continuation is `preState + RESET + char`: the re-establishment is immediately cancelled. A subsequent wrap boundary will have empty `activeAnsiState` (correct).
+
+Only SGR sequences (ending in 'm') affect state. Non-SGR CSI (cursor moves etc.) are skipped.
+
+Existing tests needed updating: the "does not count ANSI color codes toward visible width" and "does not count mid-line cursor sequence" tests had expected values from the old behaviour. Both updated to reflect reset/re-establishment.
+
+### A-1: Resolved by W-1
+
+Once every continuation line carries its own colour prefix, slicing `allContent` in `renderConversation.ts` is safe. No separate code change.
+
+### D-1: buildDivider uses code-unit length
+
+One-line fix in `renderConversation.ts`: `prefix.length` to `stringWidth(prefix)`. Added `string-width` as a direct dependency of `claude-sdk-cli` via `pnpm add`.
+
+### D-2: Editor cursor on emoji produces lone surrogates
+
+Two sub-fixes:
+
+1. `EditorState.ts` left/right: added `graphemeBoundaryBefore` and `graphemeBoundaryAfter` helpers using `Intl.Segmenter`. `cursorCol` remains a code-unit index; only movement becomes grapheme-aware. `char` insertion (`cursorCol += key.value.length`) was already correct.
+
+2. `renderEditor.ts`: replaced `line[cursorCol]` (one code unit) with a segmenter lookup to get the full grapheme cluster under the cursor. `line.slice(cursorCol + 1)` became `line.slice(cursorCol + charUnder.length)`.
+
+### Test trap: lone-surrogate regex
+
+The renderEditor test initially used `/[\uD800-\uDFFF]/` which matches ANY surrogate, including the legitimate pair in '🎉'. The correct regex for lone surrogates: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/`.
+
+### Files changed
+
+- `packages/claude-core/src/reflow.ts` — W-1 fix
+- `packages/claude-core/test/reflow.spec.ts` — W-1 tests (updated 2 existing, added 5 new)
+- `apps/claude-sdk-cli/src/view/renderConversation.ts` — D-1 fix
+- `apps/claude-sdk-cli/src/model/EditorState.ts` — D-2 fix (grapheme helpers + left/right)
+- `apps/claude-sdk-cli/src/view/renderEditor.ts` — D-2 fix (full grapheme under cursor)
+- `apps/claude-sdk-cli/test/renderConversation.spec.ts` — D-1 test
+- `apps/claude-sdk-cli/test/EditorState.spec.ts` — D-2 tests
+- `apps/claude-sdk-cli/test/renderEditor.spec.ts` — D-2 tests
+- `apps/claude-sdk-cli/package.json` + `pnpm-lock.yaml` — added string-width dependency

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -26,3 +26,6 @@
 {"description":"Hook commands support ~, $HOME, and relative paths","category":"fixed"}
 {"description":"Hook input delivered via stdin instead of command arguments","category":"changed"}
 {"description":"Support reading PDF and image files as native API content blocks","category":"added"}
+{"description":"Fix colour loss when syntax-highlighted code scrolls off screen","category":"fixed"}
+{"description":"Fix divider width calculation for emoji labels","category":"fixed"}
+{"description":"Fix garbled cursor rendering on emoji characters","category":"fixed"}

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -51,6 +51,7 @@
     "@shellicar/claude-sdk": "workspace:^",
     "@shellicar/claude-sdk-tools": "workspace:^",
     "cli-highlight": "^2.1.11",
+    "string-width": "^8.2.0",
     "typescript": "^5.9.3",
     "winston": "^3.19.0",
     "zod": "^4.3.6"

--- a/apps/claude-sdk-cli/src/model/EditorState.ts
+++ b/apps/claude-sdk-cli/src/model/EditorState.ts
@@ -1,5 +1,39 @@
 import type { KeyAction } from '@shellicar/claude-core/input';
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+/**
+ * Returns the code-unit position of the grapheme boundary immediately before
+ * `pos`. Moves back by one grapheme cluster, so moving left through a
+ * 2-code-unit emoji jumps to its start rather than landing mid-surrogate.
+ */
+function graphemeBoundaryBefore(line: string, pos: number): number {
+  let boundary = 0;
+  for (const { segment, index } of graphemeSegmenter.segment(line)) {
+    const end = index + segment.length;
+    if (end >= pos) {
+      return index;
+    }
+    boundary = index;
+  }
+  return boundary;
+}
+
+/**
+ * Returns the code-unit position after the grapheme cluster that starts at
+ * `pos`. Advances by one grapheme cluster, so moving right through a
+ * 2-code-unit emoji jumps to the character after it.
+ */
+function graphemeBoundaryAfter(line: string, pos: number): number {
+  for (const { segment, index } of graphemeSegmenter.segment(line)) {
+    if (index === pos) {
+      return index + segment.length;
+    }
+  }
+  // Fallback: advance one code unit (should not happen with well-formed text).
+  return pos + 1;
+}
+
 /**
  * Pure editor state — lines of text and cursor position.
  * No rendering, no I/O.
@@ -135,7 +169,8 @@ export class EditorState {
       }
       case 'left': {
         if (this.#cursorCol > 0) {
-          this.#cursorCol--;
+          const line = this.#lines[this.#cursorLine] ?? '';
+          this.#cursorCol = graphemeBoundaryBefore(line, this.#cursorCol);
         } else if (this.#cursorLine > 0) {
           this.#cursorLine--;
           this.#cursorCol = (this.#lines[this.#cursorLine] ?? '').length;
@@ -145,7 +180,7 @@ export class EditorState {
       case 'right': {
         const line = this.#lines[this.#cursorLine] ?? '';
         if (this.#cursorCol < line.length) {
-          this.#cursorCol++;
+          this.#cursorCol = graphemeBoundaryAfter(line, this.#cursorCol);
         } else if (this.#cursorLine < this.#lines.length - 1) {
           this.#cursorLine++;
           this.#cursorCol = 0;

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -1,6 +1,7 @@
 import { DIM, RESET } from '@shellicar/claude-core/ansi';
 import { wrapLine } from '@shellicar/claude-core/reflow';
 import { highlight, supportsLanguage } from 'cli-highlight';
+import stringWidth from 'string-width';
 import type { Block, ConversationState } from '../model/ConversationState.js';
 
 const FILL = '\u2500';
@@ -91,7 +92,7 @@ export function buildDivider(displayLabel: string | null, cols: number): string 
     return DIM + FILL.repeat(cols) + RESET;
   }
   const prefix = `${FILL}${FILL} ${displayLabel} `;
-  const remaining = Math.max(0, cols - prefix.length);
+  const remaining = Math.max(0, cols - stringWidth(prefix));
   return DIM + prefix + FILL.repeat(remaining) + RESET;
 }
 

--- a/apps/claude-sdk-cli/src/view/renderEditor.ts
+++ b/apps/claude-sdk-cli/src/view/renderEditor.ts
@@ -23,8 +23,14 @@ export function renderEditor(state: EditorState, cols: number): string[] {
     const pfx = i === 0 ? PROMPT_PREFIX : INDENT;
     const line = state.lines[i] ?? '';
     if (i === state.cursorLine) {
-      const charUnder = line[state.cursorCol] ?? ' ';
-      const withCursor = `${line.slice(0, state.cursorCol)}${INVERSE_ON}${charUnder}${INVERSE_OFF}${line.slice(state.cursorCol + 1)}`;
+      // Use a segmenter to read the full grapheme cluster under the cursor
+      // rather than a single code unit. This prevents lone surrogates when the
+      // cursor rests on a 2-code-unit emoji (e.g. 🎉).
+      const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+      const segs = [...seg.segment(line)];
+      const grapheme = segs.find((s) => s.index === state.cursorCol);
+      const charUnder = grapheme?.segment ?? ' ';
+      const withCursor = `${line.slice(0, state.cursorCol)}${INVERSE_ON}${charUnder}${INVERSE_OFF}${line.slice(state.cursorCol + charUnder.length)}`;
       out.push(...wrapLine(pfx + withCursor, cols));
     } else {
       out.push(...wrapLine(pfx + line, cols));

--- a/apps/claude-sdk-cli/test/EditorState.spec.ts
+++ b/apps/claude-sdk-cli/test/EditorState.spec.ts
@@ -405,6 +405,17 @@ describe('EditorState — left', () => {
     const actual = s.cursorCol;
     expect(actual).toBe(expected);
   });
+
+  it('moves back by the full grapheme when at the end of a 2-code-unit emoji (D-2)', () => {
+    // \uD83C\uDF89 is U+1F389 PARTY POPPER: 2 code units, 1 grapheme
+    // After typing it, cursorCol = 2. One left should land at 0, not 1.
+    const s = new EditorState();
+    s.handleKey(char('\uD83C\uDF89'));
+    s.handleKey(key('left'));
+    const actual = s.cursorCol;
+    const expected = 0;
+    expect(actual).toBe(expected);
+  });
 });
 
 describe('EditorState — right', () => {
@@ -415,6 +426,17 @@ describe('EditorState — right', () => {
     s.handleKey(key('right'));
     const expected = 1;
     const actual = s.cursorCol;
+    expect(actual).toBe(expected);
+  });
+
+  it('advances by the full grapheme when on a 2-code-unit emoji (D-2)', () => {
+    // Type \uD83C\uDF89 then go home: cursor at 0. One right should land at 2, not 1.
+    const s = new EditorState();
+    s.handleKey(char('\uD83C\uDF89'));
+    s.handleKey(key('home'));
+    s.handleKey(key('right'));
+    const actual = s.cursorCol;
+    const expected = 2;
     expect(actual).toBe(expected);
   });
 

--- a/apps/claude-sdk-cli/test/renderConversation.spec.ts
+++ b/apps/claude-sdk-cli/test/renderConversation.spec.ts
@@ -1,3 +1,4 @@
+import stringWidth from 'string-width';
 import { describe, expect, it } from 'vitest';
 import { ConversationState } from '../src/model/ConversationState.js';
 import { buildDivider, renderConversation } from '../src/view/renderConversation.js';
@@ -145,6 +146,19 @@ describe('buildDivider', () => {
     // Should contain fill characters beyond the prefix
     const actual = result.includes('\u2500\u2500 hi ');
     expect(actual).toBe(true);
+  });
+
+  it('fills exactly cols visual columns for an emoji label (D-1)', () => {
+    // Before the fix, prefix.length used code units: \u{1F527} has length 2
+    // but also visual width 2, so this test passes either way for that emoji.
+    // \u2139\uFE0F (information source + variation selector) has .length = 2
+    // but stringWidth may return 1 or 2 depending on terminal. The divider must
+    // always fill exactly `cols` regardless.
+    const cols = 40;
+    const result = stripAnsi(buildDivider('\uD83D\uDD27 tools', cols));
+    const actual = stringWidth(result);
+    const expected = cols;
+    expect(actual).toBe(expected);
   });
 });
 

--- a/apps/claude-sdk-cli/test/renderEditor.spec.ts
+++ b/apps/claude-sdk-cli/test/renderEditor.spec.ts
@@ -1,4 +1,4 @@
-import { INVERSE_ON } from '@shellicar/claude-core/ansi';
+import { INVERSE_OFF, INVERSE_ON } from '@shellicar/claude-core/ansi';
 import { describe, expect, it } from 'vitest';
 import { EditorState } from '../src/model/EditorState.js';
 import { renderEditor } from '../src/view/renderEditor.js';
@@ -126,6 +126,42 @@ describe('renderEditor — no divider', () => {
     const s = makeState('hello');
     const expected = false;
     const actual = renderEditor(s, COLS).some((line) => line.includes('─'));
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grapheme-aware cursor (D-2)
+// ---------------------------------------------------------------------------
+
+describe('renderEditor — emoji cursor (D-2)', () => {
+  it('cursor on a 2-code-unit emoji does not produce lone surrogates in output', () => {
+    // Type the party popper emoji (\uD83C\uDF89, 2 code units), go home so
+    // the cursor is at position 0 (start of the emoji). renderEditor must
+    // include the full grapheme inside the INVERSE block, not just the high
+    // surrogate with the low surrogate dangling after INVERSE_OFF.
+    const s = new EditorState();
+    s.handleKey(char('\uD83C\uDF89'));
+    s.handleKey(key('home'));
+    const output = renderEditor(s, COLS).join('');
+    // Matches a high surrogate NOT followed by a low surrogate, or a low
+    // surrogate NOT preceded by a high surrogate. Paired surrogates (a
+    // complete emoji like \uD83C\uDF89) do NOT match.
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: testing for lone Unicode surrogates
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    const actual = loneSurrogate.test(output);
+    const expected = false;
+    expect(actual).toBe(expected);
+  });
+
+  it('cursor at the start of an emoji highlights the full emoji, not just the high surrogate', () => {
+    const s = new EditorState();
+    s.handleKey(char('\uD83C\uDF89'));
+    s.handleKey(key('home'));
+    const output = renderEditor(s, COLS).join('');
+    // The inverse block should contain the full 2-code-unit emoji (\uD83C\uDF89)
+    const actual = output.includes(`${INVERSE_ON}\uD83C\uDF89${INVERSE_OFF}`);
+    const expected = true;
     expect(actual).toBe(expected);
   });
 });

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -1,2 +1,3 @@
 {"description":"Package now publishes CJS alongside ESM with working sourcemaps","category":"fixed"}
 {"description":"Support binary file reads through encoding parameter on IFileSystem.readFile","category":"added"}
+{"description":"Re-establish ANSI colour state on wrapped continuation lines","category":"fixed"}

--- a/packages/claude-core/src/reflow.ts
+++ b/packages/claude-core/src/reflow.ts
@@ -1,4 +1,5 @@
 import stringWidth from 'string-width';
+import { RESET } from './ansi.js';
 import { sanitiseZwj } from './sanitise.js';
 
 const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
@@ -139,15 +140,43 @@ export function wrapLine(line: string, columns: number): string[] {
   let current = '';
   let currentWidth = 0;
   let pendingAnsi = '';
+  // Accumulated SGR state: all sequences in effect since the last reset.
+  // Tracked so continuation lines can re-establish colour context when
+  // displayed in isolation (e.g. after allContent.slice(overflow)).
+  let activeAnsiState = '';
+
+  // Apply any SGR sequences in `seqs` to `activeAnsiState`.
+  // Only sequences ending in 'm' are SGR; other CSI sequences (cursor moves,
+  // etc.) are not relevant to colour state.
+  const applyToState = (seqs: string): void => {
+    for (const match of seqs.matchAll(ANSI_RE)) {
+      const seq = match[0];
+      if (!seq.endsWith('m')) {
+        continue;
+      }
+      if (seq === '\x1b[0m' || seq === '\x1b[m') {
+        activeAnsiState = '';
+      } else {
+        activeAnsiState += seq;
+      }
+    }
+  };
 
   const placeChar = (segment: string, cw: number) => {
     if (currentWidth + cw > columns) {
-      result.push(current);
-      current = pendingAnsi + segment;
+      // Close the current line: append a reset if any colour state is active
+      // so the terminal doesn't bleed that state onto the next render row.
+      result.push(activeAnsiState ? current + RESET : current);
+      // Continuation line: re-establish the pre-pendingAnsi state, then
+      // emit the pending ANSI sequences, then the character.
+      const preState = activeAnsiState;
+      applyToState(pendingAnsi);
+      current = preState + pendingAnsi + segment;
       pendingAnsi = '';
       currentWidth = cw;
     } else {
       current += pendingAnsi + segment;
+      applyToState(pendingAnsi);
       pendingAnsi = '';
       currentWidth += cw;
     }

--- a/packages/claude-core/test/reflow.spec.ts
+++ b/packages/claude-core/test/reflow.spec.ts
@@ -34,18 +34,68 @@ describe('wrapLine', () => {
   it('does not count ANSI color codes toward the visible line width', () => {
     // Visible text is 'helloworld!' = 11 chars; split should be at visible col 10.
     // \x1b[33m is 5 bytes but 0 visible width — must not shift the split point.
+    // After the W-1 fix: the first chunk ends with RESET, the second re-establishes YELLOW.
     const line = `${YELLOW}helloworld!${RESET}`;
     const actual = wrapLine(line, 10);
-    const expected = [`${YELLOW}helloworld`, `!${RESET}`];
+    const expected = [`${YELLOW}helloworld${RESET}`, `${YELLOW}!${RESET}`];
     expect(actual).toEqual(expected);
   });
 
   it('does not count a mid-line cursor sequence toward the visible line width', () => {
     // '01' + cursor 'X' + '3456789' = 10 visible chars on line 1, 'abc' overflows.
     // The 7 bytes of INVERSE_ON+INVERSE_OFF must not eat into the 10-col budget.
+    // INVERSE_ON (\x1b[7m) and INVERSE_OFF (\x1b[27m) are both SGR sequences, so
+    // their combined state is carried to the continuation line (visually a no-op).
     const line = `01${INVERSE_ON}X${INVERSE_OFF}3456789abc`;
     const actual = wrapLine(line, 10);
-    const expected = [`01${INVERSE_ON}X${INVERSE_OFF}3456789`, 'abc'];
+    const expected = [`01${INVERSE_ON}X${INVERSE_OFF}3456789${RESET}`, `${INVERSE_ON}${INVERSE_OFF}abc`];
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('wrapLine — ANSI state continuations (W-1)', () => {
+  it('continuation line starts with the colour that was active at the break point', () => {
+    // 15 yellow A's wrap at col 10: the second chunk must re-establish YELLOW.
+    const line = `${YELLOW}${'A'.repeat(15)}${RESET}`;
+    const wrapped = wrapLine(line, 10);
+    const actual = (wrapped[1] ?? '').startsWith(YELLOW);
+    const expected = true;
+    expect(actual).toBe(expected);
+  });
+
+  it('non-last wrapped line ends with a reset when colour is active', () => {
+    const line = `${YELLOW}${'A'.repeat(15)}${RESET}`;
+    const wrapped = wrapLine(line, 10);
+    const actual = (wrapped[0] ?? '').endsWith(RESET);
+    const expected = true;
+    expect(actual).toBe(expected);
+  });
+
+  it('no reset is added to a non-last line when no colour is active at the break', () => {
+    // Plain text: no ANSI at all — no spurious reset should appear.
+    const wrapped = wrapLine('A'.repeat(15), 10);
+    const actual = (wrapped[0] ?? '').endsWith(RESET);
+    const expected = false;
+    expect(actual).toBe(expected);
+  });
+
+  it('colour state is re-established on every continuation line for multi-wrap lines', () => {
+    // 25 yellow A's wrapped at 10: all three chunks must carry YELLOW.
+    const line = `${YELLOW}${'A'.repeat(25)}${RESET}`;
+    const wrapped = wrapLine(line, 10);
+    const actual = (wrapped[2] ?? '').startsWith(YELLOW);
+    const expected = true;
+    expect(actual).toBe(expected);
+  });
+
+  it('a reset at the wrap boundary clears the carried state for subsequent continuations', () => {
+    // 10 yellow A's fill line 0. RESET then 20 plain B's follow.
+    // Line 1: starts with preState(YELLOW)+RESET+B's (pendingAnsi resets the re-establishment)
+    // Line 2: no colour prefix (state was empty after line 1 break)
+    const line = `${YELLOW}${'A'.repeat(10)}${RESET}${'B'.repeat(20)}`;
+    const wrapped = wrapLine(line, 10);
+    const actual = (wrapped[2] ?? '').startsWith(YELLOW);
+    const expected = false;
+    expect(actual).toBe(expected);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       cli-highlight:
         specifier: ^2.1.11
         version: 2.1.11
+      string-width:
+        specifier: ^8.2.0
+        version: 8.2.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Restore ANSI colour on wrapped continuation lines
- Fix colour loss when syntax-highlighted code scrolls off screen
- Fix divider width calculation for emoji labels
- Fix garbled cursor rendering on emoji characters

Closes #217
Closes #218