### PR TITLE
Ship LICENSE, CHANGELOG, and README with published packages

### DIFF
--- a/.claude/testament/2026-05-18.md
+++ b/.claude/testament/2026-05-18.md
@@ -1,76 +1,30 @@
-# 04:58
+# 08:10
 
-Maker for publish-md-and-licence. Added a `LICENSE` (MIT, 2026) at the repo
-root and in each of the six publishable package directories. Updated each
-publishable `package.json`'s `files` field from `["dist"]` to
-`["dist", "*.md"]`. Verified by `pnpm build` then `pnpm pack` for each
-package; all six tarballs include `LICENSE`, `CHANGELOG.md`, `package.json`,
-and the `dist/` payload, plus `README.md` for the two packages that have one.
+Courier for publish-md-and-licence.
 
-## CLAUDE.md leakage
+## What shipped
 
-`*.md` is a glob, and three packages have a contributor-facing `CLAUDE.md`
-sitting at their root: `apps/claude-sdk-cli`, `packages/claude-sdk`,
-`packages/claude-sdk-tools`. Those `CLAUDE.md` files now ship to npm with
-the next publish.
+MIT LICENSE files (copyright 2026 Stephen Hellicar) added at the repo root
+and in all six publishable package directories. Each publishable
+`package.json` `files` field changed from `["dist"]` to
+`["dist", "CHANGELOG.md", "README.md"]`.
 
-The mission spec is literal — it said `files: ["dist", "*.md"]` — so the
-inclusion is faithful to the directive. Whether shipping internal contributor
-notes alongside the package is the intent is a call the SC owns. If not,
-the fix is `["dist", "CHANGELOG.md", "README.md"]` (explicit) or
-`.npmignore` entries for `CLAUDE.md`. Flagged in the debrief; not corrected
-unilaterally.
+## Why explicit filenames, not a glob
 
-The `apps/claude-cli` package has no `CLAUDE.md` of its own and is
-unaffected. `packages/claude-core` and `packages/mcp-exec` similarly have
-no `CLAUDE.md`.
+`*.md` was the original directive and produced correct tarballs, but three
+packages (`apps/claude-sdk-cli`, `packages/claude-sdk`,
+`packages/claude-sdk-tools`) have a contributor-facing `CLAUDE.md` at their
+root. The glob would have shipped those to npm consumers. The SC corrected the
+directive to explicit names. `CLAUDE.md` files stay in the repo; they just
+don't appear in published tarballs.
 
-## pnpm pack output
+## pnpm pack behaviour
 
-Each `pnpm pack` invocation lists the tarball contents to stdout under a
-`Tarball Contents` heading and writes the `.tgz` to the `--pack-destination`.
-Run in parallel across the six directories was clean — no contention on
-`/tmp` because each package produces a distinctly-named file
-(`shellicar-<pkg>-<version>.tgz`).
+Listing `README.md` in `files` for packages that don't have one does not
+produce a warning. pnpm 10.33.2 silently skips the missing file. Four
+packages have no README and produce correct tarballs regardless.
 
-## /tmp had a stray tarball
+## Fresh worktree
 
-`/tmp/shellicar-cosmos-query-builder-1.1.5.tgz` was already present before
-this cast and is unrelated to this work. Cleaned up only the six I produced.
-A Find across `/tmp` for `^shellicar-.*\.tgz$` will surface it for whoever
-notices later — left in place because deleting an unrelated artefact is not
-my call.
-
-## Install step was required
-
-`pnpm build` failed on first attempt with `turbo: command not found`. The
-worktree had `package.json` but no `node_modules` — turbo lives in the root
-`devDependencies`. `pnpm install` (lockfile was up to date so resolution was
-skipped, ~900ms) fixed it. Future operators arriving in a fresh worktree
-should expect to run install before any pnpm script that uses workspace
-tooling.
-
-# 05:15
-
-Phase 1 re-run after SC routed the CLAUDE.md leakage. Mission `## Changes`
-directive narrowed from `["dist", "*.md"]` to
-`["dist", "CHANGELOG.md", "README.md"]`. Updated each of the six publishable
-`package.json` files. LICENSE files unchanged from the earlier pass — they
-were correct from the start.
-
-Re-packed each of the six packages and verified per the corrected `## Verify`
-section:
-
-- All six tarballs contain `CHANGELOG.md`, `LICENSE`, `package.json`, and
-  the `dist/...` payload.
-- `README.md` present only in `apps/claude-cli` and `packages/claude-sdk`,
-  which are the only two packages that have one.
-- `CLAUDE.md` absent from every tarball.
-
-`pnpm pack` did not emit any warning for the four packages that lack a
-`README.md` (`apps/claude-sdk-cli`, `packages/claude-core`,
-`packages/claude-sdk-tools`, `packages/mcp-exec`). The mission warned to
-expect one; pnpm 10.33.2 silently skips the missing file with no message at
-all. Either behaviour produces the same correct tarball.
-
-No rebuild needed — `dist/` was untouched between the two passes.
+`pnpm build` fails without `node_modules` — turbo lives in devDependencies
+at the root. Run `pnpm install` first in any fresh worktree.

--- a/.claude/testament/2026-05-18.md
+++ b/.claude/testament/2026-05-18.md
@@ -1,0 +1,76 @@
+# 04:58
+
+Maker for publish-md-and-licence. Added a `LICENSE` (MIT, 2026) at the repo
+root and in each of the six publishable package directories. Updated each
+publishable `package.json`'s `files` field from `["dist"]` to
+`["dist", "*.md"]`. Verified by `pnpm build` then `pnpm pack` for each
+package; all six tarballs include `LICENSE`, `CHANGELOG.md`, `package.json`,
+and the `dist/` payload, plus `README.md` for the two packages that have one.
+
+## CLAUDE.md leakage
+
+`*.md` is a glob, and three packages have a contributor-facing `CLAUDE.md`
+sitting at their root: `apps/claude-sdk-cli`, `packages/claude-sdk`,
+`packages/claude-sdk-tools`. Those `CLAUDE.md` files now ship to npm with
+the next publish.
+
+The mission spec is literal — it said `files: ["dist", "*.md"]` — so the
+inclusion is faithful to the directive. Whether shipping internal contributor
+notes alongside the package is the intent is a call the SC owns. If not,
+the fix is `["dist", "CHANGELOG.md", "README.md"]` (explicit) or
+`.npmignore` entries for `CLAUDE.md`. Flagged in the debrief; not corrected
+unilaterally.
+
+The `apps/claude-cli` package has no `CLAUDE.md` of its own and is
+unaffected. `packages/claude-core` and `packages/mcp-exec` similarly have
+no `CLAUDE.md`.
+
+## pnpm pack output
+
+Each `pnpm pack` invocation lists the tarball contents to stdout under a
+`Tarball Contents` heading and writes the `.tgz` to the `--pack-destination`.
+Run in parallel across the six directories was clean — no contention on
+`/tmp` because each package produces a distinctly-named file
+(`shellicar-<pkg>-<version>.tgz`).
+
+## /tmp had a stray tarball
+
+`/tmp/shellicar-cosmos-query-builder-1.1.5.tgz` was already present before
+this cast and is unrelated to this work. Cleaned up only the six I produced.
+A Find across `/tmp` for `^shellicar-.*\.tgz$` will surface it for whoever
+notices later — left in place because deleting an unrelated artefact is not
+my call.
+
+## Install step was required
+
+`pnpm build` failed on first attempt with `turbo: command not found`. The
+worktree had `package.json` but no `node_modules` — turbo lives in the root
+`devDependencies`. `pnpm install` (lockfile was up to date so resolution was
+skipped, ~900ms) fixed it. Future operators arriving in a fresh worktree
+should expect to run install before any pnpm script that uses workspace
+tooling.
+
+# 05:15
+
+Phase 1 re-run after SC routed the CLAUDE.md leakage. Mission `## Changes`
+directive narrowed from `["dist", "*.md"]` to
+`["dist", "CHANGELOG.md", "README.md"]`. Updated each of the six publishable
+`package.json` files. LICENSE files unchanged from the earlier pass — they
+were correct from the start.
+
+Re-packed each of the six packages and verified per the corrected `## Verify`
+section:
+
+- All six tarballs contain `CHANGELOG.md`, `LICENSE`, `package.json`, and
+  the `dist/...` payload.
+- `README.md` present only in `apps/claude-cli` and `packages/claude-sdk`,
+  which are the only two packages that have one.
+- `CLAUDE.md` absent from every tarball.
+
+`pnpm pack` did not emit any warning for the four packages that lack a
+`README.md` (`apps/claude-sdk-cli`, `packages/claude-core`,
+`packages/claude-sdk-tools`, `packages/mcp-exec`). The mission warned to
+expect one; pnpm 10.33.2 silently skips the missing file with no message at
+all. Either behaviour produces the same correct tarball.
+
+No rebuild needed — `dist/` was untouched between the two passes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/claude-cli/LICENSE
+++ b/apps/claude-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/claude-cli/package.json
+++ b/apps/claude-cli/package.json
@@ -25,7 +25,9 @@
     "claude-cli": "dist/main.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "scripts": {
     "dev": "node --inspect --import tsx src/main.ts",

--- a/apps/claude-sdk-cli/LICENSE
+++ b/apps/claude-sdk-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -24,7 +24,9 @@
     "claude-sdk-cli": "dist/main.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "type": "module",
   "scripts": {

--- a/packages/claude-core/LICENSE
+++ b/packages/claude-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/claude-core/package.json
+++ b/packages/claude-core/package.json
@@ -30,7 +30,9 @@
   "keywords": [],
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "exports": {
     "./*": {

--- a/packages/claude-sdk-tools/LICENSE
+++ b/packages/claude-sdk-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/claude-sdk-tools/package.json
+++ b/packages/claude-sdk-tools/package.json
@@ -20,7 +20,9 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "type": "module",
   "exports": {

--- a/packages/claude-sdk/LICENSE
+++ b/packages/claude-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -20,7 +20,9 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "type": "module",
   "exports": {

--- a/packages/mcp-exec/LICENSE
+++ b/packages/mcp-exec/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -27,7 +27,9 @@
     "mcp-exec": "./dist/esm/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "contributors": [
     "BananaBot9000 <bananabot9000@bananabot.dev>",


### PR DESCRIPTION
## Summary

- Add MIT LICENSE to repo root and all six publishable packages
- Extend each package's files field to include CHANGELOG.md and README.md
- Use explicit filenames rather than a glob to keep contributor CLAUDE.md off npm