### PR TITLE
Reject oversized images at ReadFile boundary

### DIFF
--- a/.claude/testament/2026-05-06.md
+++ b/.claude/testament/2026-05-06.md
@@ -49,3 +49,51 @@ Type-check: clean.
 The implementation goes in `ReadFile.ts` after `detectBlock()` returns a `binary` result, before constructing the return. The check is `data.length > IMAGE_BASE64_MAX_BYTES` (constant at 5 * 1024 * 1024). The MIME type guard is simplest as `result.mimeType.startsWith('image/')`. The failure shape is `{ error: true, message: '...', path: filePath }` — same as the existing error returns.
 
 The `message identifies the breach` test asserts `toMatch(/base64.*too large/i)` — the Builder's message must include "base64" and "too large" (case-insensitive, with anything in between).
+
+# 23:57
+
+Phase 2 — Builder. Mission: make the two failing image size limit tests pass.
+
+## What I changed
+
+`packages/claude-sdk-tools/src/ReadFile/ReadFile.ts` — two additions:
+
+1. Module-level constant after `MAX_BINARY_BYTES`:
+   ```ts
+   const IMAGE_BASE64_MAX_BYTES = 5 * 1024 * 1024; // Anthropic API per-image cap
+   ```
+
+2. Guard block inserted between the `!result` check and the `result.kind === 'binary'` return:
+   ```ts
+   if (result.kind === 'binary' && result.mimeType.startsWith('image/')) {
+     if (data.length > IMAGE_BASE64_MAX_BYTES) {
+       const kb = Math.round(data.length / 1024);
+       return {
+         textContent: {
+           error: true,
+           message: `Image base64 payload too large (${kb}KB, max 5120KB).`,
+           path: filePath,
+         } satisfies ReadFileOutput,
+       };
+     }
+   }
+   ```
+
+The MIME type guard uses `startsWith('image/')` — simplest approach, covers all four image types in the switch without needing a separate constant set.
+
+The message "Image base64 payload too large" satisfies the test's `/base64.*too large/i` regex.
+
+No test modifications.
+
+## Test result
+
+```
+Test Files  21 passed (21)
+     Tests  282 passed (282)
+```
+
+Type-check: clean. Biome: clean.
+
+## For the Courier
+
+No surprises. The package had no lint script (`pnpm --filter @shellicar/claude-sdk-tools lint` returns no script); ran `pnpm biome check` on the changed file directly — no issues. Staged `packages/claude-sdk-tools/src/ReadFile/ReadFile.ts` only.

--- a/.claude/testament/2026-05-06.md
+++ b/.claude/testament/2026-05-06.md
@@ -1,99 +1,40 @@
-# 23:53
+# 00:06
 
-Phase 1 — Scaffolder. Mission: add failing tests for a new image base64 size cap in `ReadFile`.
+Phase 3 — Courier. Synthesising the prompt record.
 
-## What I found
+## What was built
 
-**`ReadFile.ts` flow** for images: `stat()` → MAX_BINARY_BYTES check (32 MB raw) → `readFile('base64')` → `detectBlock()` → if `result.kind === 'binary'`, returns binary result with attachment. There is no per-image cap. The new check needs to go between `detectBlock()` returning and the binary result being returned — checking `data.length > 5_242_880`.
+`ReadFile` now rejects images whose base64 payload exceeds the Anthropic API per-image cap of 5,242,880 bytes (5 MiB). The check lives in `packages/claude-sdk-tools/src/ReadFile/ReadFile.ts`, after `detectBlock()` returns a binary result with an image MIME type.
 
-**`MemoryFileSystem`** accepts `Buffer` directly in its constructor (`Record<string, string | Buffer>`). `stat()` returns `content.byteLength` as size. `readFile('base64')` calls `content.toString('base64')`. This means test Buffers flow cleanly through without any string encoding workaround.
+The guard: `result.mimeType.startsWith('image/')` then `data.length > IMAGE_BASE64_MAX_BYTES` where the constant is `5 * 1024 * 1024`. The `data` variable is the already-computed base64 string returned by `readFile('base64')` — no re-encoding needed.
 
-**`pngMagic`** is already defined at module scope (29 bytes: PNG sig + IHDR length + IHDR type + IHDR data). Reused for padding.
+Failure shape is the existing `ReadFileOutputFailure`: `{ error: true, message, path }`. Message: `Image base64 payload too large (${kb}KB, max 5120KB).`
+
+The 32 MB `MAX_BINARY_BYTES` gate is unchanged — it's a coarse first-pass that covers PDFs too, and revisiting it is separate work.
 
 ## The boundary math
 
-- `data.length > 5_242_880` is the future check
-- 3,932,161 raw bytes → `ceil(3932161/3)*4 = 5,242,884` base64 bytes → over ✓
-- 3,932,160 raw bytes → `ceil(3932160/3)*4 = 5,242,880` base64 bytes → exactly at cap, `>` is false → passes ✓
-- The "at the cap" case tests the boundary of `>` (not `>=`): 3,932,160 raw bytes gives exactly 5,242,880 base64 bytes, which must pass.
+- `data.length > IMAGE_BASE64_MAX_BYTES` — strictly greater than, not `>=`
+- 3,932,160 raw bytes → `ceil(3932160/3)*4 = 5,242,880` base64 bytes → exactly at cap, passes
+- 3,932,161 raw bytes → `ceil(3932161/3)*4 = 5,242,884` base64 bytes → over, fails
 
-## What I wrote
+The test scaffolding uses `overLimitPng` (3,932,161 bytes) and `atLimitPng` (3,932,160 bytes) as Buffer constants.
 
-Appended a new `describe('createReadFile — image size limit', ...)` block with 7 `it` blocks grouped into 3 nested describes:
+## Test structure
 
-1. **`when image base64 payload exceeds the 5 MB cap`** — 2 tests (failure shape, message regex)
-2. **`when image base64 payload is at or below the 5 MB cap`** — 3 tests (type at cap, attachment at cap, small PNG)
-3. **`when a PDF exceeds 5 MB base64`** — 2 tests (PDF type, PDF attachment)
+New `describe` block: `createReadFile — image size limit`, three nested describes:
+1. `when image base64 payload exceeds the 5 MB cap` — 2 tests (failure shape, message matches `/base64.*too large/i`)
+2. `when image base64 payload is at or below the 5 MB cap` — 3 tests (binary type at cap, attachment at cap, small PNG passes)
+3. `when a PDF exceeds 5 MB base64` — 2 tests (PDF is not subject to image gate)
 
-Module-level buffer constants: `overLimitPng` (3,932,161 bytes), `atLimitPng` (3,932,160 bytes), `overLimitPdf` (4,000,000 bytes, starts with `%PDF-1.4\n`).
+`MemoryFileSystem` accepts `Buffer` directly — no string conversion needed. `pngMagic` (29 bytes: PNG sig + IHDR) was already defined at module scope in the test file; used as the header for all synthetic test images.
 
-## Test run result
+## Things a future operator should know
 
-```
-✓ all 265 pre-existing tests pass
-× createReadFile — image size limit > when image base64 payload exceeds the 5 MB cap > returns the failure shape
-  → expected undefined to be true
-× createReadFile — image size limit > when image base64 payload exceeds the 5 MB cap > message identifies the breach
-  → .toMatch() expects to receive a string, but got undefined
-✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > returns a binary result when payload is exactly at the cap
-✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > includes an attachment when payload is exactly at the cap
-✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > a small PNG returns a binary result
-✓ createReadFile — image size limit > when a PDF exceeds 5 MB base64 > returns a binary result because PDFs are not subject to the image cap
-✓ createReadFile — image size limit > when a PDF exceeds 5 MB base64 > includes an attachment for the PDF
-```
+The package has no `lint` script — `pnpm --filter @shellicar/claude-sdk-tools lint` returns "no script". If you need to lint a changed file, run `pnpm biome check <file>` directly.
 
-Type-check: clean.
+The MIME type check uses `startsWith('image/')` rather than a constant set of the four image types. This is intentional: simpler, and the four types in the `detectBlock` switch are the only ones `file-type` will return for image content anyway.
 
-## For the Builder
+## Final state
 
-The implementation goes in `ReadFile.ts` after `detectBlock()` returns a `binary` result, before constructing the return. The check is `data.length > IMAGE_BASE64_MAX_BYTES` (constant at 5 * 1024 * 1024). The MIME type guard is simplest as `result.mimeType.startsWith('image/')`. The failure shape is `{ error: true, message: '...', path: filePath }` — same as the existing error returns.
-
-The `message identifies the breach` test asserts `toMatch(/base64.*too large/i)` — the Builder's message must include "base64" and "too large" (case-insensitive, with anything in between).
-
-# 23:57
-
-Phase 2 — Builder. Mission: make the two failing image size limit tests pass.
-
-## What I changed
-
-`packages/claude-sdk-tools/src/ReadFile/ReadFile.ts` — two additions:
-
-1. Module-level constant after `MAX_BINARY_BYTES`:
-   ```ts
-   const IMAGE_BASE64_MAX_BYTES = 5 * 1024 * 1024; // Anthropic API per-image cap
-   ```
-
-2. Guard block inserted between the `!result` check and the `result.kind === 'binary'` return:
-   ```ts
-   if (result.kind === 'binary' && result.mimeType.startsWith('image/')) {
-     if (data.length > IMAGE_BASE64_MAX_BYTES) {
-       const kb = Math.round(data.length / 1024);
-       return {
-         textContent: {
-           error: true,
-           message: `Image base64 payload too large (${kb}KB, max 5120KB).`,
-           path: filePath,
-         } satisfies ReadFileOutput,
-       };
-     }
-   }
-   ```
-
-The MIME type guard uses `startsWith('image/')` — simplest approach, covers all four image types in the switch without needing a separate constant set.
-
-The message "Image base64 payload too large" satisfies the test's `/base64.*too large/i` regex.
-
-No test modifications.
-
-## Test result
-
-```
-Test Files  21 passed (21)
-     Tests  282 passed (282)
-```
-
-Type-check: clean. Biome: clean.
-
-## For the Courier
-
-No surprises. The package had no lint script (`pnpm --filter @shellicar/claude-sdk-tools lint` returns no script); ran `pnpm biome check` on the changed file directly — no issues. Staged `packages/claude-sdk-tools/src/ReadFile/ReadFile.ts` only.
+282 tests passing (21 test files). Type-check clean. Biome clean.

--- a/.claude/testament/2026-05-06.md
+++ b/.claude/testament/2026-05-06.md
@@ -1,0 +1,51 @@
+# 23:53
+
+Phase 1 — Scaffolder. Mission: add failing tests for a new image base64 size cap in `ReadFile`.
+
+## What I found
+
+**`ReadFile.ts` flow** for images: `stat()` → MAX_BINARY_BYTES check (32 MB raw) → `readFile('base64')` → `detectBlock()` → if `result.kind === 'binary'`, returns binary result with attachment. There is no per-image cap. The new check needs to go between `detectBlock()` returning and the binary result being returned — checking `data.length > 5_242_880`.
+
+**`MemoryFileSystem`** accepts `Buffer` directly in its constructor (`Record<string, string | Buffer>`). `stat()` returns `content.byteLength` as size. `readFile('base64')` calls `content.toString('base64')`. This means test Buffers flow cleanly through without any string encoding workaround.
+
+**`pngMagic`** is already defined at module scope (29 bytes: PNG sig + IHDR length + IHDR type + IHDR data). Reused for padding.
+
+## The boundary math
+
+- `data.length > 5_242_880` is the future check
+- 3,932,161 raw bytes → `ceil(3932161/3)*4 = 5,242,884` base64 bytes → over ✓
+- 3,932,160 raw bytes → `ceil(3932160/3)*4 = 5,242,880` base64 bytes → exactly at cap, `>` is false → passes ✓
+- The "at the cap" case tests the boundary of `>` (not `>=`): 3,932,160 raw bytes gives exactly 5,242,880 base64 bytes, which must pass.
+
+## What I wrote
+
+Appended a new `describe('createReadFile — image size limit', ...)` block with 7 `it` blocks grouped into 3 nested describes:
+
+1. **`when image base64 payload exceeds the 5 MB cap`** — 2 tests (failure shape, message regex)
+2. **`when image base64 payload is at or below the 5 MB cap`** — 3 tests (type at cap, attachment at cap, small PNG)
+3. **`when a PDF exceeds 5 MB base64`** — 2 tests (PDF type, PDF attachment)
+
+Module-level buffer constants: `overLimitPng` (3,932,161 bytes), `atLimitPng` (3,932,160 bytes), `overLimitPdf` (4,000,000 bytes, starts with `%PDF-1.4\n`).
+
+## Test run result
+
+```
+✓ all 265 pre-existing tests pass
+× createReadFile — image size limit > when image base64 payload exceeds the 5 MB cap > returns the failure shape
+  → expected undefined to be true
+× createReadFile — image size limit > when image base64 payload exceeds the 5 MB cap > message identifies the breach
+  → .toMatch() expects to receive a string, but got undefined
+✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > returns a binary result when payload is exactly at the cap
+✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > includes an attachment when payload is exactly at the cap
+✓ createReadFile — image size limit > when image base64 payload is at or below the 5 MB cap > a small PNG returns a binary result
+✓ createReadFile — image size limit > when a PDF exceeds 5 MB base64 > returns a binary result because PDFs are not subject to the image cap
+✓ createReadFile — image size limit > when a PDF exceeds 5 MB base64 > includes an attachment for the PDF
+```
+
+Type-check: clean.
+
+## For the Builder
+
+The implementation goes in `ReadFile.ts` after `detectBlock()` returns a `binary` result, before constructing the return. The check is `data.length > IMAGE_BASE64_MAX_BYTES` (constant at 5 * 1024 * 1024). The MIME type guard is simplest as `result.mimeType.startsWith('image/')`. The failure shape is `{ error: true, message: '...', path: filePath }` — same as the existing error returns.
+
+The `message identifies the breach` test asserts `toMatch(/base64.*too large/i)` — the Builder's message must include "base64" and "too large" (case-insensitive, with anything in between).

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -19,3 +19,4 @@
 {"description":"Removed the 500KB limit on text file reads","category":"changed"}
 {"description":"Binary files are blocked from text reads when the format is recognised; unrecognised formats are still treated as text","category":"fixed"}
 {"description":"Tool handlers return structured output with textContent and optional attachments","category":"changed"}
+{"description":"ReadFile rejects images whose base64 payload exceeds the Anthropic API 5 MB per-image cap","category":"fixed"}

--- a/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
@@ -8,6 +8,7 @@ import { ReadFileInputSchema, ReadFileOutputSchema } from './schema';
 import type { BinaryMimeType, InputMimeType, ReadFileOutput } from './types';
 
 const MAX_BINARY_BYTES = 32 * 1024 * 1024;
+const IMAGE_BASE64_MAX_BYTES = 5 * 1024 * 1024; // Anthropic API per-image cap
 
 // file-type needs up to ~4100 bytes for accurate detection.
 const HEADER_BASE64_CHARS = 5600;
@@ -95,6 +96,19 @@ export function createReadFile(fs: IFileSystem) {
             path: filePath,
           } satisfies ReadFileOutput,
         };
+      }
+
+      if (result.kind === 'binary' && result.mimeType.startsWith('image/')) {
+        if (data.length > IMAGE_BASE64_MAX_BYTES) {
+          const kb = Math.round(data.length / 1024);
+          return {
+            textContent: {
+              error: true,
+              message: `Image base64 payload too large (${kb}KB, max 5120KB).`,
+              path: filePath,
+            } satisfies ReadFileOutput,
+          };
+        }
       }
 
       if (result.kind === 'binary') {

--- a/packages/claude-sdk-tools/test/ReadFile.spec.ts
+++ b/packages/claude-sdk-tools/test/ReadFile.spec.ts
@@ -429,3 +429,92 @@ describe('createReadFile — mime type mismatch', () => {
     expect(actual).toBe(expected);
   });
 });
+
+// ---------------------------------------------------------------------------
+// image size limit
+// ---------------------------------------------------------------------------
+
+// Over the cap: 3,932,161 raw bytes → base64 length 5,242,884 (> 5,242,880)
+const overLimitPng = Buffer.concat([pngMagic, Buffer.alloc(3_932_161 - pngMagic.length)]);
+// At the cap: 3,932,160 raw bytes → base64 length exactly 5,242,880 (not over)
+const atLimitPng = Buffer.concat([pngMagic, Buffer.alloc(3_932_160 - pngMagic.length)]);
+// Over 5 MB base64, but a PDF — the image cap must not apply
+const pdfHeader = Buffer.from('%PDF-1.4\n');
+const overLimitPdf = Buffer.concat([pdfHeader, Buffer.alloc(4_000_000 - pdfHeader.length)]);
+
+describe('createReadFile — image size limit', () => {
+  describe('when image base64 payload exceeds the 5 MB cap', () => {
+    it('returns the failure shape', async () => {
+      const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
+
+      const expected = true;
+      const actual = (result.textContent as ReadFileOutputFailure).error;
+      expect(actual).toBe(expected);
+    });
+
+    it('message identifies the breach', async () => {
+      const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
+
+      const actual = (result.textContent as ReadFileOutputFailure).message;
+      expect(actual).toMatch(/base64.*too large/i);
+    });
+  });
+
+  describe('when image base64 payload is at or below the 5 MB cap', () => {
+    it('returns a binary result when payload is exactly at the cap', async () => {
+      const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
+
+      const expected = 'binary';
+      const actual = (result.textContent as ReadFileBinarySuccess).type;
+      expect(actual).toBe(expected);
+    });
+
+    it('includes an attachment when payload is exactly at the cap', async () => {
+      const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
+
+      const expected = 1;
+      const actual = result.attachments?.length;
+      expect(actual).toBe(expected);
+    });
+
+    it('a small PNG returns a binary result', async () => {
+      const fs = new MemoryFileSystem({ '/images/small.png': pngMagic });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/images/small.png', mimeType: 'image/*' });
+
+      const expected = 'binary';
+      const actual = (result.textContent as ReadFileBinarySuccess).type;
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('when a PDF exceeds 5 MB base64', () => {
+    it('returns a binary result because PDFs are not subject to the image cap', async () => {
+      const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
+
+      const expected = 'binary';
+      const actual = (result.textContent as ReadFileBinarySuccess).type;
+      expect(actual).toBe(expected);
+    });
+
+    it('includes an attachment for the PDF', async () => {
+      const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
+      const ReadFile = createReadFile(fs);
+      const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
+
+      const expected = 1;
+      const actual = result.attachments?.length;
+      expect(actual).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Images exceeding the Anthropic API 5 MB base64 per-image cap produce a 400 that poisons conversation history, blocking all subsequent requests on that session
- ReadFile now checks the base64 payload size after encoding and rejects images that would breach the cap
- Only image MIME types are checked (jpeg, png, gif, webp); PDFs and text are unaffected
- Dimension checks, auto-resize, conversation rollback on 400, and the Files API path are out of scope (tracked in #323)