### PR TITLE
Make the platform binary executable on install (npm only +x's bin targets)

### DIFF
--- a/platforms/claude-sdk-cli-darwin-arm64/package.json
+++ b/platforms/claude-sdk-cli-darwin-arm64/package.json
@@ -12,6 +12,9 @@
   "exports": {
     "./claude-sdk-cli": "./claude-sdk-cli"
   },
+  "bin": {
+    "claude-sdk-cli-darwin-arm64": "./claude-sdk-cli"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shellicar/claude-cli.git"


### PR DESCRIPTION
## Summary

Fixes the `EACCES` crash launching the installed CLI: the platform binary lands on disk as `0644` (no execute bit), so the launcher's `spawn` of it fails.

## Root cause

npm only sets the executable bit on files listed in a package's `bin` field. The platform package exposes its binary via `exports`, not `bin`, so npm masks it to `0644` on **install** (extract-time normalisation). The pipeline's "Restore executable bit" `chmod +x` runs before packing, but that mode doesn't survive npm's install-time mask. Build is green; the installed launch is broken — the green-proxy gap.

## Fix

Declare the binary in the platform package's `bin`:

```json
"bin": { "claude-sdk-cli-darwin-arm64": "./claude-sdk-cli" }
```

- npm now sets the binary to `0755` at install (its one real guarantee) — no runtime chmod, no install script.
- The name is suffixed so it doesn't collide with the main package's `claude-sdk-cli` bin.
- The launcher keeps resolving the binary via `exports`; this change only affects the mode npm writes on install.
- Cost: a harmless `.bin/claude-sdk-cli-darwin-arm64` symlink.

This is the idiomatic approach for binary-distribution packages — rely on npm's `bin` +x guarantee, not a runtime chmod in the launcher.

## Recommended follow-up (deliberately NOT in this PR)

A **pre-publish** acceptance gate, so this class of failure is caught before a version is burned (post-publish catches it only after publishing, and an unpublished npm version can never be reused):

- A job (`needs: build`) that `npm pack`s both the main and platform packages, installs the two tarballs **together** into a temp prefix (so the launcher's `optionalDependency` resolves to the local platform tarball, not the registry), then runs the installed launcher's `--verify` and requires exit `0`.
- `npm pack` + install applies the same `0644` mask as a registry install, so it reproduces this exact `EACCES` — and goes green once this fix lands.
- The fiddly part is getting the launcher's `optionalDependency` to resolve to the local tarball; that wants eyes on a real run, which is why it's described here rather than committed. An untested CI gate would be its own green proxy.

🍌 Authored by BananaBot9000.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
