### PR TITLE
Retry internal server errors with backoff

### DIFF
--- a/.claude/testament/2026-06-15.md
+++ b/.claude/testament/2026-06-15.md
@@ -129,3 +129,30 @@ A correct gate existed for ~84 seconds on the original feature branch (`2c7ea94`
 ### Note for the next Courier
 
 Testaments are tracked and ship with the PR, and `.claude/testament/<date>.md` accumulates entries from every mission that lands on that date through the `union` merge driver in `.claude/testament/.gitattributes` (the esbuild and beta.9 entries above this one are other missions'). Consolidate your mission's phases into one entry; do not leave per-phase fragments scattered across the dated files.
+
+# 23:03 — Builder (Phase 1): retry on internal server error
+
+Mission: `api_error` (the API's type for 500-class internal server errors) was the one transient `APIError` type `isRetryable` did not retry. Added it.
+
+## What changed
+
+- `packages/claude-sdk/test/backoff.spec.ts` — one `it('returns true for api_error', …)` in the `isRetryable` block, mirroring the `overloaded_error`/`timeout_error` cases exactly (`makeApiError('api_error')`, single assertion).
+- `packages/claude-sdk/src/private/backoff.ts` — added `|| t === 'api_error'` to the retryable `APIError` type comparison. One more `||` term, nothing else.
+
+TDD order held: red first (`expected false to be true`, the right failure), then the one-term code change made it green.
+
+## Results
+
+- `pnpm --filter @shellicar/claude-sdk test` — 225 passed (11 files).
+- `pnpm --filter @shellicar/claude-sdk type-check` — clean. This also confirms `api_error` is a member of `ErrorType` from `@anthropic-ai/sdk/resources/shared.js`; the typed `makeApiError` helper would not compile otherwise.
+
+## Notes for the next operator
+
+- The comment above the retry line still reads "retry rate-limit and overload only". It was already stale before this change (it never mentioned `timeout_error`), so it is pre-existing, not introduced here. Left untouched — comment style is the Cleaner's job, not the Builder's.
+- No tests changed, only added. Implementation was correct against the new test without touching anything else.
+
+## Stage / commit
+
+Two files staged, not committed (Builder stages, supervisor commits). Suggested commit message:
+
+`Retry on internal server error`

--- a/.claude/testament/2026-06-15.md
+++ b/.claude/testament/2026-06-15.md
@@ -143,7 +143,3 @@ Testaments are tracked and ship with the PR, and `.claude/testament/<date>.md` a
 ## Trap worth keeping
 
 Match on `error.type === 'api_error'`, never on the `"Internal server error"` message string: the SDK surfaces `message` as a JSON-stringified payload, not that clean string, so a message match would silently never fire. `type-check` doubles as proof that `api_error` is a member of `ErrorType` from `@anthropic-ai/sdk/resources/shared.js` — the typed `makeApiError` helper would not compile otherwise.
-
-## Pre-existing, left alone
-
-The comment above the retry line reads "retry rate-limit and overload only". It was already stale before this change (it never mentioned `timeout_error` either), so it is pre-existing, not introduced here. Comment cleanup is the Cleaner's job.

--- a/.claude/testament/2026-06-15.md
+++ b/.claude/testament/2026-06-15.md
@@ -130,29 +130,20 @@ A correct gate existed for ~84 seconds on the original feature branch (`2c7ea94`
 
 Testaments are tracked and ship with the PR, and `.claude/testament/<date>.md` accumulates entries from every mission that lands on that date through the `union` merge driver in `.claude/testament/.gitattributes` (the esbuild and beta.9 entries above this one are other missions'). Consolidate your mission's phases into one entry; do not leave per-phase fragments scattered across the dated files.
 
-# 23:03 — Builder (Phase 1): retry on internal server error
+# Retry on internal server error (Builder + Courier)
 
-Mission: `api_error` (the API's type for 500-class internal server errors) was the one transient `APIError` type `isRetryable` did not retry. Added it.
+`api_error`, the API's type for 500-class internal server errors, was the one transient `APIError` type `isRetryable` did not retry. The API returns it when Claude is overloaded, so giving up abandoned a usually-transient failure. It is now retried with backoff like the other transient types.
 
-## What changed
+## The change
 
-- `packages/claude-sdk/test/backoff.spec.ts` — one `it('returns true for api_error', …)` in the `isRetryable` block, mirroring the `overloaded_error`/`timeout_error` cases exactly (`makeApiError('api_error')`, single assertion).
-- `packages/claude-sdk/src/private/backoff.ts` — added `|| t === 'api_error'` to the retryable `APIError` type comparison. One more `||` term, nothing else.
+- `packages/claude-sdk/src/private/backoff.ts` — `api_error` added to the retryable `APIError` types in `isRetryable`, beside `rate_limit_error`, `overloaded_error`, `timeout_error`. One more term in the existing `error.type` comparison.
+- `packages/claude-sdk/test/backoff.spec.ts` — one `it` asserting `isRetryable` returns `true` for `api_error`, mirroring the `overloaded_error` case. TDD red-first held.
+- `apps/claude-sdk-cli/changes.jsonl` — one entry, "Retry on internal server error" (added).
 
-TDD order held: red first (`expected false to be true`, the right failure), then the one-term code change made it green.
+## Trap worth keeping
 
-## Results
+Match on `error.type === 'api_error'`, never on the `"Internal server error"` message string: the SDK surfaces `message` as a JSON-stringified payload, not that clean string, so a message match would silently never fire. `type-check` doubles as proof that `api_error` is a member of `ErrorType` from `@anthropic-ai/sdk/resources/shared.js` — the typed `makeApiError` helper would not compile otherwise.
 
-- `pnpm --filter @shellicar/claude-sdk test` — 225 passed (11 files).
-- `pnpm --filter @shellicar/claude-sdk type-check` — clean. This also confirms `api_error` is a member of `ErrorType` from `@anthropic-ai/sdk/resources/shared.js`; the typed `makeApiError` helper would not compile otherwise.
+## Pre-existing, left alone
 
-## Notes for the next operator
-
-- The comment above the retry line still reads "retry rate-limit and overload only". It was already stale before this change (it never mentioned `timeout_error`), so it is pre-existing, not introduced here. Left untouched — comment style is the Cleaner's job, not the Builder's.
-- No tests changed, only added. Implementation was correct against the new test without touching anything else.
-
-## Stage / commit
-
-Two files staged, not committed (Builder stages, supervisor commits). Suggested commit message:
-
-`Retry on internal server error`
+The comment above the retry line reads "retry rate-limit and overload only". It was already stale before this change (it never mentioned `timeout_error` either), so it is pre-existing, not introduced here. Comment cleanup is the Cleaner's job.

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -66,3 +66,4 @@
 {"description":"Format 1M+ token counts with M suffix in the status bar","category":"added"}
 {"description":"Disable extended thinking correctly: send `thinking: {type: \"disabled\"}` and omit `output_config` when thinking is off","category":"fixed"}
 {"description":"Show the permissions notice only when displayed permissions change, not on every config edit","category":"fixed"}
+{"description":"Retry on internal server error","category":"added"}

--- a/packages/claude-sdk/src/private/backoff.ts
+++ b/packages/claude-sdk/src/private/backoff.ts
@@ -38,7 +38,7 @@ export function isRetryable(error: unknown): boolean {
     return true;
   }
 
-  // In-stream and HTTP-level typed errors: retry rate-limit and overload only.
+  // In-stream and HTTP-level typed errors: retry the transient ones; permanent client errors fall through.
   if (error instanceof APIError) {
     const t = error.type;
     return t === 'rate_limit_error' || t === 'overloaded_error' || t === 'timeout_error' || t === 'api_error';

--- a/packages/claude-sdk/src/private/backoff.ts
+++ b/packages/claude-sdk/src/private/backoff.ts
@@ -41,7 +41,7 @@ export function isRetryable(error: unknown): boolean {
   // In-stream and HTTP-level typed errors: retry rate-limit and overload only.
   if (error instanceof APIError) {
     const t = error.type;
-    return t === 'rate_limit_error' || t === 'overloaded_error' || t === 'timeout_error';
+    return t === 'rate_limit_error' || t === 'overloaded_error' || t === 'timeout_error' || t === 'api_error';
   }
 
   return false;

--- a/packages/claude-sdk/test/backoff.spec.ts
+++ b/packages/claude-sdk/test/backoff.spec.ts
@@ -101,6 +101,12 @@ describe('isRetryable', () => {
     expect(actual).toBe(expected);
   });
 
+  it('returns true for api_error', () => {
+    const expected = true;
+    const actual = isRetryable(makeApiError('api_error'));
+    expect(actual).toBe(expected);
+  });
+
   it('returns false for invalid_request_error', () => {
     const expected = false;
     const actual = isRetryable(makeApiError('invalid_request_error'));


### PR DESCRIPTION
## Summary

- Add `api_error` to the retryable error types so internal server errors retry with backoff like other transient failures
- Match on the API error `type`, never the message string
- Cover the new type with an `isRetryable` test
- Record the change in the CLI changelog