### PR TITLE
Remove latest dist-tag step that fails under OIDC publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -138,7 +138,3 @@ jobs:
           fi
           cd "${{ steps.package.outputs.dir }}"
           pnpm publish --provenance --ignore-scripts --no-git-checks --tag "${{ steps.dist-tag.outputs.channel }}" $DRY_RUN
-          if [ "${{ steps.dist-tag.outputs.setLatest }}" = "true" ] && [ "${{ steps.dist-tag.outputs.channel }}" != "latest" ] && [ -z "$DRY_RUN" ]; then
-            echo "Moving latest to ${{ steps.dist-tag.outputs.pkg }}@${{ steps.dist-tag.outputs.version }}"
-            npm dist-tag add "${{ steps.dist-tag.outputs.pkg }}@${{ steps.dist-tag.outputs.version }}" latest
-          fi


### PR DESCRIPTION
## Summary

- Drop the `npm dist-tag add ... latest` step from the publish workflow
- OIDC trusted publishing authenticates `pnpm publish` but not dist-tag changes, so the step failed with E401 and the run went red
- Pre-1.0 stays on the `@beta` channel and `latest` is no longer moved, so future beta releases publish clean end to end