### PR TITLE
Add Claude Opus 4.8 pricing and fix Sonnet 4 context window

### DIFF
--- a/.claude/testament/2026-06-05.md
+++ b/.claude/testament/2026-06-05.md
@@ -17,3 +17,37 @@ This worktree ships without `node_modules`. Run `pnpm install` in the worktree r
 ## Phase 3 objective
 
 Create the GitHub release for `claude-sdk-cli@1.0.0-beta.8`, then verify trusted publishing (OIDC). The `npm_token` secret is still present as a fallback, so a successful publish alone does not prove OIDC was used. The evidence is in the Publish step of the `npm-publish.yml` workflow run -- specifically whether provenance was attached. Provenance is the signal that OIDC carried it, not the token.
+
+# 23:28
+
+Maker for opus-4-8 pricing and context-window support.
+
+## What changed
+
+`packages/claude-sdk/src/private/pricing.ts`:
+- Added `claude-opus-4-8` to PRICING (same rates as opus-4-7: $5/$25 per million)
+- Added `claude-opus-4-8: 1_000_000` to CONTEXT_WINDOW
+- Corrected `claude-sonnet-4` in CONTEXT_WINDOW from 200k to 1M (authoritative value)
+- Updated `getContextWindow` fallback: added `getFamilyDefault()` — unrecognised `claude-opus-*` and `claude-sonnet-*` ids resolve to 1M, everything else to 200k
+
+`packages/claude-sdk/test/pricing.spec.ts` (new file):
+- 8 tests covering `getContextWindow` behaviour
+- Pinned models, family fallback for opus/sonnet/haiku, and precedence guards (pinned 200k beats family fallback)
+
+## What to know
+
+The new `getFamilyDefault` makes `claude-opus-4-5` and `claude-opus-4-1` resolve to 1M via fallback, even though they are authoritatively 200k. The mission listed them as 200k but did not instruct adding explicit pins for them, and said the fallback is "forward-looking". This is a known gap left by the mission scope.
+
+The worktree bootstrap note from earlier today still applies: `pnpm install` needed before any build step.
+
+# 00:12
+
+Phase 1 recast — added 200k pins for opus-4-5 and opus-4-1.
+
+The first cast was blocked: the new family fallback (`^claude-(opus|sonnet)-` → 1M) would have lifted `claude-opus-4-5` and `claude-opus-4-1` to 1M, both of which are authoritatively 200k. They were hitting the old flat-200k fallback correctly before the change.
+
+Two pins added to `CONTEXT_WINDOW`:
+- `claude-opus-4-5: 200_000`
+- `claude-opus-4-1: 200_000`
+
+Two precedence guard tests added to `pricing.spec.ts`. Total is now 10 tests in pricing.spec.ts, 164 in the suite.

--- a/.claude/testament/2026-06-05.md
+++ b/.claude/testament/2026-06-05.md
@@ -1,53 +1,40 @@
-# 03:59
+# 01:51
 
-Courier for beta.8 release. Branch `feature/version-beta8` pushed and PR opened.
+Courier for opus-4-8 pricing and context-window support.
 
-## What shipped in beta.8
-
-Only `apps/claude-sdk-cli/package.json` and `apps/claude-sdk-cli/CHANGELOG.md` changed vs `claude-sdk-cli@1.0.0-beta.7`. No lock file change. Source changes since beta.7 came from PR #331 (launch flag extensions): `--resume <id>`, multiple `--file` flags, `\n`/`\t` escape decoding in `--prompt`, unknown flag rejection, model `*` suffix in status bar, and model name/version split.
-
-## Worktree bootstrap (always needed)
-
-This worktree ships without `node_modules`. Run `pnpm install` in the worktree root before any build or verify step -- pnpm pulls from the global store in ~1s.
-
-`pnpm exec tsx` from `scripts/` also fails (scripts has no local node_modules in this worktree). Workaround: run `scripts/node_modules/.bin/tsx` from the main worktree at `~/repos/@shellicar/claude-cli/`.
-
-`pnpm run ci` is the biome check. `pnpm ci` is not the same thing.
-
-## Phase 3 objective
-
-Create the GitHub release for `claude-sdk-cli@1.0.0-beta.8`, then verify trusted publishing (OIDC). The `npm_token` secret is still present as a fallback, so a successful publish alone does not prove OIDC was used. The evidence is in the Publish step of the `npm-publish.yml` workflow run -- specifically whether provenance was attached. Provenance is the signal that OIDC carried it, not the token.
-
-# 23:28
-
-Maker for opus-4-8 pricing and context-window support.
-
-## What changed
+## What shipped
 
 `packages/claude-sdk/src/private/pricing.ts`:
-- Added `claude-opus-4-8` to PRICING (same rates as opus-4-7: $5/$25 per million)
+- Added `claude-opus-4-8` to PRICING at opus-4-7 rates ($5/$25 per million input/output)
 - Added `claude-opus-4-8: 1_000_000` to CONTEXT_WINDOW
-- Corrected `claude-sonnet-4` in CONTEXT_WINDOW from 200k to 1M (authoritative value)
-- Updated `getContextWindow` fallback: added `getFamilyDefault()` — unrecognised `claude-opus-*` and `claude-sonnet-*` ids resolve to 1M, everything else to 200k
+- Corrected `claude-sonnet-4` in CONTEXT_WINDOW from 200k to 1M
+- Added `claude-opus-4-5: 200_000` and `claude-opus-4-1: 200_000` explicit pins (see trap below)
+- Updated `getContextWindow` fallback via `getFamilyDefault()`: `^claude-(opus|sonnet)-` → 1M, everything else → 200k
 
-`packages/claude-sdk/test/pricing.spec.ts` (new file):
-- 8 tests covering `getContextWindow` behaviour
-- Pinned models, family fallback for opus/sonnet/haiku, and precedence guards (pinned 200k beats family fallback)
+`packages/claude-sdk/test/pricing.spec.ts` (new):
+- 10 tests covering `getContextWindow` behaviour
+- Pinned models, family fallback for opus/sonnet/haiku, and precedence guards proving the map is checked before fallback
 
-## What to know
+## The trap: opus-4-5 and opus-4-1 needed explicit 200k pins
 
-The new `getFamilyDefault` makes `claude-opus-4-5` and `claude-opus-4-1` resolve to 1M via fallback, even though they are authoritatively 200k. The mission listed them as 200k but did not instruct adding explicit pins for them, and said the fallback is "forward-looking". This is a known gap left by the mission scope.
+The new `getFamilyDefault` (`^claude-(opus|sonnet)-` → 1M) captures any unrecognised opus or sonnet id. `claude-opus-4-5` and `claude-opus-4-1` are authoritatively 200k but were not pinned before this change -- they were hitting the old flat-200k fallback correctly. With the new family rule, they would have resolved to 1M.
 
-The worktree bootstrap note from earlier today still applies: `pnpm install` needed before any build step.
+The fix is two explicit pins. The SC made this call after the Maker was blocked on the first cast. The precedence-guard tests in `pricing.spec.ts` cover both.
 
-# 00:12
+If you add a future model to the family fallback, check whether it should be 200k -- the pattern is `claude-opus-4-X` where X is a specific version number, not a suffix family marker.
 
-Phase 1 recast — added 200k pins for opus-4-5 and opus-4-1.
+## Authoritative context window reference
 
-The first cast was blocked: the new family fallback (`^claude-(opus|sonnet)-` → 1M) would have lifted `claude-opus-4-5` and `claude-opus-4-1` to 1M, both of which are authoritatively 200k. They were hitting the old flat-200k fallback correctly before the change.
+From the Anthropic models endpoint at the time of this change:
+- 1M: opus-4-8, opus-4-7, opus-4-6, sonnet-4-6, sonnet-4-5, sonnet-4
+- 200k: opus-4-5, opus-4-1, opus-4, haiku-4-5
 
-Two pins added to `CONTEXT_WINDOW`:
-- `claude-opus-4-5: 200_000`
-- `claude-opus-4-1: 200_000`
+## Worktree bootstrap
 
-Two precedence guard tests added to `pricing.spec.ts`. Total is now 10 tests in pricing.spec.ts, 164 in the suite.
+This worktree ships without `node_modules`. Run `pnpm install` before any build or test step.
+
+`pnpm exec tsx` from `scripts/` fails. Use `scripts/node_modules/.bin/tsx` from the main worktree at `~/repos/@shellicar/claude-cli/` instead.
+
+## Branch state at handoff
+
+Branch `feature/opus-4-8-support` has one commit beyond the branch point (`61d4fb6`). Since branching, PR #334 ("Retry transient API errors with exponential backoff") merged to main -- `origin/main` is now at `ceb37b9`. The changes are in entirely different files (backoff.ts, TurnRunner.ts) with no conflict with pricing.ts/pricing.spec.ts.

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -23,3 +23,5 @@
 {"description":"Update runtime and build dependencies","category":"changed"}
 {"description":"Updated patch dependencies","category":"changed"}
 {"description":"Updated patch and minor dependencies","category":"changed"}
+{"description":"Add support for Claude Opus 4.8","category":"added"}
+{"description":"Fix context window size for Sonnet 4 (200k to 1M)","category":"fixed"}

--- a/packages/claude-sdk/src/private/pricing.ts
+++ b/packages/claude-sdk/src/private/pricing.ts
@@ -11,6 +11,7 @@ type ModelRates = {
 const M = 1_000_000;
 
 const PRICING: Record<string, ModelRates> = {
+  'claude-opus-4-8': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-7': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-6': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
   'claude-opus-4-5': { input: 5 / M, cacheWrite5m: 6.25 / M, cacheWrite1h: 10 / M, cacheRead: 0.5 / M, output: 25 / M },
@@ -27,11 +28,14 @@ const PRICING: Record<string, ModelRates> = {
 };
 
 const CONTEXT_WINDOW: Record<string, number> = {
+  'claude-opus-4-8': 1_000_000,
   'claude-opus-4-7': 1_000_000,
   'claude-opus-4-6': 1_000_000,
   'claude-sonnet-4-6': 1_000_000,
   'claude-opus-4': 200_000,
-  'claude-sonnet-4': 200_000,
+  'claude-opus-4-5': 200_000,
+  'claude-opus-4-1': 200_000,
+  'claude-sonnet-4': 1_000_000,
   'claude-haiku-4-5': 200_000,
   'claude-haiku-3-5': 200_000,
   'claude-sonnet-3-7': 200_000,
@@ -40,7 +44,11 @@ const CONTEXT_WINDOW: Record<string, number> = {
 };
 
 export function getContextWindow(modelId: string): number {
-  return CONTEXT_WINDOW[modelId] ?? CONTEXT_WINDOW[stripDateSuffix(modelId)] ?? 200_000;
+  return CONTEXT_WINDOW[modelId] ?? CONTEXT_WINDOW[stripDateSuffix(modelId)] ?? getFamilyDefault(modelId);
+}
+
+function getFamilyDefault(modelId: string): number {
+  return /^claude-(opus|sonnet)-/.test(modelId) ? 1_000_000 : 200_000;
 }
 
 function stripDateSuffix(modelId: string): string {

--- a/packages/claude-sdk/test/pricing.spec.ts
+++ b/packages/claude-sdk/test/pricing.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { getContextWindow } from '../src/private/pricing.js';
+
+// ---------------------------------------------------------------------------
+// getContextWindow
+// ---------------------------------------------------------------------------
+
+describe('getContextWindow', () => {
+  describe('pinned 1M models', () => {
+    it('returns 1_000_000 for claude-opus-4-8 (pinned)', () => {
+      const expected = 1_000_000;
+
+      const actual = getContextWindow('claude-opus-4-8');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 1_000_000 for claude-sonnet-4-6 (pinned)', () => {
+      const expected = 1_000_000;
+
+      const actual = getContextWindow('claude-sonnet-4-6');
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('family fallback — opus and sonnet resolve to 1M', () => {
+    it('returns 1_000_000 for claude-opus-4-9 (unmapped opus)', () => {
+      const expected = 1_000_000;
+
+      const actual = getContextWindow('claude-opus-4-9');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 1_000_000 for claude-sonnet-4-7 (unmapped sonnet)', () => {
+      const expected = 1_000_000;
+
+      const actual = getContextWindow('claude-sonnet-4-7');
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('family fallback — haiku resolves to 200k', () => {
+    it('returns 200_000 for claude-haiku-4-5 (pinned)', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-haiku-4-5');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 200_000 for claude-haiku-4-6 (unmapped haiku)', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-haiku-4-6');
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('pinned 200k models beat family fallback', () => {
+    it('returns 200_000 for claude-opus-4 despite opus family default', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-opus-4');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 200_000 for claude-opus-4-5 despite opus family default', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-opus-4-5');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 200_000 for claude-opus-4-1 despite opus family default', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-opus-4-1');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('returns 200_000 for claude-sonnet-3-7 despite sonnet family default', () => {
+      const expected = 200_000;
+
+      const actual = getContextWindow('claude-sonnet-3-7');
+
+      expect(actual).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` to pricing table at Opus 4.7 rates
- Pin `claude-opus-4-8` context window to 1M
- Correct `claude-sonnet-4` context window from 200k to 1M
- Add family fallback so future Opus/Sonnet models default to 1M