### PR TITLE
Replace manual stream accumulator with SDK native events

### DIFF
--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -27,3 +27,107 @@ The fix: handlers return `{ textContent, attachments? }`. ToolRegistry destructu
 ### Owned types replacing SDK types
 
 `BetaToolResultBlockParam` is gone from production code. We own what we build. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours. The SDK types are wide interfaces covering every source variant; we only construct base64 variants. Narrow types eliminated `as any` in tests and made the spec helpers (`getTextBlock`, `getDocumentBlock`) type-clean.
+
+
+# 21:37
+
+## Scout: stream refactor investigation (#237)
+
+### What the current StreamProcessor does
+
+`StreamProcessor.process(stream: AsyncIterable<BetaRawMessageStreamEvent>)` is a manual accumulator. It iterates raw SDK stream events in a `for await` loop and maintains a `BlockAccumulator` state machine (`current: BlockAccumulator | null`) that assembles partial events into complete blocks. All per-stream state (current block, completed blocks, token counts, stop reason) lives in local variables inside `process()`.
+
+It emits 10 events: `message_start`, `message_stop`, `message_text`, `thinking_start`, `thinking_text`, `thinking_stop`, `compaction_start`, `compaction_complete`, `server_tool_use`, `server_tool_result`.
+
+### What the SDK's BetaMessageStream provides
+
+`beta.messages.stream(body, options)` returns a `BetaMessageStream`. The current `AnthropicClient` already creates one but returns it typed as `AsyncIterable<BetaRawMessageStreamEvent>`, throwing away the event emitter surface.
+
+The SDK fires `contentBlock` at each `content_block_stop` with the fully assembled block. It fires `text` for each text delta, `thinking` for each thinking delta. It has `streamEvent` for every raw event with the accumulated snapshot. `finalMessage()` awaits stream completion and returns the full `BetaMessage` including all content blocks, stop_reason, usage, and context_management.
+
+### The refactor
+
+`IMessageStreamer.stream()` return type changes from `AsyncIterable<BetaRawMessageStreamEvent>` to `BetaMessageStream`. `IStreamProcessor.process()` parameter type changes the same way.
+
+Inside `StreamProcessor.process()`: subscribe to `stream.on('text', ...)`, `stream.on('thinking', ...)`, `stream.on('contentBlock', ...)`, `stream.on('streamEvent', ...)` for block-start detection. Emit the same `MessageStreamEvents` as before. Then `await stream.finalMessage()` to get all assembled blocks and usage — replacing the entire manual accumulator.
+
+The view layer wiring in `main.ts` does not change. The emitted event names (`MessageStreamEvents`) do not change.
+
+### Test strategy
+
+Current tests pass raw `AsyncIterable<BetaRawMessageStreamEvent>`. After the refactor, they need `BetaMessageStream`. Use `BetaMessageStream.fromReadableStream(readable)` where `readable` is a `ReadableStream` of newline-separated JSON-encoded events. **Important**: `fromReadableStream` requires `message_start` and `message_stop` in the event list (calls `#endRequest()` at the end which checks for the snapshot). Current `StreamProcessor.spec.ts` tests do not include message framing events — they will need a `wrapWithMessageEnvelope` helper.
+
+Import: `BetaMessageStream` is importable from `@anthropic-ai/sdk/lib/BetaMessageStream.js` or via the SDK root.
+
+### Editor clear timing (not a stream processor issue)
+
+The symptom: user can start typing before the editor is ready. Path: `completeStreaming()` (from `runAgent` finally block) sets `#mode='editor'` and calls `#editorState.reset()`. Then `gitMonitor.takeSnapshot()` and `session.saveConversation()` run asynchronously. Then `waitForInput()` is called, which calls `#editorState.reset()` again — clearing anything the user typed in the gap. This is entirely in `AppLayout` / `main.ts`. The stream processor is not involved.
+
+### Three known symptoms
+
+1. Aborted response blocks out of order — SDK's `contentBlock` only fires for completed blocks; incomplete blocks at abort don't fire. Should be better with refactor but not proven without live test.
+2. Final text fragment after block sealed — SDK fires `text` and `contentBlock` synchronously within `#addStreamEvent`; ordering is guaranteed. Should be fixed but not provable without live test.
+3. Editor clear timing — not caused by StreamProcessor. Separate issue in `AppLayout.waitForInput()`.
+
+# 22:17
+
+## Apostle: stream refactor implementation plan (#237)
+
+### What I verified that the Scout didn't trace precisely
+
+**`AnthropicClient.finalMessage` forwarding is load-bearing.** `main.ts` calls `client.on('finalMessage', (msg) => auditWriter.write(session.id, msg))`. This is on `AnthropicClient`'s own internal `#emitter`, populated by `stream.on('finalMessage', ...)` inside `AnthropicClient.stream()`. The `StreamProcessor` calling `await stream.finalMessage()` doesn't affect this — the `finalMessage` event fires before `end`, which fires before `done()` resolves, which is before `stream.finalMessage()` returns. The audit write happens before `process()` returns. The forwarding code in `AnthropicClient.stream()` stays.
+
+**`fromReadableStream` timing is safe.** The key concern: if `BetaMessageStream.fromReadableStream(readable)` starts executing immediately, would events fire before `StreamProcessor.process()` registers its listeners? No. `_run` starts the async executor synchronously, but the executor suspends at the first `for await` on the `ReadableStream`. No events fire until that await resolves. Listeners registered in `process()` before `await stream.finalMessage()` are in place before any events fire.
+
+**`FakeMessageStreamer` must create streams lazily.** Pre-constructing `BetaMessageStream` at test setup time (e.g., `new FakeMessageStreamer([makeTextStream('hello')])` where `makeTextStream` returns a `BetaMessageStream`) would race with listener registration. The fix: store `BetaRawMessageStreamEvent[]` in `FakeMessageStreamer` and call `makeBetaStream(events)` inside `stream()`. The stream is created at the moment `TurnRunner.run()` calls `this.#streamer.stream(...)`, which is immediately before `StreamProcessor.process()` registers listeners.
+
+**`BetaContentBlock` union covers 15 types, 2 are ignored.** `mcp_tool_use` and `container_upload` are skipped in both the `contentBlock` handler and `mapBlocks`. This matches current behavior (`break` without push in `content_block_start`).
+
+**`BetaToolUseBlock.input` is `unknown`, not `Record<string, unknown>`.** Cast required in `mapBlocks`. `BetaServerToolUseBlock.input` is `{ [key: string]: unknown }` — compatible with `Record<string, unknown>`, no cast needed.
+
+**`wrapWithMessageEnvelope` is only needed for `StreamProcessor.spec.ts`.** `TurnRunner.spec.ts` and `QueryRunner.spec.ts` already include complete message framing in their stream helpers.
+
+**`Stream.fromReadableStream` parses newline-separated JSON, not SSE.** Confirmed in `src/core/streaming.ts` lines 111–113. The Scout's `makeBetaStream` format is correct.
+
+### The plan
+
+7 files change. `TurnRunner.ts` does not change — the type flows through automatically once `IMessageStreamer.stream()` and `IStreamProcessor.process()` are updated. `main.ts` and `AgentMessageHandler.ts` are unchanged.
+
+The plan document is at `~/repos/fleet/claude-fleet-shellicar/projects/claude-cli/investigation/2026-04-26_237_stream-refactor-apostle.md`.
+
+# 23:01
+
+## Maker: stream refactor implementation (#237)
+
+### What was built
+
+7 production files changed, 1 new test helper file added:
+
+- `packages/claude-sdk/src/private/MessageStreamer.ts` — return type changed from `AsyncIterable<BetaRawMessageStreamEvent>` to `BetaMessageStream`
+- `packages/claude-sdk/src/public/interfaces.ts` — `IStreamProcessor.process()` param changed to `BetaMessageStream`, removed `Anthropic` namespace import
+- `packages/claude-sdk/src/private/StreamProcessor.ts` — full rewrite: removed `BlockAccumulator` state machine, subscribe to SDK events, `await stream.finalMessage()`, new `mapBlocks()` helper
+- `packages/claude-sdk/src/private/AnthropicClient.ts` — `stream()` return type changed to `BetaMessageStream`
+- `packages/claude-sdk/test/helpers.ts` — NEW: `makeBetaStream()` + `wrapWithMessageEnvelope()` shared across all three spec files
+- `packages/claude-sdk/test/StreamProcessor.spec.ts` — all event arrays wrapped with `wrapWithMessageEnvelope()`, passed to `makeBetaStream()`
+- `packages/claude-sdk/test/TurnRunner.spec.ts` — async generators → arrays, `FakeMessageStreamer` returns `BetaMessageStream` lazily
+- `packages/claude-sdk/test/QueryRunner.spec.ts` — same pattern as TurnRunner
+
+TurnRunner.ts required no changes — the type flows through automatically.
+
+### Deviations from the Apostle plan
+
+**`content: []` required in message_start events.** The Apostle plan did not flag this. The SDK's `_accumulateMessage` returns `event.message` as the initial snapshot for `message_start`. Any subsequent `content_block_start` calls `snapshot.content.push(event.content_block)`. If `message.content` is absent (which the old async-generator tests omitted), `push` throws at runtime. TurnRunner and QueryRunner stream helpers needed `content: []` added to every `message_start` event.
+
+**`wrapWithMessageEnvelope` already included `content: []`.** The StreamProcessor tests worked first try because `MESSAGE_START` in helpers.ts included the field from the start.
+
+**Multi-invocations test fixed with correct sequential indices.** The Apostle plan said to just change `makeStream` → `makeBetaStream(wrapWithMessageEnvelope(...))` for all tests. But the SDK's `_accumulateMessage` for `content_block_delta` uses `snapshot.content.at(event.index)` (not `at(-1)`), while `_addStreamEvent` uses `at(-1)`. When index 0 appears twice in a stream, the second pair's text delta would address `content[0]` (wrong block) instead of the actual text block. The fix: create new event constants with sequential indices (2, 3, 4) for the second server tool pair and text block. This is noted in the test with a comment explaining the SDK's indexing behavior.
+
+**`BetaContentBlock` cast, not `BetaRawMessageStreamEvent`.** The Apostle plan did not specify the inner cast type for `content_block` values. The original spec used `Anthropic.Beta.Messages.BetaContentBlock`. My initial spec used `BetaRawMessageStreamEvent` (incorrect — `BetaRawMessageStreamEvent` is not assignable to `BetaContentBlock`). Fixed by importing `BetaContentBlock` and using that as the cast target.
+
+**`BetaMessageStream` import unused in TurnRunner and QueryRunner spec files.** Both spec files import `{ BetaMessageStream }` for the `FakeMessageStreamer` return type annotation. Biome/tsc may flag this as unused if type-only imports are required. No issues found in current type-check pass.
+
+### Import path used
+
+`@anthropic-ai/sdk/lib/BetaMessageStream.mjs` for both production and test imports — consistent with the `.mjs` pattern used elsewhere in the codebase (`@anthropic-ai/sdk/resources/beta.mjs`). The Apostle plan suggested `.js` for tests; `.mjs` is correct and consistent.
+
+### 136 tests pass, build clean, type-check clean.

--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -1,12 +1,8 @@
-# 17:58
+# PR #312: binary file support and tool output layer
 
-## PR #312: binary file support and tool output layer
+Tool handlers return `{ textContent, attachments? }`. ToolRegistry passes only `textContent` through the ref-swap transform; attachment blocks go directly into `tool_result.content`. This keeps binary data out of the transform path.
 
-Handlers return `{ textContent, attachments? }`. ToolRegistry passes only `textContent` through the ref-swap transform; attachment blocks go directly into `tool_result.content`. This keeps binary data out of the transform path.
-
-### Traps
-
-**`ToolHandler<never>` is intentional.** Contravariance: any specifically-typed handler is assignable to `ToolHandler<never>` because `never` is a subtype of everything. Changing to `ToolHandler<unknown>` breaks the tools package. A JSDoc comment explains this. Do not change it.
+**`ToolHandler<never>` is intentional.** Contravariance: any specifically-typed handler is assignable to `ToolHandler<never>`. Changing to `ToolHandler<unknown>` breaks the tools package. A JSDoc comment explains this. Do not change it.
 
 **`output_schema` on `ToolDefinition` is required for DTS.** Without it, tsup DTS workers compute conflicting representations of the handler return union (TS2719). All 20 handlers wrap their return in `{ textContent: result }`.
 
@@ -14,176 +10,52 @@ Handlers return `{ textContent, attachments? }`. ToolRegistry passes only `textC
 
 **`InputMimeTypeSchema` and `SupportedMimeTypeSchema` are separate schemas.** Same values now but different purposes; they will diverge.
 
-**ASCII-only magic bytes in MemoryFileSystem tests.** `Buffer.from(str)` interprets as UTF-8. `\xff` (U+00FF) becomes two bytes `[0xC3, 0xBF]`. Use ASCII-safe content. GIF magic bytes (`GIF89a`) are safe; JPEG magic bytes (`\xff\xd8\xff`) are not.
+**ASCII-only magic bytes in tests.** `Buffer.from(str)` interprets as UTF-8. `\xff` (U+00FF) becomes two bytes `[0xC3, 0xBF]`. GIF magic bytes (`GIF89a`) are safe; JPEG (`\xff\xd8\xff`) are not.
 
-**Owned types.** `BetaToolResultBlockParam` is gone. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours.
+**Owned types.** `BetaToolResultBlockParam` is gone. Use `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` -- all ours.
 
-# 22:28
+# PR #314: rendering bug fixes
 
-## Four rendering bug fixes: W-1, A-1, D-1, D-2
+Four bugs: ANSI colour on wrapped continuation lines (W-1), sliced content with colour (A-1, resolved by W-1), divider width with unicode (D-1), emoji cursor movement (D-2).
 
-### W-1: ANSI state on continuation lines
+**ANSI continuation (W-1).** `wrapLine` tracks `activeAnsiState`. At each line break: close with RESET, open continuation with `preState + pendingAnsi + segment`. Save `preState = activeAnsiState` BEFORE calling `applyToState(pendingAnsi)` -- order matters. Only SGR sequences (ending in `m`) affect state.
 
-`wrapLine` now tracks `activeAnsiState` (accumulated SGR since last reset). At each line break, the current line closes with `RESET`, and the continuation starts with `preState + pendingAnsi + segment`.
+**Divider width (D-1).** Use `stringWidth(prefix)` not `prefix.length`. `string-width` added as a direct dependency.
 
-`BetaToolResultBlockParam` is gone from production code. We own what we build. `ToolResultBlock`, `DocumentBlock`, `ImageBlock`, `ToolHandlerResult`, `ToolHandler` are all ours. The SDK types are wide interfaces covering every source variant; we only construct base64 variants. Narrow types eliminated `as any` in tests and made the spec helpers (`getTextBlock`, `getDocumentBlock`) type-clean.
+**Emoji cursor (D-2).** `EditorState.ts` uses `graphemeBoundaryBefore`/`graphemeBoundaryAfter` via `Intl.Segmenter`. `cursorCol` stays a code-unit index; only cursor movement is grapheme-aware. `renderEditor.ts` uses the segmenter to get the full grapheme cluster under the cursor.
 
+**Lone-surrogate regex trap.** `/[\uD800-\uDFFF]/` matches any surrogate including legitimate pairs inside emoji. Correct pattern for lone surrogates only: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/`.
 
-# 21:37
+# PR #315: maxTokens and claudeMd sources config
 
-## Scout: stream refactor investigation (#237)
+`maxTokens` was hardcoded at 32000 in `mapConfig()`. Now in `sdkConfigSchema`, wired through `configLoader.config.maxTokens`.
 
-### What the current StreamProcessor does
+`ClaudeMdLoader` had four hardcoded source files. Each source now has an enabled flag. `DEFAULT_SOURCES` (all true) preserves existing behaviour. Sources are passed per-call, not at construction. The `enabled` check lives in `main.ts`, not in `ClaudeMdLoader`.
 
-`StreamProcessor.process(stream: AsyncIterable<BetaRawMessageStreamEvent>)` is a manual accumulator. It iterates raw SDK stream events in a `for await` loop and maintains a `BlockAccumulator` state machine (`current: BlockAccumulator | null`) that assembles partial events into complete blocks. All per-stream state (current block, completed blocks, token counts, stop reason) lives in local variables inside `process()`.
+**Config snapshot test.** `cli-config.spec.ts` has a full-equality snapshot of the default config. Any new field requires updating it.
 
-It emits 10 events: `message_start`, `message_stop`, `message_text`, `thinking_start`, `thinking_text`, `thinking_stop`, `compaction_start`, `compaction_complete`, `server_tool_use`, `server_tool_result`.
+# PR #316: stream processor refactor (#237)
 
-### What the SDK's BetaMessageStream provides
+`StreamProcessor` was a manual accumulator: a `for await` loop over raw `BetaRawMessageStreamEvent`, with a `BlockAccumulator` state machine assembling partial deltas into blocks. `AnthropicClient` already created a `BetaMessageStream` internally but threw away the event emitter by returning it as `AsyncIterable`.
 
-`beta.messages.stream(body, options)` returns a `BetaMessageStream`. The current `AnthropicClient` already creates one but returns it typed as `AsyncIterable<BetaRawMessageStreamEvent>`, throwing away the event emitter surface.
+Now `IMessageStreamer.stream()` and `IStreamProcessor.process()` pass `BetaMessageStream`. `StreamProcessor.process()` subscribes to SDK events (`text`, `thinking`, `contentBlock`, `streamEvent`) and calls `await stream.finalMessage()` instead of accumulating manually. The 10 emitted `MessageStreamEvents` are unchanged. `main.ts` wiring is unchanged. `TurnRunner.ts` required no changes -- the type flows through automatically.
 
-The SDK fires `contentBlock` at each `content_block_stop` with the fully assembled block. It fires `text` for each text delta, `thinking` for each thinking delta. It has `streamEvent` for every raw event with the accumulated snapshot. `finalMessage()` awaits stream completion and returns the full `BetaMessage` including all content blocks, stop_reason, usage, and context_management.
+**`FakeMessageStreamer` must create streams lazily.** Call `makeBetaStream(events)` inside `stream()`, not at construction. If the stream is created before `StreamProcessor.process()` registers listeners, events fire into the void. The stream must be created at the moment `TurnRunner.run()` calls `streamer.stream(...)`, just before `process()` subscribes.
 
-### The refactor
+**`message_start` events need `content: []`.** The SDK's `_accumulateMessage` uses the message object as the initial snapshot. Subsequent `content_block_start` events call `snapshot.content.push(...)`. If `content` is absent, it throws at runtime.
 
-`IMessageStreamer.stream()` return type changes from `AsyncIterable<BetaRawMessageStreamEvent>` to `BetaMessageStream`. `IStreamProcessor.process()` parameter type changes the same way.
+**Sequential block indices are required.** `_accumulateMessage` for `content_block_delta` uses `snapshot.content.at(event.index)`. If two blocks both use index 0, the second delta addresses the first block. Event constants in multi-invocation tests use sequential indices (0, 1, 2, 3...).
 
-Inside `StreamProcessor.process()`: subscribe to `stream.on('text', ...)`, `stream.on('thinking', ...)`, `stream.on('contentBlock', ...)`, `stream.on('streamEvent', ...)` for block-start detection. Emit the same `MessageStreamEvents` as before. Then `await stream.finalMessage()` to get all assembled blocks and usage — replacing the entire manual accumulator.
+**`message_start` stub casts need `as unknown as`.** The minimal stub `{ type: 'message_start', message: { content: [], usage: {...} } }` doesn't satisfy `BetaMessage` (missing `id`, `model`, etc.). Direct `as BetaRawMessageStreamEvent` fails under strict type check. Use `as unknown as BetaRawMessageStreamEvent`.
 
-The view layer wiring in `main.ts` does not change. The emitted event names (`MessageStreamEvents`) do not change.
+**`BetaToolUseBlock.input` is `unknown`.** Cast required in `mapBlocks`. `BetaServerToolUseBlock.input` is `{ [key: string]: unknown }`, no cast needed.
 
-### Test strategy
+**`mcp_tool_use` and `container_upload` are intentionally ignored** in the `contentBlock` handler and `mapBlocks`.
 
-Current tests pass raw `AsyncIterable<BetaRawMessageStreamEvent>`. After the refactor, they need `BetaMessageStream`. Use `BetaMessageStream.fromReadableStream(readable)` where `readable` is a `ReadableStream` of newline-separated JSON-encoded events. **Important**: `fromReadableStream` requires `message_start` and `message_stop` in the event list (calls `#endRequest()` at the end which checks for the snapshot). Current `StreamProcessor.spec.ts` tests do not include message framing events — they will need a `wrapWithMessageEnvelope` helper.
+**Import path is `.mjs`.** `@anthropic-ai/sdk/lib/BetaMessageStream.mjs` -- consistent with `@anthropic-ai/sdk/resources/beta.mjs` used elsewhere.
 
-Import: `BetaMessageStream` is importable from `@anthropic-ai/sdk/lib/BetaMessageStream.js` or via the SDK root.
+**`AnthropicClient.finalMessage` forwarding stays.** `main.ts` subscribes to `client.on('finalMessage', ...)` for audit writes. This is on `AnthropicClient`'s own emitter, populated by `stream.on('finalMessage', ...)` inside `AnthropicClient.stream()`. The `StreamProcessor` calling `await stream.finalMessage()` does not interfere.
 
-### Editor clear timing (not a stream processor issue)
+**Editor clear timing is not a stream processor issue.** `completeStreaming()` resets editor state, then async work runs (`gitMonitor.takeSnapshot()`, `session.saveConversation()`), then `waitForInput()` calls `editorState.reset()` again, clearing anything typed in the gap. All in `AppLayout`/`main.ts`.
 
-The symptom: user can start typing before the editor is ready. Path: `completeStreaming()` (from `runAgent` finally block) sets `#mode='editor'` and calls `#editorState.reset()`. Then `gitMonitor.takeSnapshot()` and `session.saveConversation()` run asynchronously. Then `waitForInput()` is called, which calls `#editorState.reset()` again — clearing anything the user typed in the gap. This is entirely in `AppLayout` / `main.ts`. The stream processor is not involved.
-
-### Three known symptoms
-
-1. Aborted response blocks out of order — SDK's `contentBlock` only fires for completed blocks; incomplete blocks at abort don't fire. Should be better with refactor but not proven without live test.
-2. Final text fragment after block sealed — SDK fires `text` and `contentBlock` synchronously within `#addStreamEvent`; ordering is guaranteed. Should be fixed but not provable without live test.
-3. Editor clear timing — not caused by StreamProcessor. Separate issue in `AppLayout.waitForInput()`.
-
-# 22:17
-
-## Apostle: stream refactor implementation plan (#237)
-
-### What I verified that the Scout didn't trace precisely
-
-**`AnthropicClient.finalMessage` forwarding is load-bearing.** `main.ts` calls `client.on('finalMessage', (msg) => auditWriter.write(session.id, msg))`. This is on `AnthropicClient`'s own internal `#emitter`, populated by `stream.on('finalMessage', ...)` inside `AnthropicClient.stream()`. The `StreamProcessor` calling `await stream.finalMessage()` doesn't affect this — the `finalMessage` event fires before `end`, which fires before `done()` resolves, which is before `stream.finalMessage()` returns. The audit write happens before `process()` returns. The forwarding code in `AnthropicClient.stream()` stays.
-
-**`fromReadableStream` timing is safe.** The key concern: if `BetaMessageStream.fromReadableStream(readable)` starts executing immediately, would events fire before `StreamProcessor.process()` registers its listeners? No. `_run` starts the async executor synchronously, but the executor suspends at the first `for await` on the `ReadableStream`. No events fire until that await resolves. Listeners registered in `process()` before `await stream.finalMessage()` are in place before any events fire.
-
-**`FakeMessageStreamer` must create streams lazily.** Pre-constructing `BetaMessageStream` at test setup time (e.g., `new FakeMessageStreamer([makeTextStream('hello')])` where `makeTextStream` returns a `BetaMessageStream`) would race with listener registration. The fix: store `BetaRawMessageStreamEvent[]` in `FakeMessageStreamer` and call `makeBetaStream(events)` inside `stream()`. The stream is created at the moment `TurnRunner.run()` calls `this.#streamer.stream(...)`, which is immediately before `StreamProcessor.process()` registers listeners.
-
-**`BetaContentBlock` union covers 15 types, 2 are ignored.** `mcp_tool_use` and `container_upload` are skipped in both the `contentBlock` handler and `mapBlocks`. This matches current behavior (`break` without push in `content_block_start`).
-
-**`BetaToolUseBlock.input` is `unknown`, not `Record<string, unknown>`.** Cast required in `mapBlocks`. `BetaServerToolUseBlock.input` is `{ [key: string]: unknown }` — compatible with `Record<string, unknown>`, no cast needed.
-
-**`wrapWithMessageEnvelope` is only needed for `StreamProcessor.spec.ts`.** `TurnRunner.spec.ts` and `QueryRunner.spec.ts` already include complete message framing in their stream helpers.
-
-**`Stream.fromReadableStream` parses newline-separated JSON, not SSE.** Confirmed in `src/core/streaming.ts` lines 111–113. The Scout's `makeBetaStream` format is correct.
-
-### The plan
-
-7 files change. `TurnRunner.ts` does not change — the type flows through automatically once `IMessageStreamer.stream()` and `IStreamProcessor.process()` are updated. `main.ts` and `AgentMessageHandler.ts` are unchanged.
-
-The plan document is at `~/repos/fleet/claude-fleet-shellicar/projects/claude-cli/investigation/2026-04-26_237_stream-refactor-apostle.md`.
-
-# 23:01
-
-## Maker: stream refactor implementation (#237)
-
-### What was built
-
-7 production files changed, 1 new test helper file added:
-
-- `packages/claude-sdk/src/private/MessageStreamer.ts` — return type changed from `AsyncIterable<BetaRawMessageStreamEvent>` to `BetaMessageStream`
-- `packages/claude-sdk/src/public/interfaces.ts` — `IStreamProcessor.process()` param changed to `BetaMessageStream`, removed `Anthropic` namespace import
-- `packages/claude-sdk/src/private/StreamProcessor.ts` — full rewrite: removed `BlockAccumulator` state machine, subscribe to SDK events, `await stream.finalMessage()`, new `mapBlocks()` helper
-- `packages/claude-sdk/src/private/AnthropicClient.ts` — `stream()` return type changed to `BetaMessageStream`
-- `packages/claude-sdk/test/helpers.ts` — NEW: `makeBetaStream()` + `wrapWithMessageEnvelope()` shared across all three spec files
-- `packages/claude-sdk/test/StreamProcessor.spec.ts` — all event arrays wrapped with `wrapWithMessageEnvelope()`, passed to `makeBetaStream()`
-- `packages/claude-sdk/test/TurnRunner.spec.ts` — async generators → arrays, `FakeMessageStreamer` returns `BetaMessageStream` lazily
-- `packages/claude-sdk/test/QueryRunner.spec.ts` — same pattern as TurnRunner
-
-TurnRunner.ts required no changes — the type flows through automatically.
-
-### Deviations from the Apostle plan
-
-**`content: []` required in message_start events.** The Apostle plan did not flag this. The SDK's `_accumulateMessage` returns `event.message` as the initial snapshot for `message_start`. Any subsequent `content_block_start` calls `snapshot.content.push(event.content_block)`. If `message.content` is absent (which the old async-generator tests omitted), `push` throws at runtime. TurnRunner and QueryRunner stream helpers needed `content: []` added to every `message_start` event.
-
-**`wrapWithMessageEnvelope` already included `content: []`.** The StreamProcessor tests worked first try because `MESSAGE_START` in helpers.ts included the field from the start.
-
-**Multi-invocations test fixed with correct sequential indices.** The Apostle plan said to just change `makeStream` → `makeBetaStream(wrapWithMessageEnvelope(...))` for all tests. But the SDK's `_accumulateMessage` for `content_block_delta` uses `snapshot.content.at(event.index)` (not `at(-1)`), while `_addStreamEvent` uses `at(-1)`. When index 0 appears twice in a stream, the second pair's text delta would address `content[0]` (wrong block) instead of the actual text block. The fix: create new event constants with sequential indices (2, 3, 4) for the second server tool pair and text block. This is noted in the test with a comment explaining the SDK's indexing behavior.
-
-**`BetaContentBlock` cast, not `BetaRawMessageStreamEvent`.** The Apostle plan did not specify the inner cast type for `content_block` values. The original spec used `Anthropic.Beta.Messages.BetaContentBlock`. My initial spec used `BetaRawMessageStreamEvent` (incorrect — `BetaRawMessageStreamEvent` is not assignable to `BetaContentBlock`). Fixed by importing `BetaContentBlock` and using that as the cast target.
-
-**`BetaMessageStream` import unused in TurnRunner and QueryRunner spec files.** Both spec files import `{ BetaMessageStream }` for the `FakeMessageStreamer` return type annotation. Biome/tsc may flag this as unused if type-only imports are required. No issues found in current type-check pass.
-
-### Import path used
-
-`@anthropic-ai/sdk/lib/BetaMessageStream.mjs` for both production and test imports — consistent with the `.mjs` pattern used elsewhere in the codebase (`@anthropic-ai/sdk/resources/beta.mjs`). The Apostle plan suggested `.js` for tests; `.mjs` is correct and consistent.
-
-### 136 tests pass, build clean, type-check clean.
-
-# 23:16
-
-## Courier: stream refactor PR (#237)
-
-Branch `fix/stream-refactor` had one commit ahead of origin/main and one behind: PR #314 (rendering bug fixes) merged while Phase 3 was in progress. The courier merged origin/main before pushing to avoid a conflicting state on the PR.
-
-Changes shipped: `packages/claude-sdk/changes.jsonl` + this testament.
-# 21:37
-
-## Phase 1: maxTokens + claudeMd sources config
-
-Straightforward config extension. Both changes followed the existing pattern cleanly.
-
-### maxTokens
-
-`maxTokens: 32000` was hardcoded in `mapConfig()` in `main.ts`. Added `maxTokens` to `sdkConfigSchema`, wired `configLoader.config.maxTokens` into `mapConfig()`.
-
-### claudeMd sources
-
-`ClaudeMdLoader` had a hardcoded array of four files. Each entry now has a `source` key (`'user' | 'project' | 'projectClaude' | 'local'`). `ClaudeMdSources` type exported from `ClaudeMdLoader.ts`. `DEFAULT_SOURCES` (all true) added so existing `getContent()` calls without arguments still work.
-
-Sources are passed as a parameter on each call (not at construction). The `enabled` check is a conditional in `main.ts` around the `getContent()` call. Hot-reload is automatic: every turn reads the live config.
-
-### The "enabled=false skips all" test gap
-
-The `enabled` check is in `main.ts`, not in `ClaudeMdLoader`. No integration harness exists to test it. The `returns null when all sources are disabled` test covers the equivalent at the loader level. PM flagged this for a future decision on whether an integration harness is worth adding.
-
-### Config snapshot test
-
-`cli-config.spec.ts` has a full-equality snapshot for the default config. Adding new fields requires updating it. Any future config additions must update this test.
-
-# 23:13
-
-## Phase 2: Courier
-Key subtlety: save `preState = activeAnsiState` BEFORE calling `applyToState(pendingAnsi)`. The continuation re-establishes context with `preState`, then emits `pendingAnsi`, then the character. If `pendingAnsi` contains a reset, the re-establishment is immediately cancelled (correct). Only SGR sequences (ending in 'm') affect state.
-
-Two existing reflow tests had expected values from the old behaviour; both updated.
-
-### A-1: Resolved by W-1
-
-Once every continuation line carries its own colour prefix, slicing `allContent` is safe. No separate code change needed.
-
-### D-1: buildDivider width
-
-`prefix.length` to `stringWidth(prefix)`. Added `string-width` as a direct dependency via `pnpm add`.
-
-### D-2: Emoji cursor
-
-`EditorState.ts`: `graphemeBoundaryBefore`/`graphemeBoundaryAfter` helpers using `Intl.Segmenter`. `cursorCol` stays a code-unit index; only movement is grapheme-aware.
-
-`renderEditor.ts`: segmenter lookup replaces `line[cursorCol]` to get the full grapheme cluster under the cursor.
-
-### Test trap: lone-surrogate regex
-
-`/[\uD800-\uDFFF]/` matches ANY surrogate including the legitimate pair in '🎉'. Correct regex for lone surrogates: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/`.
+**Turbo cache masks type errors.** CI runs `type-check --only`, which skips the build dependency cache. Local `pnpm type-check` can hit a stale cache and report clean when it isn't. Run `pnpm run --if-present type-check --only` to match CI.

--- a/.claude/testament/2026-04-26.md
+++ b/.claude/testament/2026-04-26.md
@@ -131,3 +131,11 @@ TurnRunner.ts required no changes — the type flows through automatically.
 `@anthropic-ai/sdk/lib/BetaMessageStream.mjs` for both production and test imports — consistent with the `.mjs` pattern used elsewhere in the codebase (`@anthropic-ai/sdk/resources/beta.mjs`). The Apostle plan suggested `.js` for tests; `.mjs` is correct and consistent.
 
 ### 136 tests pass, build clean, type-check clean.
+
+# 23:16
+
+## Courier: stream refactor PR (#237)
+
+Branch `fix/stream-refactor` had one commit ahead of origin/main and one behind: PR #314 (rendering bug fixes) merged while Phase 3 was in progress. The courier merged origin/main before pushing to avoid a conflicting state on the PR.
+
+Changes shipped: `packages/claude-sdk/changes.jsonl` + this testament.

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -16,3 +16,4 @@
 {"description":"Tool handlers return structured output with optional attachments for binary content","category":"changed"}
 {"description":"Deliver tool attachments as native content blocks inside tool results","category":"added"}
 {"description":"Add output_schema to ToolDefinition for typed handler outputs","category":"added"}
+{"description":"Refactor stream processor to use SDK native event emitter","category":"changed"}

--- a/packages/claude-sdk/src/private/AnthropicClient.ts
+++ b/packages/claude-sdk/src/private/AnthropicClient.ts
@@ -1,7 +1,8 @@
 import EventEmitter from 'node:events';
 import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
-import type { BetaMessage, BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import versionJson from '@shellicar/build-version/version';
 import type { ILogger } from '../public/types';
 import { customFetch } from './http/customFetch';
@@ -71,7 +72,7 @@ export class AnthropicClient extends IMessageStreamer {
     this.#emitter.off(event, listener);
   }
 
-  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): AsyncIterable<BetaRawMessageStreamEvent> {
+  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): BetaMessageStream {
     const stream = this.#raw.beta.messages.stream(body, options);
     stream.on('finalMessage', (msg) => {
       try {

--- a/packages/claude-sdk/src/private/AnthropicClient.ts
+++ b/packages/claude-sdk/src/private/AnthropicClient.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'node:events';
 import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta.mjs';
-import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import versionJson from '@shellicar/build-version/version';
 import type { ILogger } from '../public/types';
 import { customFetch } from './http/customFetch';

--- a/packages/claude-sdk/src/private/MessageStreamer.ts
+++ b/packages/claude-sdk/src/private/MessageStreamer.ts
@@ -1,7 +1,7 @@
 import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
-import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 
 export abstract class IMessageStreamer {
-  public abstract stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): AsyncIterable<BetaRawMessageStreamEvent>;
+  public abstract stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): BetaMessageStream;
 }

--- a/packages/claude-sdk/src/private/MessageStreamer.ts
+++ b/packages/claude-sdk/src/private/MessageStreamer.ts
@@ -1,6 +1,6 @@
 import type { Anthropic } from '@anthropic-ai/sdk';
-import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
+import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 
 export abstract class IMessageStreamer {
   public abstract stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): BetaMessageStream;

--- a/packages/claude-sdk/src/private/StreamProcessor.ts
+++ b/packages/claude-sdk/src/private/StreamProcessor.ts
@@ -1,16 +1,8 @@
-import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaContentBlock } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import { IStreamProcessor } from '../public/interfaces';
 import type { ILogger } from '../public/types';
-import type { ContentBlock, MessageStreamResult, ServerToolResultBlock } from './types';
-
-type BlockAccumulator =
-  | { type: 'thinking'; thinking: string; signature: string }
-  | { type: 'text'; text: string }
-  | { type: 'tool_use'; id: string; name: string; partialJson: string }
-  | { type: 'compaction'; content: string }
-  | { type: 'server_tool_use'; id: string; name: string; partialJson: string }
-  | { type: 'server_tool_result'; name: string; blockType: ServerToolResultBlock['type']; toolUseId: string; result: unknown }
-  | { type: 'redacted_thinking'; data: string };
+import type { ContentBlock, MessageStreamResult } from './types';
 
 const SERVER_TOOL_RESULT_NAMES = {
   web_search_tool_result: 'web_search',
@@ -28,19 +20,15 @@ const SERVER_TOOL_RESULT_NAMES = {
  * once at setup and the same handlers fire for every stream this instance
  * processes.
  *
- * Per-stream state (the partial assembled message, cache split tracking, stop
- * reason, token counts) lives in local variables inside the `process()` method,
- * not on the instance. The instance only holds its logger and its event
- * subscriptions.
+ * Per-stream state lives entirely in the SDK's `BetaMessageStream` instance
+ * and is assembled by the SDK. This processor subscribes to the stream's
+ * events, re-emits them in the `MessageStreamEvents` vocabulary, and then
+ * awaits `finalMessage()` to obtain the fully assembled result.
  *
  * Concurrent `process()` calls on the same instance are not supported: the
  * intended usage is one call at a time. The events emitted during a call
  * belong to that call; interleaving two calls would mix events on the shared
  * emitter and confuse subscribers.
- *
- * Replaces the former per-stream `MessageStream` class, which allocated fresh
- * state on every API call. This processor is long-lived and reuses the same
- * event emitter surface across every stream the turn runner processes.
  */
 export class StreamProcessor extends IStreamProcessor {
   readonly #logger: ILogger | undefined;
@@ -50,178 +38,120 @@ export class StreamProcessor extends IStreamProcessor {
     this.#logger = logger;
   }
 
-  public async process(stream: AsyncIterable<Anthropic.Beta.Messages.BetaRawMessageStreamEvent>): Promise<MessageStreamResult> {
-    let current: BlockAccumulator | null = null;
-    const completed: ContentBlock[] = [];
-    let stopReason: string | null = null;
-    let contextManagementOccurred = false;
-    let inputTokens = 0;
-    let cacheCreationTokens = 0;
-    let cacheReadTokens = 0;
-    let outputTokens = 0;
-
-    const handleEvent = (event: Anthropic.Beta.Messages.BetaRawMessageStreamEvent): void => {
+  public async process(stream: BetaMessageStream): Promise<MessageStreamResult> {
+    stream.on('streamEvent', (event) => {
       this.#logger?.trace('event', event);
-      switch (event.type) {
-        case 'message_start':
-          this.#logger?.debug('message_start');
-          inputTokens = event.message.usage.input_tokens;
-          cacheCreationTokens = event.message.usage.cache_creation_input_tokens ?? 0;
-          cacheReadTokens = event.message.usage.cache_read_input_tokens ?? 0;
-          this.emit('message_start');
-          break;
-        case 'message_stop':
-          this.#logger?.debug('message_stop');
-          this.emit('message_stop');
-          break;
-        case 'message_delta':
-          if (event.delta.stop_reason != null) {
-            stopReason = event.delta.stop_reason;
-            this.#logger?.debug('stop_reason', { reason: event.delta.stop_reason });
-          }
-          outputTokens = event.usage.output_tokens;
-          if (event.context_management != null) {
-            contextManagementOccurred = true;
-            this.#logger?.info('context_management', { context_management: event.context_management });
-          }
-          break;
-        case 'content_block_start':
-          this.#logger?.debug('content_block_start', { index: event.index, type: event.content_block.type });
-          if (current != null) {
-            this.#logger?.warn('content_block_start with existing current block', { existing: current.type, incoming: event.content_block.type });
-          }
-          switch (event.content_block.type) {
-            case 'tool_use':
-              this.#logger?.info('tool_use_start', { name: event.content_block.name });
-              current = { type: 'tool_use', id: event.content_block.id, name: event.content_block.name, partialJson: '' };
-              break;
-            case 'thinking':
-              current = { type: 'thinking', thinking: '', signature: '' };
-              this.emit('thinking_start');
-              break;
-            case 'text':
-              current = { type: 'text', text: '' };
-              break;
-            case 'compaction':
-              current = { type: 'compaction', content: '' };
-              this.emit('compaction_start');
-              break;
-            case 'server_tool_use': {
-              const block = event.content_block;
-              this.#logger?.info('server_tool_use_start', { name: block.name });
-              current = { type: 'server_tool_use', id: block.id, name: block.name, partialJson: '' };
-              break;
-            }
-            case 'web_search_tool_result':
-            case 'web_fetch_tool_result':
-            case 'code_execution_tool_result':
-            case 'bash_code_execution_tool_result':
-            case 'text_editor_code_execution_tool_result':
-            case 'tool_search_tool_result':
-            case 'mcp_tool_result':
-              current = { type: 'server_tool_result', name: SERVER_TOOL_RESULT_NAMES[event.content_block.type], blockType: event.content_block.type, toolUseId: event.content_block.tool_use_id, result: event.content_block.content };
-              break;
-            case 'redacted_thinking': {
-              const block = event.content_block as unknown as { data: string };
-              current = { type: 'redacted_thinking', data: block.data };
-              break;
-            }
-            case 'mcp_tool_use':
-            case 'container_upload':
-              break;
-          }
-          break;
-        case 'content_block_stop': {
-          this.#logger?.debug('content_block_stop', { type: current?.type });
-          const acc = current;
-          current = null;
-          if (acc == null) {
-            this.#logger?.warn('content_block_stop with no current block');
-            break;
-          }
-          switch (acc.type) {
-            case 'thinking':
-              completed.push({ type: 'thinking', thinking: acc.thinking, signature: acc.signature });
-              this.emit('thinking_stop');
-              break;
-            case 'text':
-              completed.push({ type: 'text', text: acc.text });
-              break;
-            case 'tool_use':
-              completed.push({ type: 'tool_use', id: acc.id, name: acc.name, input: acc.partialJson.length > 0 ? JSON.parse(acc.partialJson) : {} });
-              break;
-            case 'compaction':
-              if (acc.content) {
-                completed.push({ type: 'compaction', content: acc.content });
-              }
-              this.emit('compaction_complete', acc.content || 'No compaction summary received');
-              break;
-            case 'server_tool_use': {
-              const input: Record<string, unknown> = acc.partialJson.length > 0 ? JSON.parse(acc.partialJson) : {};
-              completed.push({ type: 'server_tool_use', id: acc.id, name: acc.name, input });
-              this.emit('server_tool_use', acc.name, input);
-              break;
-            }
-            case 'server_tool_result':
-              completed.push({ type: acc.blockType, toolUseId: acc.toolUseId, content: acc.result });
-              this.emit('server_tool_result', acc.name, acc.result);
-              break;
-            case 'redacted_thinking':
-              completed.push({ type: 'redacted_thinking', data: acc.data });
-              break;
-          }
-          break;
+      if (event.type === 'message_start') {
+        this.#logger?.debug('message_start');
+        this.emit('message_start');
+      } else if (event.type === 'content_block_start') {
+        this.#logger?.debug('content_block_start', { index: event.index, type: event.content_block.type });
+        if (event.content_block.type === 'thinking') {
+          this.emit('thinking_start');
+        } else if (event.content_block.type === 'compaction') {
+          this.emit('compaction_start');
+        } else if (event.content_block.type === 'server_tool_use') {
+          this.#logger?.info('server_tool_use_start', { name: event.content_block.name });
+        } else if (event.content_block.type === 'tool_use') {
+          this.#logger?.info('tool_use_start', { name: event.content_block.name });
         }
-        case 'content_block_delta':
-          switch (event.delta.type) {
-            case 'text_delta':
-              if (current?.type === 'text') {
-                current.text += event.delta.text;
-                this.emit('message_text', event.delta.text);
-              }
-              break;
-            case 'input_json_delta':
-              if (current?.type === 'tool_use' || current?.type === 'server_tool_use') {
-                current.partialJson += event.delta.partial_json;
-              }
-              break;
-            case 'thinking_delta':
-              if (current?.type === 'thinking') {
-                current.thinking += event.delta.thinking;
-                this.emit('thinking_text', event.delta.thinking);
-              }
-              break;
-            case 'signature_delta':
-              if (current?.type === 'thinking') {
-                current.signature += event.delta.signature;
-              }
-              break;
-            case 'compaction_delta':
-              if (current?.type === 'compaction') {
-                current.content += event.delta.content ?? '';
-              }
-              break;
-            case 'citations_delta':
-              break;
-          }
+      } else if (event.type === 'message_delta') {
+        if (event.delta.stop_reason != null) {
+          this.#logger?.debug('stop_reason', { reason: event.delta.stop_reason });
+        }
+        if (event.context_management != null) {
+          this.#logger?.info('context_management', { context_management: event.context_management });
+        }
+      }
+    });
+
+    stream.on('text', (delta) => {
+      this.emit('message_text', delta);
+    });
+
+    stream.on('thinking', (delta) => {
+      this.emit('thinking_text', delta);
+    });
+
+    stream.on('contentBlock', (content) => {
+      this.#logger?.debug('content_block_stop', { type: content.type });
+      switch (content.type) {
+        case 'thinking':
+          this.emit('thinking_stop');
+          break;
+        case 'compaction':
+          this.emit('compaction_complete', content.content || 'No compaction summary received');
+          break;
+        case 'server_tool_use':
+          this.emit('server_tool_use', content.name, content.input);
+          break;
+        case 'web_search_tool_result':
+        case 'web_fetch_tool_result':
+        case 'code_execution_tool_result':
+        case 'bash_code_execution_tool_result':
+        case 'text_editor_code_execution_tool_result':
+        case 'tool_search_tool_result':
+        case 'mcp_tool_result':
+          this.emit('server_tool_result', SERVER_TOOL_RESULT_NAMES[content.type], content.content as unknown);
           break;
       }
-    };
+    });
 
-    for await (const event of stream) {
-      handleEvent(event);
-    }
+    stream.on('end', () => {
+      this.emit('message_stop');
+    });
 
+    const msg = await stream.finalMessage();
     return {
-      blocks: completed,
-      stopReason,
-      contextManagementOccurred,
+      blocks: mapBlocks(msg.content),
+      stopReason: msg.stop_reason,
+      contextManagementOccurred: msg.context_management != null,
       usage: {
-        inputTokens,
-        cacheCreationTokens,
-        cacheReadTokens,
-        outputTokens,
+        inputTokens: msg.usage.input_tokens,
+        cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
+        outputTokens: msg.usage.output_tokens,
       },
     };
   }
+}
+
+function mapBlocks(content: ReadonlyArray<BetaContentBlock>): ContentBlock[] {
+  const result: ContentBlock[] = [];
+  for (const block of content) {
+    switch (block.type) {
+      case 'text':
+        result.push({ type: 'text', text: block.text });
+        break;
+      case 'thinking':
+        result.push({ type: 'thinking', thinking: block.thinking, signature: block.signature });
+        break;
+      case 'redacted_thinking':
+        result.push({ type: 'redacted_thinking', data: block.data });
+        break;
+      case 'tool_use':
+        result.push({ type: 'tool_use', id: block.id, name: block.name, input: block.input as Record<string, unknown> });
+        break;
+      case 'compaction':
+        result.push({ type: 'compaction', content: block.content ?? '' });
+        break;
+      case 'server_tool_use':
+        result.push({ type: 'server_tool_use', id: block.id, name: block.name, input: block.input });
+        break;
+      case 'web_search_tool_result':
+      case 'web_fetch_tool_result':
+      case 'code_execution_tool_result':
+      case 'bash_code_execution_tool_result':
+      case 'text_editor_code_execution_tool_result':
+      case 'tool_search_tool_result':
+      case 'mcp_tool_result':
+        result.push({ type: block.type, toolUseId: block.tool_use_id, content: block.content });
+        break;
+      case 'mcp_tool_use':
+      case 'container_upload':
+        // Ignored: matches current behavior (explicit break in content_block_start)
+        break;
+    }
+  }
+  return result;
 }

--- a/packages/claude-sdk/src/private/StreamProcessor.ts
+++ b/packages/claude-sdk/src/private/StreamProcessor.ts
@@ -1,5 +1,5 @@
-import type { BetaContentBlock } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
+import type { BetaContentBlock } from '@anthropic-ai/sdk/resources/beta.mjs';
 import { IStreamProcessor } from '../public/interfaces';
 import type { ILogger } from '../public/types';
 import type { ContentBlock, MessageStreamResult } from './types';

--- a/packages/claude-sdk/src/public/interfaces.ts
+++ b/packages/claude-sdk/src/public/interfaces.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'node:events';
-import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaTool } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import type { Conversation } from '../private/Conversation';
 import type { MessageStreamEvents, MessageStreamResult } from '../private/types';
 import type { DurableConfig, PerQueryInput, ToolResolveResult, TurnInput } from './types';
@@ -15,7 +15,7 @@ import type { DurableConfig, PerQueryInput, ToolResolveResult, TurnInput } from 
  * intended usage is one call at a time.
  */
 export abstract class IStreamProcessor extends EventEmitter<MessageStreamEvents> {
-  public abstract process(stream: AsyncIterable<Anthropic.Beta.Messages.BetaRawMessageStreamEvent>): Promise<MessageStreamResult>;
+  public abstract process(stream: BetaMessageStream): Promise<MessageStreamResult>;
 }
 
 /**

--- a/packages/claude-sdk/src/public/interfaces.ts
+++ b/packages/claude-sdk/src/public/interfaces.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'node:events';
-import type { BetaTool } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
+import type { BetaTool } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { Conversation } from '../private/Conversation';
 import type { MessageStreamEvents, MessageStreamResult } from '../private/types';
 import type { DurableConfig, PerQueryInput, ToolResolveResult, TurnInput } from './types';

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -2,9 +2,11 @@ import { MessageChannel, type MessagePort } from 'node:worker_threads';
 import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
+import { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { ApprovalCoordinator } from '../src/private/ApprovalCoordinator.js';
+import { makeBetaStream } from './helpers.js';
 import { IControlChannel } from '../src/private/ControlChannel.js';
 import { Conversation } from '../src/private/Conversation.js';
 import { IMessageStreamer } from '../src/private/MessageStreamer.js';
@@ -20,22 +22,26 @@ import type { AnyToolDefinition, ConsumerMessage, DocumentBlock, DurableConfig, 
 // HTTP responses).
 // ---------------------------------------------------------------------------
 
-async function* makeEndTurnStream(text: string): AsyncIterable<BetaRawMessageStreamEvent> {
-  yield { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent;
-  yield { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_stop' } as BetaRawMessageStreamEvent;
+function makeEndTurnStream(text: string): BetaRawMessageStreamEvent[] {
+  return [
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent,
+    { type: 'message_stop' } as BetaRawMessageStreamEvent,
+  ];
 }
 
-async function* makeToolUseStream(toolId: string, toolName: string, input: Record<string, unknown> = {}): AsyncIterable<BetaRawMessageStreamEvent> {
-  yield { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent;
-  yield { type: 'message_delta', delta: { stop_reason: 'tool_use', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_stop' } as BetaRawMessageStreamEvent;
+function makeToolUseStream(toolId: string, toolName: string, input: Record<string, unknown> = {}): BetaRawMessageStreamEvent[] {
+  return [
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'tool_use', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent,
+    { type: 'message_stop' } as BetaRawMessageStreamEvent,
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -44,20 +50,20 @@ async function* makeToolUseStream(toolId: string, toolName: string, input: Recor
 
 class FakeMessageStreamer extends IMessageStreamer {
   public readonly calls: { body: BetaMessageStreamParams; options: Anthropic.RequestOptions }[] = [];
-  readonly #responses: Array<AsyncIterable<BetaRawMessageStreamEvent>>;
+  readonly #responses: Array<BetaRawMessageStreamEvent[]>;
 
-  public constructor(responses: Array<AsyncIterable<BetaRawMessageStreamEvent>>) {
+  public constructor(responses: Array<BetaRawMessageStreamEvent[]>) {
     super();
     this.#responses = [...responses];
   }
 
-  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): AsyncIterable<BetaRawMessageStreamEvent> {
+  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): BetaMessageStream {
     this.calls.push({ body, options });
     const next = this.#responses.shift();
     if (next == null) {
       throw new Error('FakeMessageStreamer: no more scripted responses');
     }
-    return next;
+    return makeBetaStream(next);
   }
 }
 
@@ -138,7 +144,7 @@ type Wiring = {
   queryRunner: QueryRunner;
 };
 
-function makeWiring(responses: Array<AsyncIterable<BetaRawMessageStreamEvent>>, tools: AnyToolDefinition[] = [], durableOverrides: Partial<DurableConfig> = {}, conversation?: Conversation): Wiring {
+function makeWiring(responses: Array<BetaRawMessageStreamEvent[]>, tools: AnyToolDefinition[] = [], durableOverrides: Partial<DurableConfig> = {}, conversation?: Conversation): Wiring {
   const streamer = new FakeMessageStreamer(responses);
   const processor = new StreamProcessor();
   const turnRunner = new TurnRunner(streamer, processor);

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -1,12 +1,11 @@
 import { MessageChannel, type MessagePort } from 'node:worker_threads';
 import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
-import { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { ApprovalCoordinator } from '../src/private/ApprovalCoordinator.js';
-import { makeBetaStream } from './helpers.js';
 import { IControlChannel } from '../src/private/ControlChannel.js';
 import { Conversation } from '../src/private/Conversation.js';
 import { IMessageStreamer } from '../src/private/MessageStreamer.js';
@@ -15,6 +14,7 @@ import { StreamProcessor } from '../src/private/StreamProcessor.js';
 import { ToolRegistry } from '../src/private/ToolRegistry.js';
 import { TurnRunner } from '../src/private/TurnRunner.js';
 import type { AnyToolDefinition, ConsumerMessage, DocumentBlock, DurableConfig, PerQueryInput, SdkMessage, TextBlock, ToolResultBlock } from '../src/public/types.js';
+import { makeBetaStream } from './helpers.js';
 
 // ---------------------------------------------------------------------------
 // Stream helpers (the QueryRunner

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -24,7 +24,7 @@ import type { AnyToolDefinition, ConsumerMessage, DocumentBlock, DurableConfig, 
 
 function makeEndTurnStream(text: string): BetaRawMessageStreamEvent[] {
   return [
-    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as unknown as BetaRawMessageStreamEvent,
     { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent,
     { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent,
     { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
@@ -35,7 +35,7 @@ function makeEndTurnStream(text: string): BetaRawMessageStreamEvent[] {
 
 function makeToolUseStream(toolId: string, toolName: string, input: Record<string, unknown> = {}): BetaRawMessageStreamEvent[] {
   return [
-    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as unknown as BetaRawMessageStreamEvent,
     { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} } } as BetaRawMessageStreamEvent,
     { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) } } as BetaRawMessageStreamEvent,
     { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,

--- a/packages/claude-sdk/test/StreamProcessor.spec.ts
+++ b/packages/claude-sdk/test/StreamProcessor.spec.ts
@@ -210,17 +210,7 @@ describe('StreamProcessor — server tool use', () => {
     };
     const textStop4: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 4 };
 
-    const result = await new StreamProcessor().process(
-      makeBetaStream(
-        wrapWithMessageEnvelope([
-          serverToolUseStart, serverToolUseStop,
-          webFetchResultStart, webFetchResultStop,
-          serverToolUseStart2, serverToolUseStop2,
-          webFetchResultStart2, webFetchResultStop2,
-          textStart4, textDelta4, textStop4,
-        ]),
-      ),
-    );
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, serverToolUseStart2, serverToolUseStop2, webFetchResultStart2, webFetchResultStop2, textStart4, textDelta4, textStop4])));
     expect(result.blocks[4]).toEqual({ type: 'text', text: 'The fetch worked.' });
   });
 

--- a/packages/claude-sdk/test/StreamProcessor.spec.ts
+++ b/packages/claude-sdk/test/StreamProcessor.spec.ts
@@ -1,27 +1,24 @@
-import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaContentBlock, BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
 import { describe, expect, it } from 'vitest';
 import { StreamProcessor } from '../src/private/StreamProcessor.js';
+import { makeBetaStream, wrapWithMessageEnvelope } from './helpers.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function* makeStream(events: Anthropic.Beta.Messages.BetaRawMessageStreamEvent[]): AsyncIterable<Anthropic.Beta.Messages.BetaRawMessageStreamEvent> {
-  yield* events;
-}
-
-const startCompaction: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+const startCompaction: BetaRawMessageStreamEvent = {
   type: 'content_block_start',
   index: 0,
   content_block: { type: 'compaction', content: null },
 };
 
-const stopCompaction: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+const stopCompaction: BetaRawMessageStreamEvent = {
   type: 'content_block_stop',
   index: 0,
 };
 
-function deltaCompaction(content: string | null): Anthropic.Beta.Messages.BetaRawMessageStreamEvent {
+function deltaCompaction(content: string | null): BetaRawMessageStreamEvent {
   return { type: 'content_block_delta', index: 0, delta: { type: 'compaction_delta', content } };
 }
 
@@ -33,7 +30,7 @@ function deltaCompaction(content: string | null): Anthropic.Beta.Messages.BetaRa
 describe('StreamProcessor — single stream correctness', () => {
   it('processes a compaction stream and returns the summary block', async () => {
     const processor = new StreamProcessor();
-    const result = await processor.process(makeStream([startCompaction, deltaCompaction('First summary'), stopCompaction]));
+    const result = await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('First summary'), stopCompaction])));
     const block = result.blocks.find((b) => b.type === 'compaction') as { type: 'compaction'; content: string } | undefined;
     expect(block?.content).toBe('First summary');
   });
@@ -44,7 +41,7 @@ describe('StreamProcessor — single stream correctness', () => {
     processor.on('compaction_complete', (summary) => {
       emitted = summary;
     });
-    await processor.process(makeStream([startCompaction, deltaCompaction('First summary'), stopCompaction]));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('First summary'), stopCompaction])));
     expect(emitted).toBe('First summary');
   });
 });
@@ -59,8 +56,8 @@ describe('StreamProcessor — long-lived instance', () => {
   it('processes two streams on the same instance without leaking state', async () => {
     const processor = new StreamProcessor();
 
-    const firstResult = await processor.process(makeStream([startCompaction, deltaCompaction('First summary'), stopCompaction]));
-    const secondResult = await processor.process(makeStream([startCompaction, deltaCompaction('Second summary'), stopCompaction]));
+    const firstResult = await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('First summary'), stopCompaction])));
+    const secondResult = await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('Second summary'), stopCompaction])));
 
     // First result has its own summary block only.
     expect(firstResult.blocks.length).toBe(1);
@@ -81,9 +78,9 @@ describe('StreamProcessor — long-lived instance', () => {
       summaries.push(summary);
     });
 
-    await processor.process(makeStream([startCompaction, deltaCompaction('First'), stopCompaction]));
-    await processor.process(makeStream([startCompaction, deltaCompaction('Second'), stopCompaction]));
-    await processor.process(makeStream([startCompaction, deltaCompaction('Third'), stopCompaction]));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('First'), stopCompaction])));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('Second'), stopCompaction])));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([startCompaction, deltaCompaction('Third'), stopCompaction])));
 
     expect(summaries).toEqual(['First', 'Second', 'Third']);
   });
@@ -96,7 +93,7 @@ describe('StreamProcessor — long-lived instance', () => {
 // ---------------------------------------------------------------------------
 
 describe('StreamProcessor — server tool use', () => {
-  const serverToolUseStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const serverToolUseStart: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 0,
     content_block: {
@@ -104,15 +101,15 @@ describe('StreamProcessor — server tool use', () => {
       id: 'srvtoolu_01RJsBbMt7mZuyXVAR9VVeiY',
       name: 'web_fetch',
       input: { url: 'https://www.anthropic.com/news/claude-opus-4-7' },
-    } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    } as unknown as BetaContentBlock,
   };
 
-  const serverToolUseStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const serverToolUseStop: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 0,
   };
 
-  const webFetchResultStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webFetchResultStart: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 1,
     content_block: {
@@ -120,62 +117,110 @@ describe('StreamProcessor — server tool use', () => {
       tool_use_id: 'srvtoolu_01RJsBbMt7mZuyXVAR9VVeiY',
       content: { type: 'web_fetch_result', url: 'https://www.anthropic.com/news/claude-opus-4-7', retrieved_at: '2026-04-18T05:18:32.325000+00:00', content: { type: 'document', source: { type: 'text', media_type: 'text/plain', data: 'Page content here' }, title: 'Introducing Claude Opus 4.7' } },
       caller: { type: 'direct' },
-    } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    } as unknown as BetaContentBlock,
   };
 
-  const webFetchResultStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webFetchResultStop: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 1,
   };
 
-  const textStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStart: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 2,
     content_block: { type: 'text', text: '', citations: null },
   };
 
-  const textDelta: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textDelta: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 2,
     delta: { type: 'text_delta', text: 'The fetch worked.' },
   };
 
-  const textStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStop: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 2,
   };
 
   it('does not push server_tool_use or web_fetch_tool_result blocks to completed', async () => {
-    const result = await new StreamProcessor().process(makeStream([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop]));
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop])));
     expect(result.blocks).toHaveLength(2);
   });
 
   it('yields exactly three blocks after server tool use', async () => {
-    const result = await new StreamProcessor().process(makeStream([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, textStart, textDelta, textStop]));
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, textStart, textDelta, textStop])));
     expect(result.blocks).toHaveLength(3);
   });
 
   it('the block after server tool use is the correct text content', async () => {
-    const result = await new StreamProcessor().process(makeStream([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, textStart, textDelta, textStop]));
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, textStart, textDelta, textStop])));
     expect(result.blocks[2]).toEqual({ type: 'text', text: 'The fetch worked.' });
   });
 
   it('unknown block types (e.g. redacted_thinking) do not emit server_tool_result', async () => {
-    const redactedThinkingStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+    const redactedThinkingStart: BetaRawMessageStreamEvent = {
       type: 'content_block_start',
       index: 0,
-      content_block: { type: 'redacted_thinking', data: 'encrypted' } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+      content_block: { type: 'redacted_thinking', data: 'encrypted' },
     };
-    const redactedThinkingStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 0 };
+    const redactedThinkingStop: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 0 };
     const emitted: string[] = [];
     const processor = new StreamProcessor();
     processor.on('server_tool_result', (name) => emitted.push(name));
-    await processor.process(makeStream([redactedThinkingStart, redactedThinkingStop, textStart, textDelta, textStop]));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([redactedThinkingStart, redactedThinkingStop, textStart, textDelta, textStop])));
     expect(emitted).toHaveLength(0);
   });
 
   it('multiple server tool invocations in sequence do not corrupt state', async () => {
-    const result = await new StreamProcessor().process(makeStream([serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, serverToolUseStart, serverToolUseStop, webFetchResultStart, webFetchResultStop, textStart, textDelta, textStop]));
+    // The SDK accumulates blocks by push order, not by event.index. Deltas use
+    // event.index to find the block to update. To avoid index mismatch (which
+    // silently drops deltas), the second server tool pair and the final text
+    // block use sequential indices (2, 3, 4) rather than reusing 0, 1, 2.
+    const serverToolUseStart2: BetaRawMessageStreamEvent = {
+      type: 'content_block_start',
+      index: 2,
+      content_block: {
+        type: 'server_tool_use',
+        id: 'srvtoolu_02',
+        name: 'web_fetch',
+        input: { url: 'https://www.anthropic.com/news/claude-opus-4-7' },
+      } as unknown as BetaContentBlock,
+    };
+    const serverToolUseStop2: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 2 };
+    const webFetchResultStart2: BetaRawMessageStreamEvent = {
+      type: 'content_block_start',
+      index: 3,
+      content_block: {
+        type: 'web_fetch_tool_result',
+        tool_use_id: 'srvtoolu_02',
+        content: { type: 'web_fetch_result', url: 'https://www.anthropic.com/news/claude-opus-4-7', retrieved_at: '2026-04-18T05:18:32.325000+00:00', content: { type: 'document', source: { type: 'text', media_type: 'text/plain', data: 'Page content here' }, title: 'Introducing Claude Opus 4.7' } },
+        caller: { type: 'direct' },
+      } as unknown as BetaContentBlock,
+    };
+    const webFetchResultStop2: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 3 };
+    const textStart4: BetaRawMessageStreamEvent = {
+      type: 'content_block_start',
+      index: 4,
+      content_block: { type: 'text', text: '', citations: null },
+    };
+    const textDelta4: BetaRawMessageStreamEvent = {
+      type: 'content_block_delta',
+      index: 4,
+      delta: { type: 'text_delta', text: 'The fetch worked.' },
+    };
+    const textStop4: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 4 };
+
+    const result = await new StreamProcessor().process(
+      makeBetaStream(
+        wrapWithMessageEnvelope([
+          serverToolUseStart, serverToolUseStop,
+          webFetchResultStart, webFetchResultStop,
+          serverToolUseStart2, serverToolUseStop2,
+          webFetchResultStart2, webFetchResultStop2,
+          textStart4, textDelta4, textStop4,
+        ]),
+      ),
+    );
     expect(result.blocks[4]).toEqual({ type: 'text', text: 'The fetch worked.' });
   });
 
@@ -183,7 +228,7 @@ describe('StreamProcessor — server tool use', () => {
     const processor = new StreamProcessor();
     const actual: string[] = [];
     processor.on('server_tool_use', (name) => actual.push(name));
-    await processor.process(makeStream([serverToolUseStart, serverToolUseStop]));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([serverToolUseStart, serverToolUseStop])));
     const expected = ['web_fetch'];
     expect(actual).toEqual(expected);
   });
@@ -192,7 +237,7 @@ describe('StreamProcessor — server tool use', () => {
     const processor = new StreamProcessor();
     const actual: string[] = [];
     processor.on('server_tool_result', (name) => actual.push(name));
-    await processor.process(makeStream([webFetchResultStart, webFetchResultStop]));
+    await processor.process(makeBetaStream(wrapWithMessageEnvelope([webFetchResultStart, webFetchResultStop])));
     const expected = ['web_fetch'];
     expect(actual).toEqual(expected);
   });
@@ -204,40 +249,40 @@ describe('StreamProcessor — server tool use', () => {
 // ---------------------------------------------------------------------------
 
 describe('StreamProcessor — conversation integrity', () => {
-  const thinkingStart1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingStart1: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 0,
-    content_block: { type: 'thinking', thinking: '', signature: '' } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    content_block: { type: 'thinking', thinking: '', signature: '' },
   };
-  const thinkingDelta1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingDelta1: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 0,
     delta: { type: 'thinking_delta', thinking: 'Let me search.' },
   };
-  const signatureDelta1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const signatureDelta1: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 0,
     delta: { type: 'signature_delta', signature: 'sig1' },
   };
-  const thinkingStop1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingStop1: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 0,
   };
-  const textStart1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStart1: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 1,
     content_block: { type: 'text', text: '', citations: null },
   };
-  const textDelta1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textDelta1: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 1,
     delta: { type: 'text_delta', text: 'I will search for that.' },
   };
-  const textStop1: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStop1: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 1,
   };
-  const webSearchUseStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webSearchUseStart: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 2,
     content_block: {
@@ -245,55 +290,55 @@ describe('StreamProcessor — conversation integrity', () => {
       id: 'srvtoolu_webSearch01',
       name: 'web_search',
       input: {},
-    } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    } as unknown as BetaContentBlock,
   };
-  const webSearchUseStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webSearchUseStop: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 2,
   };
-  const webSearchResultStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webSearchResultStart: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 3,
     content_block: {
       type: 'web_search_tool_result',
       tool_use_id: 'srvtoolu_webSearch01',
       content: [],
-    } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    } as unknown as BetaContentBlock,
   };
-  const webSearchResultStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const webSearchResultStop: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 3,
   };
-  const thinkingStart2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingStart2: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 4,
-    content_block: { type: 'thinking', thinking: '', signature: '' } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+    content_block: { type: 'thinking', thinking: '', signature: '' },
   };
-  const thinkingDelta2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingDelta2: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 4,
     delta: { type: 'thinking_delta', thinking: 'Found the results.' },
   };
-  const signatureDelta2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const signatureDelta2: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 4,
     delta: { type: 'signature_delta', signature: 'sig2' },
   };
-  const thinkingStop2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const thinkingStop2: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 4,
   };
-  const textStart2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStart2: BetaRawMessageStreamEvent = {
     type: 'content_block_start',
     index: 5,
     content_block: { type: 'text', text: '', citations: null },
   };
-  const textDelta2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textDelta2: BetaRawMessageStreamEvent = {
     type: 'content_block_delta',
     index: 5,
     delta: { type: 'text_delta', text: 'Here are the results.' },
   };
-  const textStop2: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+  const textStop2: BetaRawMessageStreamEvent = {
     type: 'content_block_stop',
     index: 5,
   };
@@ -301,27 +346,27 @@ describe('StreamProcessor — conversation integrity', () => {
   const webSearchResponseStream = [thinkingStart1, thinkingDelta1, signatureDelta1, thinkingStop1, textStart1, textDelta1, textStop1, webSearchUseStart, webSearchUseStop, webSearchResultStart, webSearchResultStop, thinkingStart2, thinkingDelta2, signatureDelta2, thinkingStop2, textStart2, textDelta2, textStop2];
 
   it('result.blocks contains all six blocks from a web-search response', async () => {
-    const result = await new StreamProcessor().process(makeStream(webSearchResponseStream));
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope(webSearchResponseStream)));
     const expected = 6;
     const actual = result.blocks.length;
     expect(actual).toBe(expected);
   });
 
   it('blocks appear in the order emitted by the API', async () => {
-    const result = await new StreamProcessor().process(makeStream(webSearchResponseStream));
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope(webSearchResponseStream)));
     const expected = ['thinking', 'text', 'server_tool_use', 'web_search_tool_result', 'thinking', 'text'];
     const actual = result.blocks.map((b) => b.type);
     expect(actual).toEqual(expected);
   });
 
   it('redacted_thinking block appears in completed', async () => {
-    const redactedThinkingStart: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = {
+    const redactedThinkingStart: BetaRawMessageStreamEvent = {
       type: 'content_block_start',
       index: 0,
-      content_block: { type: 'redacted_thinking', data: 'encrypted-payload' } as unknown as Anthropic.Beta.Messages.BetaContentBlock,
+      content_block: { type: 'redacted_thinking', data: 'encrypted-payload' },
     };
-    const redactedThinkingStop: Anthropic.Beta.Messages.BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 0 };
-    const result = await new StreamProcessor().process(makeStream([redactedThinkingStart, redactedThinkingStop]));
+    const redactedThinkingStop: BetaRawMessageStreamEvent = { type: 'content_block_stop', index: 0 };
+    const result = await new StreamProcessor().process(makeBetaStream(wrapWithMessageEnvelope([redactedThinkingStart, redactedThinkingStop])));
     const expected = 1;
     const actual = result.blocks.length;
     expect(actual).toBe(expected);

--- a/packages/claude-sdk/test/TurnRunner.spec.ts
+++ b/packages/claude-sdk/test/TurnRunner.spec.ts
@@ -1,40 +1,48 @@
 import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
+import { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import { describe, expect, it } from 'vitest';
 import { Conversation } from '../src/private/Conversation.js';
 import { IMessageStreamer } from '../src/private/MessageStreamer.js';
 import { StreamProcessor } from '../src/private/StreamProcessor.js';
 import { TurnRunner } from '../src/private/TurnRunner.js';
 import type { DurableConfig } from '../src/public/types.js';
+import { makeBetaStream } from './helpers.js';
 
 // ---------------------------------------------------------------------------
 // Stream helpers
 // ---------------------------------------------------------------------------
 
-async function* makeTextStream(text: string): AsyncIterable<BetaRawMessageStreamEvent> {
-  yield { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent;
-  yield { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_stop' } as BetaRawMessageStreamEvent;
+function makeTextStream(text: string): BetaRawMessageStreamEvent[] {
+  return [
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent,
+    { type: 'message_stop' } as BetaRawMessageStreamEvent,
+  ];
 }
 
-async function* makeEmptyStream(): AsyncIterable<BetaRawMessageStreamEvent> {
-  yield { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 0 } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_stop' } as BetaRawMessageStreamEvent;
+function makeEmptyStream(): BetaRawMessageStreamEvent[] {
+  return [
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 0 } } as BetaRawMessageStreamEvent,
+    { type: 'message_stop' } as BetaRawMessageStreamEvent,
+  ];
 }
 
-async function* makeServerToolStream(): AsyncIterable<BetaRawMessageStreamEvent> {
-  yield { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_start', index: 0, content_block: { type: 'server_tool_use', id: 'srvtoolu_01', name: 'web_search', input: {} } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_start', index: 1, content_block: { type: 'web_search_tool_result', tool_use_id: 'srvtoolu_01', content: [] } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent;
-  yield { type: 'content_block_stop', index: 1 } as BetaRawMessageStreamEvent;
-  yield { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent;
-  yield { type: 'message_stop' } as BetaRawMessageStreamEvent;
+function makeServerToolStream(): BetaRawMessageStreamEvent[] {
+  return [
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'server_tool_use', id: 'srvtoolu_01', name: 'web_search', input: {} } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
+    { type: 'content_block_start', index: 1, content_block: { type: 'web_search_tool_result', tool_use_id: 'srvtoolu_01', content: [] } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent,
+    { type: 'content_block_stop', index: 1 } as BetaRawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 5 } } as BetaRawMessageStreamEvent,
+    { type: 'message_stop' } as BetaRawMessageStreamEvent,
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -43,20 +51,20 @@ async function* makeServerToolStream(): AsyncIterable<BetaRawMessageStreamEvent>
 
 class FakeMessageStreamer extends IMessageStreamer {
   public readonly calls: { body: BetaMessageStreamParams; options: Anthropic.RequestOptions }[] = [];
-  readonly #responses: Array<AsyncIterable<BetaRawMessageStreamEvent>>;
+  readonly #responses: Array<BetaRawMessageStreamEvent[]>;
 
-  public constructor(responses: Array<AsyncIterable<BetaRawMessageStreamEvent>>) {
+  public constructor(responses: Array<BetaRawMessageStreamEvent[]>) {
     super();
     this.#responses = [...responses];
   }
 
-  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): AsyncIterable<BetaRawMessageStreamEvent> {
+  public stream(body: BetaMessageStreamParams, options: Anthropic.RequestOptions): BetaMessageStream {
     this.calls.push({ body, options });
     const next = this.#responses.shift();
     if (next == null) {
       throw new Error('FakeMessageStreamer: no more scripted responses');
     }
-    return next;
+    return makeBetaStream(next);
   }
 }
 

--- a/packages/claude-sdk/test/TurnRunner.spec.ts
+++ b/packages/claude-sdk/test/TurnRunner.spec.ts
@@ -16,7 +16,7 @@ import { makeBetaStream } from './helpers.js';
 
 function makeTextStream(text: string): BetaRawMessageStreamEvent[] {
   return [
-    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as unknown as BetaRawMessageStreamEvent,
     { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as BetaRawMessageStreamEvent,
     { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as BetaRawMessageStreamEvent,
     { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
@@ -27,7 +27,7 @@ function makeTextStream(text: string): BetaRawMessageStreamEvent[] {
 
 function makeEmptyStream(): BetaRawMessageStreamEvent[] {
   return [
-    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as unknown as BetaRawMessageStreamEvent,
     { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 0 } } as BetaRawMessageStreamEvent,
     { type: 'message_stop' } as BetaRawMessageStreamEvent,
   ];
@@ -35,7 +35,7 @@ function makeEmptyStream(): BetaRawMessageStreamEvent[] {
 
 function makeServerToolStream(): BetaRawMessageStreamEvent[] {
   return [
-    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as BetaRawMessageStreamEvent,
+    { type: 'message_start', message: { content: [], usage: { input_tokens: 10, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 } } } as unknown as BetaRawMessageStreamEvent,
     { type: 'content_block_start', index: 0, content_block: { type: 'server_tool_use', id: 'srvtoolu_01', name: 'web_search', input: {} } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent,
     { type: 'content_block_stop', index: 0 } as BetaRawMessageStreamEvent,
     { type: 'content_block_start', index: 1, content_block: { type: 'web_search_tool_result', tool_use_id: 'srvtoolu_01', content: [] } as unknown as Anthropic.Beta.Messages.BetaContentBlock } as BetaRawMessageStreamEvent,

--- a/packages/claude-sdk/test/TurnRunner.spec.ts
+++ b/packages/claude-sdk/test/TurnRunner.spec.ts
@@ -1,7 +1,7 @@
 import type { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import type { BetaMessageStreamParams } from '@anthropic-ai/sdk/resources/beta/messages.js';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
-import { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
 import { describe, expect, it } from 'vitest';
 import { Conversation } from '../src/private/Conversation.js';
 import { IMessageStreamer } from '../src/private/MessageStreamer.js';

--- a/packages/claude-sdk/test/helpers.ts
+++ b/packages/claude-sdk/test/helpers.ts
@@ -1,0 +1,64 @@
+import { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs';
+import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta.mjs';
+
+// Minimal message_start with stub usage. BetaUsage has additional required
+// fields (cache_creation, inference_geo, etc.) that are not needed for tests,
+// so the cast bypasses the exhaustive type check.
+const MESSAGE_START: BetaRawMessageStreamEvent = {
+  type: 'message_start',
+  message: {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    content: [],
+    model: 'claude-test',
+    stop_reason: null,
+    stop_sequence: null,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  },
+} as unknown as BetaRawMessageStreamEvent;
+
+// Minimal message_delta that sets stop_reason and output_tokens.
+const MESSAGE_DELTA: BetaRawMessageStreamEvent = {
+  type: 'message_delta',
+  delta: { stop_reason: 'end_turn', stop_sequence: null },
+  usage: { output_tokens: 5 },
+} as unknown as BetaRawMessageStreamEvent;
+
+const MESSAGE_STOP: BetaRawMessageStreamEvent = { type: 'message_stop' };
+
+/**
+ * Wraps a list of content events with the message framing that
+ * BetaMessageStream.fromReadableStream requires. StreamProcessor.spec.ts
+ * event arrays omit framing; TurnRunner.spec.ts and QueryRunner.spec.ts
+ * include it in their own helpers and do not need this wrapper.
+ */
+export function wrapWithMessageEnvelope(events: BetaRawMessageStreamEvent[]): BetaRawMessageStreamEvent[] {
+  return [MESSAGE_START, ...events, MESSAGE_DELTA, MESSAGE_STOP];
+}
+
+/**
+ * Creates a BetaMessageStream from a scripted event array. Must be called
+ * lazily — at the moment the stream is handed to StreamProcessor.process() —
+ * so that process() registers its listeners before any events fire.
+ *
+ * BetaMessageStream.fromReadableStream starts _run synchronously, but the
+ * executor suspends at the first `for await` on the ReadableStream. Listener
+ * registration in process() happens before that suspension resolves.
+ */
+export function makeBetaStream(events: BetaRawMessageStreamEvent[]): BetaMessageStream {
+  const lines = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines));
+      controller.close();
+    },
+  });
+  return BetaMessageStream.fromReadableStream(readable);
+}


### PR DESCRIPTION
## Summary

- Replace block accumulator state machine with SDK BetaMessageStream event emitter
- Emit the same MessageStreamEvents as before; consumer wiring in main.ts unchanged
- Extract shared test helpers for BetaMessageStream construction

See #237