### PR TITLE
Bump claude-sdk-cli to 1.0.0-beta.8

### DIFF
--- a/.claude/testament/2026-06-05.md
+++ b/.claude/testament/2026-06-05.md
@@ -1,17 +1,19 @@
-# 02:58
+# 03:59
 
-Release Maker for beta.8. Bumped `claude-sdk-cli` from `1.0.0-beta.7` to `1.0.0-beta.8`, regenerated the changelog.
+Courier for beta.8 release. Branch `feature/version-beta8` pushed and PR opened.
 
-## What changed
+## What shipped in beta.8
 
-Only `apps/claude-sdk-cli/package.json` and `apps/claude-sdk-cli/CHANGELOG.md`. No lock file change. The changelog regeneration picked up the final items from PR #331 (launch flag extensions): `--resume`, multi-`--file`, `--prompt` escape decoding, unknown flag rejection, model `*` suffix, and model name/version split. All under `[Unreleased]` as expected.
+Only `apps/claude-sdk-cli/package.json` and `apps/claude-sdk-cli/CHANGELOG.md` changed vs `claude-sdk-cli@1.0.0-beta.7`. No lock file change. Source changes since beta.7 came from PR #331 (launch flag extensions): `--resume <id>`, multiple `--file` flags, `\n`/`\t` escape decoding in `--prompt`, unknown flag rejection, model `*` suffix in status bar, and model name/version split.
 
-## Worktree node_modules
+## Worktree bootstrap (always needed)
 
-The release-beta8 worktree had no `node_modules`. The mission's verify step (`pnpm build` etc.) failed because turbo and tsup were not on PATH. Fixed by running `pnpm install` in the worktree root -- pnpm pulled everything from the shared global store in ~1s. Subsequent build, type-check, test, and `pnpm run ci` all passed cleanly.
+This worktree ships without `node_modules`. Run `pnpm install` in the worktree root before any build or verify step -- pnpm pulls from the global store in ~1s.
 
-Note: `pnpm exec tsx` from the `scripts/` directory also fails in this worktree (pnpm recursive exec can't find tsx because scripts has no local node_modules). Used the scripts/node_modules/.bin/tsx from the main worktree directly as a workaround.
+`pnpm exec tsx` from `scripts/` also fails (scripts has no local node_modules in this worktree). Workaround: run `scripts/node_modules/.bin/tsx` from the main worktree at `~/repos/@shellicar/claude-cli/`.
 
-## Trap confirmed from beta.7 testament
+`pnpm run ci` is the biome check. `pnpm ci` is not the same thing.
 
-`pnpm ci` is not the biome check -- `pnpm run ci` is. Applied correctly.
+## Phase 3 objective
+
+Create the GitHub release for `claude-sdk-cli@1.0.0-beta.8`, then verify trusted publishing (OIDC). The `npm_token` secret is still present as a fallback, so a successful publish alone does not prove OIDC was used. The evidence is in the Publish step of the `npm-publish.yml` workflow run -- specifically whether provenance was attached. Provenance is the signal that OIDC carried it, not the token.

--- a/.claude/testament/2026-06-05.md
+++ b/.claude/testament/2026-06-05.md
@@ -1,0 +1,17 @@
+# 02:58
+
+Release Maker for beta.8. Bumped `claude-sdk-cli` from `1.0.0-beta.7` to `1.0.0-beta.8`, regenerated the changelog.
+
+## What changed
+
+Only `apps/claude-sdk-cli/package.json` and `apps/claude-sdk-cli/CHANGELOG.md`. No lock file change. The changelog regeneration picked up the final items from PR #331 (launch flag extensions): `--resume`, multi-`--file`, `--prompt` escape decoding, unknown flag rejection, model `*` suffix, and model name/version split. All under `[Unreleased]` as expected.
+
+## Worktree node_modules
+
+The release-beta8 worktree had no `node_modules`. The mission's verify step (`pnpm build` etc.) failed because turbo and tsup were not on PATH. Fixed by running `pnpm install` in the worktree root -- pnpm pulled everything from the shared global store in ~1s. Subsequent build, type-check, test, and `pnpm run ci` all passed cleanly.
+
+Note: `pnpm exec tsx` from the `scripts/` directory also fails in this worktree (pnpm recursive exec can't find tsx because scripts has no local node_modules). Used the scripts/node_modules/.bin/tsx from the main worktree directly as a workaround.
+
+## Trap confirmed from beta.7 testament
+
+`pnpm ci` is not the biome check -- `pnpm run ci` is. Applied correctly.

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add --model flag: launch-time model override
 - Add --prompt flag: send an initial message at launch
 - Add --no-resume flag: skip auto-resume of the latest session for the cwd
+- Show conversation id in status bar, controlled by statusBar.showConversationId config (default true)
+- Add --resume <conversationId> flag to resume a specific conversation by UUID
+- Allow --file to be specified multiple times; files attach in argument order
+- Decode escape sequences in --prompt values: \n, \r, \t, \\
+- Mark model with * suffix in status bar when overridden via --model
 
 ### Changed
 
@@ -38,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update runtime and build dependencies
 - List --file in --help output
 - Updated patch dependencies
+- Split model identifier into name and version for separate use
+- Show model version alongside model name in the status bar
 - Updated patch and minor dependencies
 
 ### Fixed
@@ -57,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix divider width calculation for emoji labels
 - Fix garbled cursor rendering on emoji characters
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion
+- Reject unknown flags at launch instead of silently ignoring them
 
 ### Security
 

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump claude-sdk-cli from 1.0.0-beta.7 to 1.0.0-beta.8