### PR TITLE
Make maxTokens and CLAUDE.md sources configurable

### DIFF
--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -27,3 +27,35 @@ The fix: handlers return `{ textContent, attachments? }`. ToolRegistry destructu
 ### Owned types replacing SDK types
 
 `BetaToolResultBlockParam` is gone from production code. We own what we build. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours. The SDK types are wide interfaces covering every source variant; we only construct base64 variants. Narrow types eliminated `as any` in tests and made the spec helpers (`getTextBlock`, `getDocumentBlock`) type-clean.
+
+# 21:37
+
+## Phase 1: maxTokens + claudeMd sources config
+
+Straightforward config extension. Both changes followed the existing pattern cleanly.
+
+### maxTokens
+
+`maxTokens: 32000` was hardcoded in `mapConfig()` in `main.ts`. Added it to `sdkConfigSchema` with `.optional().default(32_000).catch(32_000)`. Wired `configLoader.config.maxTokens` into `mapConfig()`. No type friction.
+
+### claudeMd sources
+
+`ClaudeMdLoader` had a hardcoded array of four files. Added a `source` key (`'user' | 'project' | 'projectClaude' | 'local'`) to each entry. Exported `ClaudeMdSources` type from `ClaudeMdLoader.ts` so tests could use it explicitly. Added `DEFAULT_SOURCES` (all true) so existing calls to `getContent()` without arguments still work.
+
+The `enabled` flag lives outside `ClaudeMdLoader` in `main.ts` (a conditional around the `getContent()` call). Sources are passed as a parameter on each call. This means config hot-reload is automatically respected: every turn reads the live config.
+
+### On the "enabled=false skips all regardless of sources" test requirement
+
+The `enabled` check is in `main.ts`, not in `ClaudeMdLoader`. A test for that behavior would need to reach through `main.ts` (no integration test exists for it). The `returns null when all sources are disabled` test in `ClaudeMdLoader.spec.ts` covers the equivalent behavior at the loader level. The schema tests confirm `enabled` and `sources` parse correctly as independent fields.
+
+### Config test snapshot
+
+`cli-config.spec.ts` has a full-equality snapshot test for the default config object. It had to be updated to include `maxTokens: 32_000` and `sources: { user: true, project: true, projectClaude: true, local: true }`. Also updated the `falls back to defaults on invalid value` test for `claudeMd` for the same reason.
+
+### Files changed
+
+- `apps/claude-sdk-cli/src/cli-config/schema.ts` (added `claudeMdSourcesSchema`, extended `claudeMdSchema`, added `maxTokens`)
+- `apps/claude-sdk-cli/src/ClaudeMdLoader.ts` (exported `ClaudeMdSources`, added `source` to file entries, updated `getContent` signature)
+- `apps/claude-sdk-cli/src/entry/main.ts` (wired `maxTokens` and `claudeMd.sources`)
+- `apps/claude-sdk-cli/test/cli-config.spec.ts` (updated snapshot, added sources and maxTokens tests)
+- `apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts` (added sources filtering test suite)

--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -36,26 +36,22 @@ Straightforward config extension. Both changes followed the existing pattern cle
 
 ### maxTokens
 
-`maxTokens: 32000` was hardcoded in `mapConfig()` in `main.ts`. Added it to `sdkConfigSchema` with `.optional().default(32_000).catch(32_000)`. Wired `configLoader.config.maxTokens` into `mapConfig()`. No type friction.
+`maxTokens: 32000` was hardcoded in `mapConfig()` in `main.ts`. Added `maxTokens` to `sdkConfigSchema`, wired `configLoader.config.maxTokens` into `mapConfig()`.
 
 ### claudeMd sources
 
-`ClaudeMdLoader` had a hardcoded array of four files. Added a `source` key (`'user' | 'project' | 'projectClaude' | 'local'`) to each entry. Exported `ClaudeMdSources` type from `ClaudeMdLoader.ts` so tests could use it explicitly. Added `DEFAULT_SOURCES` (all true) so existing calls to `getContent()` without arguments still work.
+`ClaudeMdLoader` had a hardcoded array of four files. Each entry now has a `source` key (`'user' | 'project' | 'projectClaude' | 'local'`). `ClaudeMdSources` type exported from `ClaudeMdLoader.ts`. `DEFAULT_SOURCES` (all true) added so existing `getContent()` calls without arguments still work.
 
-The `enabled` flag lives outside `ClaudeMdLoader` in `main.ts` (a conditional around the `getContent()` call). Sources are passed as a parameter on each call. This means config hot-reload is automatically respected: every turn reads the live config.
+Sources are passed as a parameter on each call (not at construction). The `enabled` check is a conditional in `main.ts` around the `getContent()` call. Hot-reload is automatic: every turn reads the live config.
 
-### On the "enabled=false skips all regardless of sources" test requirement
+### The "enabled=false skips all" test gap
 
-The `enabled` check is in `main.ts`, not in `ClaudeMdLoader`. A test for that behavior would need to reach through `main.ts` (no integration test exists for it). The `returns null when all sources are disabled` test in `ClaudeMdLoader.spec.ts` covers the equivalent behavior at the loader level. The schema tests confirm `enabled` and `sources` parse correctly as independent fields.
+The `enabled` check is in `main.ts`, not in `ClaudeMdLoader`. No integration harness exists to test it. The `returns null when all sources are disabled` test covers the equivalent at the loader level. PM flagged this for a future decision on whether an integration harness is worth adding.
 
-### Config test snapshot
+### Config snapshot test
 
-`cli-config.spec.ts` has a full-equality snapshot test for the default config object. It had to be updated to include `maxTokens: 32_000` and `sources: { user: true, project: true, projectClaude: true, local: true }`. Also updated the `falls back to defaults on invalid value` test for `claudeMd` for the same reason.
+`cli-config.spec.ts` has a full-equality snapshot for the default config. Adding new fields requires updating it. Any future config additions must update this test.
 
-### Files changed
+# 23:13
 
-- `apps/claude-sdk-cli/src/cli-config/schema.ts` (added `claudeMdSourcesSchema`, extended `claudeMdSchema`, added `maxTokens`)
-- `apps/claude-sdk-cli/src/ClaudeMdLoader.ts` (exported `ClaudeMdSources`, added `source` to file entries, updated `getContent` signature)
-- `apps/claude-sdk-cli/src/entry/main.ts` (wired `maxTokens` and `claudeMd.sources`)
-- `apps/claude-sdk-cli/test/cli-config.spec.ts` (updated snapshot, added sources and maxTokens tests)
-- `apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts` (added sources filtering test suite)
+## Phase 2: Courier

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -26,3 +26,5 @@
 {"description":"Hook commands support ~, $HOME, and relative paths","category":"fixed"}
 {"description":"Hook input delivered via stdin instead of command arguments","category":"changed"}
 {"description":"Support reading PDF and image files as native API content blocks","category":"added"}
+{"description":"Add maxTokens to config (default 32000)","category":"added"}
+{"description":"Add per-source CLAUDE.md loading control","category":"added"}

--- a/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
+++ b/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
@@ -3,9 +3,19 @@ import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 
 const INSTRUCTION_PREFIX = 'Codebase and user instructions are shown below. Be sure to adhere to these instructions. ' + 'IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.';
 
+export type ClaudeMdSources = {
+  user: boolean;
+  project: boolean;
+  projectClaude: boolean;
+  local: boolean;
+};
+
+const DEFAULT_SOURCES: ClaudeMdSources = { user: true, project: true, projectClaude: true, local: true };
+
 type ClaudeMdFile = {
   path: string;
   label: string;
+  source: keyof ClaudeMdSources;
 };
 
 function claudeMdFiles(cwd: string, home: string): ClaudeMdFile[] {
@@ -13,18 +23,22 @@ function claudeMdFiles(cwd: string, home: string): ClaudeMdFile[] {
     {
       path: resolve(home, '.claude', 'CLAUDE.md'),
       label: "user's private global instructions for all projects",
+      source: 'user',
     },
     {
       path: resolve(cwd, 'CLAUDE.md'),
       label: 'project instructions',
+      source: 'project',
     },
     {
       path: resolve(cwd, '.claude', 'CLAUDE.md'),
       label: 'project-scoped instructions',
+      source: 'projectClaude',
     },
     {
       path: resolve(cwd, 'CLAUDE.local.md'),
       label: 'local machine instructions (not committed)',
+      source: 'local',
     },
   ];
 }
@@ -51,10 +65,11 @@ export class ClaudeMdLoader {
   }
 
   /** Reads all CLAUDE.md files and returns the formatted content, or null if none were found. */
-  public async getContent(): Promise<string | null> {
+  public async getContent(sources: ClaudeMdSources = DEFAULT_SOURCES): Promise<string | null> {
     const sections: string[] = [];
 
     for (const file of claudeMdFiles(this.#fs.cwd(), this.#fs.homedir())) {
+      if (!sources[file.source]) continue;
       const content = await readIfPresent(this.#fs, file.path);
       if (content != null) {
         sections.push(`Contents of ${file.path} (${file.label}):\n\n${content}`);

--- a/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
+++ b/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
@@ -69,7 +69,9 @@ export class ClaudeMdLoader {
     const sections: string[] = [];
 
     for (const file of claudeMdFiles(this.#fs.cwd(), this.#fs.homedir())) {
-      if (!sources[file.source]) continue;
+      if (!sources[file.source]) {
+        continue;
+      }
       const content = await readIfPresent(this.#fs, file.path);
       if (content != null) {
         sections.push(`Contents of ${file.path} (${file.label}):\n\n${content}`);

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -11,13 +11,25 @@ const historyReplaySchema = z
   .default({ enabled: true, showThinking: false })
   .catch({ enabled: true, showThinking: false });
 
+const claudeMdSourcesSchema = z
+  .object({
+    user: z.boolean().optional().default(true).catch(true).describe('Load ~/.claude/CLAUDE.md'),
+    project: z.boolean().optional().default(true).catch(true).describe('Load ./CLAUDE.md'),
+    projectClaude: z.boolean().optional().default(true).catch(true).describe('Load ./.claude/CLAUDE.md'),
+    local: z.boolean().optional().default(true).catch(true).describe('Load ./CLAUDE.local.md'),
+  })
+  .optional()
+  .default({ user: true, project: true, projectClaude: true, local: true })
+  .catch({ user: true, project: true, projectClaude: true, local: true });
+
 const claudeMdSchema = z
   .object({
     enabled: z.boolean().optional().default(true).catch(true).describe('Load CLAUDE.md files as system prompts'),
+    sources: claudeMdSourcesSchema.describe('Per-source CLAUDE.md loading control'),
   })
   .optional()
-  .default({ enabled: true })
-  .catch({ enabled: true });
+  .default({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } })
+  .catch({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } });
 
 const compactSchema = z
   .object({
@@ -104,6 +116,7 @@ export const sdkConfigSchema = z
   .object({
     $schema: z.string().optional().describe('JSON Schema reference for editor autocomplete'),
     model: z.string().optional().default(DEFAULT_MODEL).catch(DEFAULT_MODEL).describe('Claude model to use'),
+    maxTokens: z.number().int().positive().optional().default(32_000).catch(32_000).describe('Maximum tokens per response'),
     historyReplay: historyReplaySchema.describe('History replay configuration'),
     claudeMd: claudeMdSchema.describe('CLAUDE.md loading configuration'),
     compact: compactSchema.describe('Compaction configuration'),

--- a/apps/claude-sdk-cli/src/entry/main.ts
+++ b/apps/claude-sdk-cli/src/entry/main.ts
@@ -230,7 +230,7 @@ const main = async () => {
 
     return {
       model: configLoader.config.model,
-      maxTokens: 32000,
+      maxTokens: configLoader.config.maxTokens,
       thinking: true,
       systemPrompts,
       tools,
@@ -288,7 +288,7 @@ const main = async () => {
   const claudeMdLoader = new ClaudeMdLoader(nodeFs);
 
   const runTurn = async (userInput: UserInput) => {
-    const claudeMdContent = configLoader.config.claudeMd.enabled ? await claudeMdLoader.getContent() : null;
+    const claudeMdContent = configLoader.config.claudeMd.enabled ? await claudeMdLoader.getContent(configLoader.config.claudeMd.sources) : null;
 
     // Update durable config with current values before each query
     Object.assign(durableConfig, mapConfig());

--- a/apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts
+++ b/apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { ClaudeMdLoader } from '../src/ClaudeMdLoader.js';
+import { type ClaudeMdSources, ClaudeMdLoader } from '../src/ClaudeMdLoader.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+const ALL_SOURCES: ClaudeMdSources = { user: true, project: true, projectClaude: true, local: true };
 
 const CWD = '/project';
 const HOME = '/home/user';
@@ -133,5 +135,111 @@ describe('ClaudeMdLoader', () => {
 
     expect(content).toContain('Trimmed content.');
     expect(content).not.toContain('\n\n  Trimmed');
+  });
+});
+
+describe('ClaudeMdLoader — sources', () => {
+  it('skips user file when user source is disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${HOME}/.claude/CLAUDE.md`]: 'User content.',
+        [`${CWD}/CLAUDE.md`]: 'Project content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { ...ALL_SOURCES, user: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).not.toContain('User content.');
+  });
+
+  it('still loads other files when user source is disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${HOME}/.claude/CLAUDE.md`]: 'User content.',
+        [`${CWD}/CLAUDE.md`]: 'Project content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { ...ALL_SOURCES, user: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).toContain('Project content.');
+  });
+
+  it('skips project file when project source is disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${CWD}/CLAUDE.md`]: 'Project root content.',
+        [`${CWD}/.claude/CLAUDE.md`]: 'Scoped content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { ...ALL_SOURCES, project: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).not.toContain('Project root content.');
+  });
+
+  it('skips projectClaude file when projectClaude source is disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${CWD}/.claude/CLAUDE.md`]: 'Scoped content.',
+        [`${CWD}/CLAUDE.local.md`]: 'Local content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { ...ALL_SOURCES, projectClaude: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).not.toContain('Scoped content.');
+  });
+
+  it('skips local file when local source is disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${CWD}/CLAUDE.md`]: 'Project content.',
+        [`${CWD}/CLAUDE.local.md`]: 'Local content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { ...ALL_SOURCES, local: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).not.toContain('Local content.');
+  });
+
+  it('returns null when all sources are disabled', async () => {
+    const fs = new MemoryFileSystem(
+      {
+        [`${HOME}/.claude/CLAUDE.md`]: 'User content.',
+        [`${CWD}/CLAUDE.md`]: 'Project content.',
+        [`${CWD}/.claude/CLAUDE.md`]: 'Scoped content.',
+        [`${CWD}/CLAUDE.local.md`]: 'Local content.',
+      },
+      HOME,
+      CWD,
+    );
+    const loader = new ClaudeMdLoader(fs);
+    const sources: ClaudeMdSources = { user: false, project: false, projectClaude: false, local: false };
+
+    const actual = await loader.getContent(sources);
+
+    expect(actual).toBeNull();
   });
 });

--- a/apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts
+++ b/apps/claude-sdk-cli/test/ClaudeMdLoader.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type ClaudeMdSources, ClaudeMdLoader } from '../src/ClaudeMdLoader.js';
+import { ClaudeMdLoader, type ClaudeMdSources } from '../src/ClaudeMdLoader.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
 
 const ALL_SOURCES: ClaudeMdSources = { user: true, project: true, projectClaude: true, local: true };

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -11,8 +11,9 @@ describe('sdkConfigSchema', () => {
       const config = parse({});
       expect(config).toEqual({
         model: 'claude-sonnet-4-6',
+        maxTokens: 32_000,
         historyReplay: { enabled: true, showThinking: false },
-        claudeMd: { enabled: true },
+        claudeMd: { enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } },
         compact: { enabled: false, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null },
         advancedTools: { enabled: false, searchTool: null, allowProgrammaticExecution: [], codeExecutionTool: 'code_execution_20260120' },
         serverTools: {
@@ -81,12 +82,44 @@ describe('sdkConfigSchema', () => {
 
     it('falls back to defaults on invalid value', () => {
       const config = parse({ claudeMd: 'bad' });
-      expect(config.claudeMd).toEqual({ enabled: true });
+      expect(config.claudeMd).toEqual({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } });
     });
 
     it('falls back field to default on wrong type', () => {
       const config = parse({ claudeMd: { enabled: 'yes' } });
       expect(config.claudeMd.enabled).toBe(true);
+    });
+
+    it('defaults all sources to true', () => {
+      const config = parse({});
+      expect(config.claudeMd.sources).toEqual({ user: true, project: true, projectClaude: true, local: true });
+    });
+
+    it('overrides individual source', () => {
+      const config = parse({ claudeMd: { sources: { user: false } } });
+      expect(config.claudeMd.sources.user).toBe(false);
+    });
+
+    it('falls back sources field to default on wrong type', () => {
+      const config = parse({ claudeMd: { sources: { user: 'no' } } });
+      expect(config.claudeMd.sources.user).toBe(true);
+    });
+  });
+
+  describe('maxTokens', () => {
+    it('defaults to 32000', () => {
+      const config = parse({});
+      expect(config.maxTokens).toBe(32_000);
+    });
+
+    it('overrides maxTokens', () => {
+      const config = parse({ maxTokens: 8_000 });
+      expect(config.maxTokens).toBe(8_000);
+    });
+
+    it('falls back to default on wrong type', () => {
+      const config = parse({ maxTokens: 'big' });
+      expect(config.maxTokens).toBe(32_000);
     });
   });
 });

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -11,6 +11,12 @@
       "description": "Claude model to use",
       "type": "string"
     },
+    "maxTokens": {
+      "default": 32000,
+      "description": "Maximum tokens per response",
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
     "historyReplay": {
       "default": {
         "enabled": true,
@@ -33,7 +39,13 @@
     },
     "claudeMd": {
       "default": {
-        "enabled": true
+        "enabled": true,
+        "sources": {
+          "user": true,
+          "project": true,
+          "projectClaude": true,
+          "local": true
+        }
       },
       "description": "CLAUDE.md loading configuration",
       "type": "object",
@@ -42,6 +54,38 @@
           "default": true,
           "description": "Load CLAUDE.md files as system prompts",
           "type": "boolean"
+        },
+        "sources": {
+          "default": {
+            "user": true,
+            "project": true,
+            "projectClaude": true,
+            "local": true
+          },
+          "description": "Per-source CLAUDE.md loading control",
+          "type": "object",
+          "properties": {
+            "user": {
+              "default": true,
+              "description": "Load ~/.claude/CLAUDE.md",
+              "type": "boolean"
+            },
+            "project": {
+              "default": true,
+              "description": "Load ./CLAUDE.md",
+              "type": "boolean"
+            },
+            "projectClaude": {
+              "default": true,
+              "description": "Load ./.claude/CLAUDE.md",
+              "type": "boolean"
+            },
+            "local": {
+              "default": true,
+              "description": "Load ./CLAUDE.local.md",
+              "type": "boolean"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add `maxTokens` to config (default 32000); replaces hardcoded value in `main.ts`
- Add per-source control for CLAUDE.md loading (user, project, projectClaude, local)
- All sources default to true; `enabled` remains the master switch

See #105