### PR TITLE
Release 1.0.0-beta.5

### DIFF
--- a/.claude/testament/2026-04-27.md
+++ b/.claude/testament/2026-04-27.md
@@ -47,3 +47,37 @@ All checks passed: build, type-check, test, ci (biome). No pnpm-lock.yaml change
 - packages/claude-sdk/CHANGELOG.md
 - packages/claude-core/package.json
 - packages/claude-core/CHANGELOG.md
+
+# 01:34
+
+## Ship: 1.0.0-beta.5
+
+### What shipped
+
+Four packages bumped to `1.0.0-beta.5`: `apps/claude-sdk-cli`, `packages/claude-sdk-tools`, `packages/claude-sdk`, `packages/claude-core`. The legacy `apps/claude-cli` was not bumped (no source changes).
+
+Changes in the release:
+- CLAUDE.md: removed the stale "Release markers" line, added Lockstep versioning, Pre-release process, Stable releases (future), and Build versioning subsections
+- `.github/workflows/npm-publish.yml`: added `workflow_dispatch` trigger, GitVersion diagnostics step, built version verification step, and dry-run support on manual dispatch
+
+### Changelog generation trap
+
+The mission documented `pnpm tsx scripts/src/generate-changelog.ts <package-dir>`. This fails because `tsx` is a devDependency of the `scripts` workspace package, not the root.
+
+Correct invocation (from the repo root):
+
+```bash
+pnpm --filter scripts exec tsx src/generate-changelog.ts ../<package-dir>
+```
+
+The path is relative to the `scripts/` directory, so `../apps/claude-sdk-cli` not `apps/claude-sdk-cli`.
+
+The SC corrected CLAUDE.md in a follow-up commit (`103e64a`) to document the right commands for both `generate-changelog` and `validate-changes`. CLAUDE.md now shows `pnpm exec tsx src/generate-changelog.ts ../<package-dir>` run from `scripts/`.
+
+### GitVersion in CI
+
+GitVersion does not produce correct versions in the npm-publish workflow. For pre-releases this is not a blocker because the publish step reads version from `package.json`, not from GitVersion. The diagnostics added to npm-publish.yml will surface what GitVersion actually sees in CI once the first release workflow runs.
+
+### SC correction
+
+After phase 1 committed, SC made one follow-up commit to fix the CLAUDE.md commands. The testament from the maker operator recorded the correct invocation; the SC aligned CLAUDE.md to match.

--- a/.claude/testament/2026-04-27.md
+++ b/.claude/testament/2026-04-27.md
@@ -1,0 +1,49 @@
+# 01:09
+
+## Phase 1: 1.0.0-beta.5 release prep
+
+### What was done
+
+Executed the beta.5 release prep: CLAUDE.md updates, npm-publish.yml diagnostics, version bumps, changelog generation.
+
+### CLAUDE.md
+
+Two changes:
+1. Removed the "Release markers" line (pre-releases don't use them)
+2. Added three new subsections after `### @shellicar/changes tooling`: Lockstep versioning, Pre-release process (current), Stable releases (future), Build versioning
+
+### npm-publish.yml
+
+Five changes applied in one edit:
+1. Added `workflow_dispatch` trigger with `tag` input
+2. Updated `Parse release tag` to read from `github.event.inputs.tag` on manual dispatch
+3. Added `GitVersion diagnostics (temporary)` step after `Install GitVersion`
+4. Added `Verify built version (temporary)` step after build/test/lint (before `Resolve package directory`)
+5. Updated `Publish` step: sets `DRY_RUN=--dry-run` on `workflow_dispatch`
+
+### Changelog generation
+
+The mission says `pnpm tsx scripts/src/generate-changelog.ts <package-dir>`. That invocation fails because tsx is a devDependency of the `scripts` workspace package, not the root. The correct command is:
+
+```bash
+pnpm --filter scripts exec tsx src/generate-changelog.ts ../<package-dir>
+```
+
+Note the path is relative to the scripts directory, so `../apps/claude-sdk-cli` not `apps/claude-sdk-cli`.
+
+### Verify results
+
+All checks passed: build, type-check, test, ci (biome). No pnpm-lock.yaml changes.
+
+### Files staged
+
+- CLAUDE.md
+- .github/workflows/npm-publish.yml
+- apps/claude-sdk-cli/package.json
+- apps/claude-sdk-cli/CHANGELOG.md
+- packages/claude-sdk-tools/package.json
+- packages/claude-sdk-tools/CHANGELOG.md
+- packages/claude-sdk/package.json
+- packages/claude-sdk/CHANGELOG.md
+- packages/claude-core/package.json
+- packages/claude-core/CHANGELOG.md

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,11 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to test (e.g. claude-sdk-cli@1.0.0-beta.5)'
+        required: true
 
 jobs:
   build:
@@ -18,7 +23,11 @@ jobs:
       - name: Parse release tag
         id: tag
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
           if [[ "$TAG" != *"@"* ]]; then
             echo "❌ Tag '$TAG' is not in package@version format"
             exit 1
@@ -36,6 +45,21 @@ jobs:
           tar xzf /tmp/gitversion.tar.gz -C /usr/local/bin gitversion
           chmod +x /usr/local/bin/gitversion
 
+      - name: GitVersion diagnostics (temporary)
+        run: |
+          echo "=== Git state ==="
+          git log --oneline -5
+          echo ""
+          echo "=== Tags ==="
+          git tag --list '*@*' --sort=-version:refname | head -20
+          echo ""
+          echo "=== GitVersion output ==="
+          gitversion /showconfig || true
+          echo ""
+          gitversion /diag || true
+          echo ""
+          gitversion || true
+
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -49,6 +73,19 @@ jobs:
       - run: pnpm run --if-present type-check --only
       - run: pnpm run --if-present test --only
       - run: pnpm run ci
+
+      - name: Verify built version (temporary)
+        if: steps.tag.outputs.package == 'claude-sdk-cli'
+        run: |
+          BUILT_VERSION=$(node apps/claude-sdk-cli/dist/esm/entry/main.js --version 2>/dev/null || echo "FAILED")
+          PKG_VERSION=$(node -p "require('./apps/claude-sdk-cli/package.json').version")
+          echo "Built version:       $BUILT_VERSION"
+          echo "package.json version: $PKG_VERSION"
+          if [ "$BUILT_VERSION" != "$PKG_VERSION" ]; then
+            echo "❌ Version mismatch — GitVersion produced: $BUILT_VERSION, expected: $PKG_VERSION"
+            exit 1
+          fi
+          echo "✅ Versions match"
 
       - name: Resolve package directory
         id: package
@@ -120,6 +157,11 @@ jobs:
             exit 1
           fi
           echo "Publishing with tag: $TAG"
-          pnpm publish --provenance --ignore-scripts --no-git-checks --tag "$TAG"
+          DRY_RUN=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DRY_RUN="--dry-run"
+            echo "⚠️ Dry run: workflow_dispatch trigger"
+          fi
+          pnpm publish --provenance --ignore-scripts --no-git-checks --tag "$TAG" $DRY_RUN
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,11 @@ Each package has `changes.jsonl` and `CHANGELOG.md`. Add an entry on every PR:
 {"description":"What changed","category":"added|changed|deprecated|removed|fixed|security"}
 ```
 
-`CHANGELOG.md` is generated from `changes.jsonl` via `pnpm tsx scripts/src/generate-changelog.ts <package-dir>`.
+`CHANGELOG.md` is generated from `changes.jsonl` by running `tsx src/generate-changelog.ts ../<package-dir>` from the `scripts/` directory.
 
 ### @shellicar/changes tooling
 
-`changes.config.json` defines valid categories. `schema/shellicar-changes.json` is generated from it. Validate with `pnpm tsx scripts/src/validate-changes.ts`. CI runs this automatically.
+`changes.config.json` defines valid categories. `schema/shellicar-changes.json` is generated from it. Validate by running `tsx src/validate-changes.ts` from the `scripts/` directory. CI runs this automatically.
 
 ### Lockstep versioning
 
@@ -111,9 +111,9 @@ All releases are pre-releases until 1.0.0. The current version series is `1.0.0-
    pnpm version 1.0.0-beta.N --no-git-tag-version
    ```
 
-3. Generate changelogs for each bumped package:
+3. Generate changelogs for each bumped package (run from `scripts/`):
    ```bash
-   pnpm tsx scripts/src/generate-changelog.ts <package-dir>
+   pnpm exec tsx src/generate-changelog.ts ../<package-dir>
    ```
    The script puts all entries under `[Unreleased]` (no release markers exist). If it produces changes for a package that was not bumped, stop and investigate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,13 +81,68 @@ Each package has `changes.jsonl` and `CHANGELOG.md`. Add an entry on every PR:
 {"description":"What changed","category":"added|changed|deprecated|removed|fixed|security"}
 ```
 
-Release markers: `{"type":"release","version":"1.0.0-beta.1","date":"YYYY-MM-DD"}`
-
 `CHANGELOG.md` is generated from `changes.jsonl` via `pnpm tsx scripts/src/generate-changelog.ts <package-dir>`.
 
 ### @shellicar/changes tooling
 
 `changes.config.json` defines valid categories. `schema/shellicar-changes.json` is generated from it. Validate with `pnpm tsx scripts/src/validate-changes.ts`. CI runs this automatically.
+
+### Lockstep versioning
+
+All packages share the same version number. If a package has source changes since the last release, it gets bumped to the new version. Packages without changes are not bumped.
+
+### Pre-release process (current)
+
+All releases are pre-releases until 1.0.0. The current version series is `1.0.0-beta.N`.
+
+**No release markers in changes.jsonl for pre-releases.** All entries stay under `[Unreleased]` in the changelog. When 1.0.0 ships, the changelog will show the complete diff from zero to 1.0.0. Individual beta changelogs are noise for anyone consuming the library.
+
+**Steps:**
+
+1. Determine which packages have source changes since the last release tag:
+   ```bash
+   git diff --stat <last-tag> HEAD -- <package>/src/
+   ```
+   Run this for each package directory. Cross-reference with new entries in each package's `changes.jsonl` (diff against the tag). Only packages with source changes get bumped.
+
+2. Bump version in each changed package:
+   ```bash
+   cd <package-dir>
+   pnpm version 1.0.0-beta.N --no-git-tag-version
+   ```
+
+3. Generate changelogs for each bumped package:
+   ```bash
+   pnpm tsx scripts/src/generate-changelog.ts <package-dir>
+   ```
+   The script puts all entries under `[Unreleased]` (no release markers exist). If it produces changes for a package that was not bumped, stop and investigate.
+
+4. Verify: `pnpm build && pnpm type-check && pnpm test && pnpm run ci`
+
+5. Single PR with all version bumps, changelog updates, and lock file changes.
+
+6. After merge, create a GitHub release for each bumped package:
+   ```bash
+   gh release create "<package>@<version>" --title "<package>@<version>" --target <main-sha> --notes "<unreleased section>" --prerelease
+   ```
+   Each release triggers the npm-publish workflow. Wait for each workflow to complete before creating the next.
+
+### Stable releases (future)
+
+Stable releases (e.g. 1.0.0, 1.1.0) use release markers in changes.jsonl. The changelog script moves entries from `[Unreleased]` into a dated version section. Pre-releases between stable versions (e.g. 1.1.0-beta.1) follow the pre-release process above: no release markers, everything stays under `[Unreleased]` until the next stable release.
+
+### Build versioning
+
+`@shellicar/build-version` is an esbuild plugin that runs GitVersion at build time and injects version metadata into the bundle. The chain is:
+
+1. Each package's `tsup.config.ts` imports `@shellicar/build-version/esbuild`
+2. The plugin is configured with `versionCalculator: 'gitversion'`
+3. At build time, the plugin runs `gitversion` and injects the result
+4. Application code imports `@shellicar/build-version/version` to read the injected values (version, branch, sha, commitDate, buildDate)
+
+GitVersion is configured in `GitVersion.yml` at the repo root. There are no other direct references to GitVersion in the codebase. The `@shellicar/build-version` dependency is the only consumer.
+
+GitVersion currently does not produce correct versions in the npm-publish CI workflow. For pre-releases this is not a blocker because package.json is the source of truth and the publish step reads it directly. Temporary diagnostics are included in this release to debug the issue (see npm-publish.yml changes below).
 
 ## Linting & Formatting
 

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -21,11 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flash tool approval prompt with inverted colours when awaiting Y/N
 - Add approval notification hook: run a command when tool approval is pending
 - Track session history per working directory for future session picker
+- Support reading PDF and image files as native API content blocks
+- Add maxTokens to config (default 32000)
+- Add per-source CLAUDE.md loading control
 
 ### Changed
 
 - Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement
 - Write session ID marker on save instead of on creation
+- Config system tracks which file each value came from
+- Hook input delivered via stdin instead of command arguments
 
 ### Fixed
 
@@ -37,3 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve editor content when starting a new conversation
 - Restore cursor visibility after exiting the CLI (#277)
 - Apply biome formatting fixes
+- Prevent crashes from unhandled child process and socket errors
+- Write session marker and history at turn start so they survive mid-response crashes
+- Hook commands support ~, $HOME, and relative paths
+- Fix colour loss when syntax-highlighted code scrolls off screen
+- Fix divider width calculation for emoji labels
+- Fix garbled cursor rendering on emoji characters

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support binary file reads through encoding parameter on IFileSystem.readFile
+
 ### Fixed
 
 - Package now publishes CJS alongside ESM with working sourcemaps
+- Re-establish ANSI colour state on wrapped continuation lines

--- a/packages/claude-core/package.json
+++ b/packages/claude-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-core",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.5",
   "private": false,
   "description": "",
   "license": "MIT",

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -22,9 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem
 - Add TypeScript language tools: ts_diagnostics, ts_hover, ts_references, ts_definition
 - Add append operation to EditFile
+- ReadFile supports PDF and image files with MIME type detection and magic bytes validation
+
+### Changed
+
+- ReadFile accepts image/* to read any supported image format; the format is detected from file content rather than the declared type
+- Removed the 500KB limit on text file reads
+- Tool handlers return structured output with textContent and optional attachments
 
 ### Fixed
 
 - Package now publishes CJS alongside ESM with working sourcemaps
 - Normalise tilde and environment variable paths in EditFile
 - Find tool follows symlinks with cycle detection
+- Binary files are blocked from text reads when the format is recognised; unrecognised formats are still treated as text

--- a/packages/claude-sdk-tools/package.json
+++ b/packages/claude-sdk-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-tools",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `CompactConfig` type; `cloneForRequest` converts compaction blocks to text when compact is disabled
 - Support tool search for on-demand tool discovery
 - Support tool use examples in tool definitions
+- Deliver tool attachments as native content blocks inside tool results
+- Add output_schema to ToolDefinition for typed handler outputs
 
 ### Changed
 
@@ -20,7 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract `AnthropicClient` from `AnthropicAgent`: auth, token refresh, and HTTP transport now live in a dedicated private class. `AnthropicAgent` becomes a thin composer that holds a client and a conversation. The previous `AnthropicMessageStreamer` wrapper is removed; `AnthropicClient` extends `IMessageStreamer` directly.
 - Replace `AnthropicBeta.Compact` enum member with standalone `COMPACT_BETA` constant
 - Omit empty `context_management` from request body instead of sending empty edits array
+- Tool handlers return structured output with optional attachments for binary content
+- Refactor stream processor to use SDK native event emitter
+
+### Removed
+
+- Remove deprecated InterleavedThinking beta header
 
 ### Fixed
 
 - Package now publishes CJS alongside ESM with working sourcemaps
+- Show thinking text when using Opus 4.7
+- Calculate costs for Opus 4.7
+- Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
+- Preserve server tool blocks (server_tool_use, web_search_tool_result, web_fetch_tool_result) in conversation history
+- Preserve redacted_thinking blocks in conversation history

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",


### PR DESCRIPTION
## Summary

- Bump four packages to 1.0.0-beta.5
- Add GitVersion diagnostics and dry-run support to npm-publish workflow
- Update CLAUDE.md with release process and build version documentation