### PR TITLE
Make the published macOS binary executable and bump to beta.12

### DIFF
--- a/.claude/testament/2026-06-22.md
+++ b/.claude/testament/2026-06-22.md
@@ -33,3 +33,44 @@ Non-obvious traps that are not visible in the code:
 - **macOS signing order is load-bearing:** strip-signature, then postject inject, then ad-hoc re-sign. Notarization is not needed (npm tar sets no quarantine xattr); if Gatekeeper ever blocks, that needs the SC's Apple cert, so stop and raise it.
 - The `node:sqlite` connection is **injected, not constructed** by the store (SC correction): `setup/container.ts` builds the path, mkdirs, news up `DatabaseSync`, injects it. Pragmas go through `.exec('PRAGMA ...')` (there is no `.pragma()` helper).
 - build-sea.sh writes the signed binary straight into `platforms/claude-sdk-cli-<platform>/` (platform derived from host, never hardcoded). A stale binary there is how a fixed source still crashed once.
+
+
+# 12:40 — beta.11 published but launch fails: platform binary lost its execute bit
+
+**Status.** `claude-sdk-cli@1.0.0-beta.11` is **live on npm** — workflow `27926045672` fully green (prepare, build, publish-platforms, publish-main), npm shows `beta` → `1.0.0-beta.11`, platform package published. Release `claude-sdk-cli@1.0.0-beta.11` created against merge commit `cc1ddd4` (#368), `--prerelease`, notes from `[Unreleased]`. The GitHub release and npm publish succeeded.
+
+**But the acceptance bar fails.** `npm i -g @shellicar/claude-sdk-cli@beta` installs, `--version` would pass, but launching fails:
+
+```
+claude-sdk-cli: failed to start binary: spawn .../claude-sdk-cli-darwin-arm64/claude-sdk-cli EACCES
+```
+
+This is exactly the gap the mission warned about — green proxy, broken launch. I stopped and surfaced; **I did not unpublish** (the mission's hard guard) and did not rerun.
+
+## Root cause (not a transient — needs a code/pipeline fix)
+
+The installed platform binary is mode `-rw-r--r--` — **no execute bit**. It is a valid 150MB `Mach-O 64-bit executable arm64` (the SEA built fine); it simply isn't executable on the consumer's disk, so the launcher's `spawn` gets `EACCES`.
+
+Why the bit is gone: **npm only sets the execute bit (0755) on files listed in a package's `bin` field.** Everything else is normalized to 0644 on install. The platform package (`platforms/claude-sdk-cli-darwin-arm64/package.json`) exposes the binary via `exports` (`"./claude-sdk-cli"`), **not** `bin` — so npm strips the execute bit on install, regardless of the mode at pack time. The `publish-platforms` job's "Restore executable bit" step sets the mode before packing, but that does not survive npm's install-time normalization.
+
+## Fix options for the SC (decision, not mine to make)
+
+The bit cannot be carried through npm for a non-`bin` file. So either:
+
+1. **Launcher chmod's the binary before spawn** — on first run, `fs.chmodSync(binPath, 0o755)` (or check-and-set) before `spawn`. Self-healing, no dependence on npm preserving the mode. This is the robust fix; the launcher already resolves the path.
+2. **Spawn through a runner** that doesn't need the x bit — weaker; the binary is a native Mach-O, not a script, so this doesn't really apply.
+
+Option 1 is the real fix. It is a source change to the launcher (`apps/claude-sdk-cli/bin/launcher.mjs` or wherever it spawns), outside this release phase — it needs a new PR, then a fresh version (beta.12, since beta.11 is now consumed and a republish of the same version is barred).
+
+## Do NOT
+
+- **Do not unpublish beta.11.** That is what killed beta.10 (npm bars republishing an unpublished `name@version`). Leave it live; dodge to beta.12 once the launcher fix lands.
+- Do not rerun the workflow — the publish succeeded; rerunning publishes nothing new and the bit problem is on the consumer side.
+
+## Verification trail
+
+- `github-release-info.sh apps/claude-sdk-cli`: clean tree, version beta.11, changelog found, main_sha cc1ddd4, existing_release null.
+- `gh run watch 27926045672`: all jobs success.
+- `github-release-status.sh`: workflow success, npm published true, latest beta = 1.0.0-beta.11.
+- `claude-sdk-cli --version` and `--verify`: both `EACCES` on spawn of the platform binary.
+- `ls -l` on the installed binary: `-rw-r--r--`, 150762416 bytes; `file`: Mach-O arm64 executable.

--- a/.claude/testament/2026-06-22.md
+++ b/.claude/testament/2026-06-22.md
@@ -1,76 +1,64 @@
-# beta.11 release: ready to cut (2026-06-22)
+# 19:29 — beta.12 release: fix in PR, awaiting merge
 
-**Status.** Both manifests at `1.0.0-beta.11`, committed on `feature/version-1.0.0-beta.11` (`284929b`). This PR is the bump. Once merged, Phase 3 re-runs to cut `claude-sdk-cli@1.0.0-beta.11` and publish the macOS SEA to npm. beta.10 is dead (see below); beta.11 is the live target.
+This file was rewritten at 19:29 because the earlier entries had a **wrong root cause** stated as fact (they blamed npm; the culprit is pnpm) and described beta.11 as the live target after it had already failed and been unpublished. The corrected, current account is below. If you are picking this up, read this top section — it supersedes everything the git history shows about beta.10/beta.11.
 
-## Why beta.11 (beta.10 is burned)
+## Where we are now
 
-beta.9 was published, so the SEA feature (#363) needed a fresh version to ship. beta.10 was bumped (#366) and the publish pipeline reworked (#367), but the beta.10 platform package was published then unpublished during a half-failed run, and **npm refuses to republish an unpublished `name@version`** (E400, the version is reserved-but-gone). So beta.10 cannot ship. beta.11 is the dodge: a pure version bump off `d10a828`, no source change, no `changes.jsonl` change (the existing `[Unreleased]` set carries forward, CHANGELOG regen is a no-op).
+- **Live target: `1.0.0-beta.12`.** beta.9, beta.10, and beta.11 are all dead on npm (history below).
+- **PR #370** (`feature/version-1.0.0-beta.12`) is **open, all checks green, awaiting merge.** It carries three commits: the beta.12 bump + the executable-bit fix (`453ce17`), the dead-`setLatest` dist-tag cleanup (`7b1fe9b`), and an empty trigger commit (see the CI gotcha below).
+- **After it merges:** re-cut the release — `gh release create claude-sdk-cli@1.0.0-beta.12 --target <new-main-sha> --prerelease --notes-file <notes>` (notes from `apps/claude-sdk-cli/CHANGELOG.md` `[Unreleased]`). That fires `npm-publish.yml`.
+- **The acceptance bar (this is the whole point):** `npm i -g @shellicar/claude-sdk-cli@beta`, then confirm the **full CLI launches**, not just `--version`. Green `--version` has masked a broken launch twice now.
 
-**The hard lesson: never unpublish a half-failed release.** That is what killed beta.10. The pipeline's decoupled build-then-publish design means a clean re-fire is the recovery, not unpublish. If a beta.11 run half-fails, re-fire; do not unpublish.
+## The execute-bit bug and the real fix (corrected root cause)
 
-## Cutting the beta.11 release (Phase 3, next)
+**Symptom:** beta.11 published and installed, but launching failed with `spawn .../claude-sdk-cli EACCES`. The installed platform binary was mode `-rw-r--r--` (0644) — a valid 150MB Mach-O arm64, just not executable.
 
-- Wait until this PR is **merged to main**. `publish-package`'s first step fails if the tag version does not equal the manifest version, so main must read `beta.11` first.
-- `gh release create claude-sdk-cli@1.0.0-beta.11 --target <new-main-sha> --prerelease --notes-file <notes>`. Notes come from `apps/claude-sdk-cli/CHANGELOG.md`'s `[Unreleased]` section. Tag is the monorepo short form, no `v`. Creating it fires `npm-publish.yml`.
-- Acceptance bar: `npm i -g @shellicar/claude-sdk-cli@beta`, then confirm the **full CLI launches**, not just `--version`. That gap (green `--version`, crashing launch) bit Phase 3's predecessor.
+**Root cause — it is pnpm, not npm.** Proven by experiment today (pack a fixture with a non-`bin` executable file):
 
-## The release pipeline (terrain)
+- `npm pack` **preserves** the execute bit (records mode 493 / 0755 in the tarball).
+- `pnpm pack` **strips** it to 0644 — *but only for files not referenced by `bin`*. A file listed in `bin` keeps its on-disk mode in the tarball.
 
-- One entrypoint: `.github/workflows/npm-publish.yml`, `on: release`, no tag filter. A `prepare` job parses the tag; the SEA path runs `build` (matrix, native macOS runner, builds and signs the binary, uploads as artifact, nothing to npm), then `publish-platforms`, then `publish-main` (ubuntu runners, pull artifact, publish at the end). **Build is decoupled from publish** (#367) so a failure cannot half-release. The platform package publishes before the launcher or its `optionalDependency` will not resolve.
-- OIDC trusted publishing, no token (`id-token: write`, `--provenance`). The npm-side trust for the platform package is established and proven (a 404 token-exchange on the first attempt was the SC's npm-side setup, now done). `workflow_dispatch` runs the same path with `--dry-run`.
-- `publish-package` has a **TEMPORARY skip-if-already-published guard**. Remove it once beta.11 is fully published. It only skips a *live* version; it does not save you from a reserved-but-unpublished one (that is the E400 that killed beta.10).
-- On a re-fire, the release run checks out the **tag's** commit. If you recreate the tag, `--target` the merge commit that contains the pipeline fix, or the old broken pipeline runs.
+The publish pipeline uses **`pnpm publish`**, so the platform binary (exposed via `exports`, not `bin`) got normalized to 0644 in the published tarball. The `Restore executable bit` chmod step in CI is real and works on the runner's disk, but pnpm discards that when it packs. The earlier testament's claim that "npm strips +x for non-`bin` files" is **wrong** — do not chmod the launcher chasing that theory.
+
+**The fix (shipped in PR #370):** add a `bin` entry to `platforms/claude-sdk-cli-darwin-arm64/package.json` with a **distinct name** so it does not clash with the launcher's own `claude-sdk-cli` bin:
+
+```json
+"bin": { "claude-sdk-cli-darwin-arm64": "./claude-sdk-cli" },
+"exports": { "./claude-sdk-cli": "./claude-sdk-cli" }
+```
+
+`exports` stays — the launcher still resolves and spawns the binary through it; the bin name is irrelevant to function and is never linked globally (the platform package is only ever a nested optional dependency). The `bin` entry exists purely to make pnpm preserve the execute bit in the tarball. The `Restore executable bit` chmod step must stay too — it puts the bit on disk before pack, and pnpm now carries that disk mode through because the file is a bin target.
+
+## The version graveyard (why beta.12)
+
+- **beta.9** — published, pre-SEA (old better-sqlite3 build). Still the current `@beta` fallback on npm.
+- **beta.10** — burned. Bumped (#366), pipeline reworked (#367), but its platform package was published then unpublished mid-failure, and **npm refuses to republish an unpublished `name@version`** (E400, reserved-but-gone). Cannot ship.
+- **beta.11** — burned. Published successfully (#368, tag `cc1ddd4`) but failed the launch bar (the EACCES above). The SC **deliberately unpublished it** (duty of care — a dead package should not sit installable on `@beta`) and repointed `@beta` to beta.9. beta.11 is now also reserved-but-gone.
+- **beta.12** — the dodge. The bin fix could not reuse beta.11, so we bumped to a fresh version.
+
+**The unpublish lesson (nuanced — the old "never unpublish" was too blunt).** Unpublishing makes `name@version` permanently un-republishable. That is catastrophic when you *still need to ship that version* — that is what killed beta.10. It is *acceptable* for a version you are abandoning anyway (beta.11, dead on arrival): you lose nothing you wanted, and you remove a broken package from `@beta`. So: never unpublish a version you still intend to ship; unpublishing a write-off you are dodging past is a judgment call, not a hard no.
+
+## Pipeline terrain (current, post-#370)
+
+- One entrypoint: `.github/workflows/npm-publish.yml`, `on: release`, no tag filter. `prepare` parses the tag; the SEA path runs `build` (matrix, native macOS runner — builds + signs the binary, uploads as artifact, nothing to npm), then `publish-platforms`, then `publish-main`. Build is decoupled from publish (#367) so a failure cannot half-release. Platform package publishes before the launcher or its `optionalDependency` will not resolve.
+- **`upload-artifact`/`download-artifact` strip the execute bit** (zip carries no Unix mode). That is why the `Restore executable bit` chmod step exists in `publish-platforms` — keep it.
+- OIDC trusted publishing, no token (`id-token: write`, `--provenance`). Publish lands on the `beta` dist-tag via `--tag`. **No separate `npm dist-tag` step** — that would need a classic token and fail E401 under OIDC. `latest` is left unmanaged pre-1.0.
+- **Removed in #370 (no longer present):** the TEMPORARY skip-if-already-published guard in `publish-package` (and its `PKG_NAME` line), and the entire `setLatest`/`current-latest` dist-tag machinery (`decide-dist-tags` now returns `{ channel }` only; `decide-cli` takes one arg). `decide` is the channel picker — pre-release `beta.N` → channel `beta`; it still guards reserved names and bad semver. Its test is `scripts/test/decide-dist-tags.spec.ts` (10 tests).
+- On a re-fire the release run checks out the **tag's** commit; `--target` the merge commit that has the fixes, or the old pipeline runs.
+
+## CI gotcha (cost us ~10 min today)
+
+A push to the PR branch sometimes does **not** create workflow runs — `pull_request: synchronize` event delivery is silently dropped (no error, empty `statusCheckRollup`). It is not a path filter (these workflows have none) and not the diff. Remedy: an empty commit, or close/reopen the PR, re-fires the event. The empty trigger commit on this branch is that workaround.
 
 ## Durable SEA/store legacy (merged; for future work)
 
 The CLI ships as a Single Executable Application. The store is builtin `node:sqlite` (no native addon), the binary bundles its own Node 26 runtime (ESM), published per-platform. This solved the `NODE_MODULE_VERSION` crash from the better-sqlite3 native addon (#359): the store runs on the bundled runtime, not the shell's fnm-pinned Node.
 
-Non-obvious traps that are not visible in the code:
+Non-obvious traps not visible in the code:
 
-- **Verify against the real boot path, not a proxy.** `--version` passing is not launch passing. Use `src/entry/verify.ts` (`--verify`: boots config, container, store, TS resolve; exit 0/2/1), which exercises the real path without a TTY.
-- **typescript cannot be bundled into the SEA blob** (dynamic resolve plus a spawned `tsserver.js` process). The launcher resolves it on the user's Node and passes the path via `CLAUDE_SDK_CLI_TSSERVER_PATH`; inside the SEA `import.meta.url` is virtual. Missing typescript degrades gracefully (TS tools gated out), it does not crash.
+- **Verify against the real boot path, not a proxy.** `--version` passing is not launch passing. `src/entry/verify.ts` (`--verify`: boots config, container, store, TS resolve; exit 0/2/1) exercises the real path without a TTY. (Note: `--verify` still spawns the platform binary, so it also hits EACCES if the execute bit is missing — it is a launch proxy, not a packaging-mode check.)
+- **typescript cannot be bundled into the SEA blob** (dynamic resolve plus a spawned `tsserver.js`). The launcher resolves it on the user's Node and passes the path via `CLAUDE_SDK_CLI_TSSERVER_PATH`; inside the SEA `import.meta.url` is virtual. Missing typescript degrades gracefully (TS tools gated out), it does not crash.
 - **ESM SEA needs Node 26+** and `"mainFormat": "module"` in `sea-config.json`. Node 24 silently runs the ESM entry as CJS and dies on `import`.
-- **macOS signing order is load-bearing:** strip-signature, then postject inject, then ad-hoc re-sign. Notarization is not needed (npm tar sets no quarantine xattr); if Gatekeeper ever blocks, that needs the SC's Apple cert, so stop and raise it.
-- The `node:sqlite` connection is **injected, not constructed** by the store (SC correction): `setup/container.ts` builds the path, mkdirs, news up `DatabaseSync`, injects it. Pragmas go through `.exec('PRAGMA ...')` (there is no `.pragma()` helper).
-- build-sea.sh writes the signed binary straight into `platforms/claude-sdk-cli-<platform>/` (platform derived from host, never hardcoded). A stale binary there is how a fixed source still crashed once.
-
-
-# 12:40 — beta.11 published but launch fails: platform binary lost its execute bit
-
-**Status.** `claude-sdk-cli@1.0.0-beta.11` is **live on npm** — workflow `27926045672` fully green (prepare, build, publish-platforms, publish-main), npm shows `beta` → `1.0.0-beta.11`, platform package published. Release `claude-sdk-cli@1.0.0-beta.11` created against merge commit `cc1ddd4` (#368), `--prerelease`, notes from `[Unreleased]`. The GitHub release and npm publish succeeded.
-
-**But the acceptance bar fails.** `npm i -g @shellicar/claude-sdk-cli@beta` installs, `--version` would pass, but launching fails:
-
-```
-claude-sdk-cli: failed to start binary: spawn .../claude-sdk-cli-darwin-arm64/claude-sdk-cli EACCES
-```
-
-This is exactly the gap the mission warned about — green proxy, broken launch. I stopped and surfaced; **I did not unpublish** (the mission's hard guard) and did not rerun.
-
-## Root cause (not a transient — needs a code/pipeline fix)
-
-The installed platform binary is mode `-rw-r--r--` — **no execute bit**. It is a valid 150MB `Mach-O 64-bit executable arm64` (the SEA built fine); it simply isn't executable on the consumer's disk, so the launcher's `spawn` gets `EACCES`.
-
-Why the bit is gone: **npm only sets the execute bit (0755) on files listed in a package's `bin` field.** Everything else is normalized to 0644 on install. The platform package (`platforms/claude-sdk-cli-darwin-arm64/package.json`) exposes the binary via `exports` (`"./claude-sdk-cli"`), **not** `bin` — so npm strips the execute bit on install, regardless of the mode at pack time. The `publish-platforms` job's "Restore executable bit" step sets the mode before packing, but that does not survive npm's install-time normalization.
-
-## Fix options for the SC (decision, not mine to make)
-
-The bit cannot be carried through npm for a non-`bin` file. So either:
-
-1. **Launcher chmod's the binary before spawn** — on first run, `fs.chmodSync(binPath, 0o755)` (or check-and-set) before `spawn`. Self-healing, no dependence on npm preserving the mode. This is the robust fix; the launcher already resolves the path.
-2. **Spawn through a runner** that doesn't need the x bit — weaker; the binary is a native Mach-O, not a script, so this doesn't really apply.
-
-Option 1 is the real fix. It is a source change to the launcher (`apps/claude-sdk-cli/bin/launcher.mjs` or wherever it spawns), outside this release phase — it needs a new PR, then a fresh version (beta.12, since beta.11 is now consumed and a republish of the same version is barred).
-
-## Do NOT
-
-- **Do not unpublish beta.11.** That is what killed beta.10 (npm bars republishing an unpublished `name@version`). Leave it live; dodge to beta.12 once the launcher fix lands.
-- Do not rerun the workflow — the publish succeeded; rerunning publishes nothing new and the bit problem is on the consumer side.
-
-## Verification trail
-
-- `github-release-info.sh apps/claude-sdk-cli`: clean tree, version beta.11, changelog found, main_sha cc1ddd4, existing_release null.
-- `gh run watch 27926045672`: all jobs success.
-- `github-release-status.sh`: workflow success, npm published true, latest beta = 1.0.0-beta.11.
-- `claude-sdk-cli --version` and `--verify`: both `EACCES` on spawn of the platform binary.
-- `ls -l` on the installed binary: `-rw-r--r--`, 150762416 bytes; `file`: Mach-O arm64 executable.
+- **macOS signing order is load-bearing:** strip-signature, then postject inject, then ad-hoc re-sign. Notarization is not needed (npm tar sets no quarantine xattr); if Gatekeeper ever blocks, that needs the SC's Apple cert — stop and raise it.
+- The `node:sqlite` connection is **injected, not constructed** by the store: `setup/container.ts` builds the path, mkdirs, news up `DatabaseSync`, injects it. Pragmas go through `.exec('PRAGMA ...')` (there is no `.pragma()` helper).
+- `build-sea.sh` writes the signed binary straight into `platforms/claude-sdk-cli-<platform>/` (platform derived from host, never hardcoded). A stale binary there is how a fixed source still crashed once.

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -31,16 +31,14 @@ runs:
     - name: Decide dist-tag
       id: dist-tag
       shell: bash
-      # current-latest is unused by publishing (only the channel/tag is applied),
-      # so it is passed empty rather than queried from the registry.
       # Capture stdout into a variable and write only the script's key=value lines
       # to $GITHUB_OUTPUT. On a runner where a platform optionalDependency does not
       # match (the launcher's darwin-arm64 dep on a linux runner), pnpm prints an
       # "Unsupported platform" WARN to stdout; piping pnpm's stdout straight into
       # $GITHUB_OUTPUT lets that line corrupt the output file and fail the step.
       run: |
-        OUTPUT=$(pnpm --filter scripts --silent exec tsx src/decide-cli.ts --package-dir "${{ inputs.package-dir }}" --current-latest "")
-        echo "$OUTPUT" | grep -E '^(version|channel|setLatest)=' >> "$GITHUB_OUTPUT"
+        OUTPUT=$(pnpm --filter scripts --silent exec tsx src/decide-cli.ts --package-dir "${{ inputs.package-dir }}")
+        echo "$OUTPUT" | grep -E '^(version|channel)=' >> "$GITHUB_OUTPUT"
 
     - name: Publish
       shell: bash
@@ -51,10 +49,5 @@ runs:
           echo "⚠️ Dry run: workflow_dispatch trigger"
         fi
         cd "${{ inputs.package-dir }}"
-        # TEMPORARY (remove once beta.10 is fully published): skip if this exact
-        # version is already on npm. Lets a re-fired beta.10 release finish the
-        # launcher publish without the platform package — already live from the
-        # earlier partial run — failing on an un-republishable version.
-        PKG_NAME=$(node -p "require('./package.json').name")
         echo "Publishing ${{ inputs.package-dir }} with tag: ${{ steps.dist-tag.outputs.channel }}"
         pnpm publish --provenance --ignore-scripts --no-git-checks --tag "${{ steps.dist-tag.outputs.channel }}" $DRY_RUN

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",

--- a/platforms/claude-sdk-cli-darwin-arm64/package.json
+++ b/platforms/claude-sdk-cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli-darwin-arm64",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "private": false,
   "description": "macOS arm64 prebuilt binary for @shellicar/claude-sdk-cli",
   "license": "MIT",
@@ -9,6 +9,9 @@
     "BananaBot9000 <bananabot9000@bananabot.dev>",
     "Claude (Anthropic) <noreply@anthropic.com>"
   ],
+  "bin": {
+    "claude-sdk-cli-darwin-arm64": "./claude-sdk-cli"
+  },
   "exports": {
     "./claude-sdk-cli": "./claude-sdk-cli"
   },

--- a/scripts/src/decide-cli.ts
+++ b/scripts/src/decide-cli.ts
@@ -8,10 +8,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const args = process.argv.slice(2);
 const packageDirIdx = args.indexOf('--package-dir');
-const currentLatestIdx = args.indexOf('--current-latest');
 
 const packageDir = packageDirIdx >= 0 ? args[packageDirIdx + 1] : undefined;
-const currentLatestArg = currentLatestIdx >= 0 ? args[currentLatestIdx + 1] : undefined;
 
 if (!packageDir) {
   process.stderr.write('--package-dir is required\n');
@@ -22,11 +20,10 @@ const packageJson = JSON.parse(readFileSync(resolve(repoRoot, packageDir, 'packa
   version: string;
 };
 const version = packageJson.version;
-const currentLatest = currentLatestArg || null;
 
 try {
-  const result = decide(version, currentLatest);
-  process.stdout.write(`version=${version}\nchannel=${result.channel}\nsetLatest=${result.setLatest}\n`);
+  const result = decide(version);
+  process.stdout.write(`version=${version}\nchannel=${result.channel}\n`);
 } catch (err) {
   process.stderr.write((err instanceof Error ? err.message : String(err)) + '\n');
   process.exit(1);

--- a/scripts/src/decide-dist-tags.ts
+++ b/scripts/src/decide-dist-tags.ts
@@ -2,10 +2,9 @@ import semver from 'semver';
 
 export type Decision = {
   channel: string;
-  setLatest: boolean;
 };
 
-export const decide = (newVersion: string, currentLatest: string | null): Decision => {
+export const decide = (newVersion: string): Decision => {
   const parsed = semver.parse(newVersion);
   if (!parsed) {
     throw new Error(`Invalid semver: ${newVersion}`);
@@ -34,7 +33,5 @@ export const decide = (newVersion: string, currentLatest: string | null): Decisi
     channel = name;
   }
 
-  const setLatest = currentLatest === null || semver.gt(newVersion, currentLatest) === true;
-
-  return { channel, setLatest };
+  return { channel };
 };

--- a/scripts/test/decide-dist-tags.spec.ts
+++ b/scripts/test/decide-dist-tags.spec.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { decide } from '../src/decide-dist-tags.js';
 
 // ---------------------------------------------------------------------------
-// first publish (no current latest)
+// first publish
 // ---------------------------------------------------------------------------
 
-describe('decide — first publish (no current latest)', () => {
+describe('decide — first publish', () => {
   it('stable first publish returns channel latest', () => {
     const expected = { channel: 'latest' };
 

--- a/scripts/test/decide-dist-tags.spec.ts
+++ b/scripts/test/decide-dist-tags.spec.ts
@@ -6,86 +6,20 @@ import { decide } from '../src/decide-dist-tags.js';
 // ---------------------------------------------------------------------------
 
 describe('decide — first publish (no current latest)', () => {
-  it('stable first publish returns channel latest and setLatest true', () => {
-    const expected = { channel: 'latest', setLatest: true };
+  it('stable first publish returns channel latest', () => {
+    const expected = { channel: 'latest' };
 
-    const actual = decide('1.0.0', null);
-
-    expect(actual).toEqual(expected);
-  });
-
-  it('pre-release first publish returns pre-release channel and setLatest true', () => {
-    const expected = { channel: 'beta', setLatest: true };
-
-    const actual = decide('1.0.0-beta.1', null);
+    const actual = decide('1.0.0');
 
     expect(actual).toEqual(expected);
   });
-});
 
-// ---------------------------------------------------------------------------
-// latest decision — both stable
-// ---------------------------------------------------------------------------
+  it('pre-release first publish returns pre-release channel', () => {
+    const expected = { channel: 'beta' };
 
-describe('decide — latest decision, both stable', () => {
-  it('new higher stable version sets setLatest to true', () => {
-    const expected = true;
+    const actual = decide('1.0.0-beta.1');
 
-    const actual = decide('1.1.0', '1.0.0').setLatest;
-
-    expect(actual).toBe(expected);
-  });
-
-  it('new lower stable version sets setLatest to false', () => {
-    const expected = false;
-
-    const actual = decide('1.0.0', '1.1.0').setLatest;
-
-    expect(actual).toBe(expected);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// latest decision — both pre-release
-// ---------------------------------------------------------------------------
-
-describe('decide — latest decision, both pre-release', () => {
-  it('new higher pre-release sets setLatest to true', () => {
-    const expected = true;
-
-    const actual = decide('1.0.0-beta.7', '1.0.0-beta.1').setLatest;
-
-    expect(actual).toBe(expected);
-  });
-
-  it('new lower pre-release sets setLatest to false', () => {
-    const expected = false;
-
-    const actual = decide('1.0.0-beta.1', '1.0.0-beta.7').setLatest;
-
-    expect(actual).toBe(expected);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// latest decision — mixed
-// ---------------------------------------------------------------------------
-
-describe('decide — latest decision, mixed', () => {
-  it('new stable beats current pre-release, setLatest is true', () => {
-    const expected = true;
-
-    const actual = decide('1.0.0', '1.0.0-beta.1').setLatest;
-
-    expect(actual).toBe(expected);
-  });
-
-  it('new pre-release does not displace current stable, setLatest is false', () => {
-    const expected = false;
-
-    const actual = decide('1.0.0-beta.1', '1.0.0').setLatest;
-
-    expect(actual).toBe(expected);
+    expect(actual).toEqual(expected);
   });
 });
 
@@ -97,7 +31,7 @@ describe('decide — channel extraction', () => {
   it('known channel name extracted from pre-release identifier', () => {
     const expected = 'beta';
 
-    const actual = decide('1.0.0-beta.7', null).channel;
+    const actual = decide('1.0.0-beta.7').channel;
 
     expect(actual).toBe(expected);
   });
@@ -105,7 +39,7 @@ describe('decide — channel extraction', () => {
   it('arbitrary channel name passes through unchanged', () => {
     const expected = 'whizzbang';
 
-    const actual = decide('1.0.0-whizzbang.5', null).channel;
+    const actual = decide('1.0.0-whizzbang.5').channel;
 
     expect(actual).toBe(expected);
   });
@@ -117,37 +51,37 @@ describe('decide — channel extraction', () => {
 
 describe('decide — rejections', () => {
   it('multi-segment pre-release identifier throws', () => {
-    const actual = () => decide('1.0.0-rc.foo.5', null);
+    const actual = () => decide('1.0.0-rc.foo.5');
 
     expect(actual).toThrow();
   });
 
   it('numeric-only first identifier throws', () => {
-    const actual = () => decide('1.0.0-0', null);
+    const actual = () => decide('1.0.0-0');
 
     expect(actual).toThrow();
   });
 
   it('pre-release missing dot-number suffix throws', () => {
-    const actual = () => decide('1.0.0-beta', null);
+    const actual = () => decide('1.0.0-beta');
 
     expect(actual).toThrow();
   });
 
   it('non-numeric second identifier throws', () => {
-    const actual = () => decide('1.0.0-beta.foo', null);
+    const actual = () => decide('1.0.0-beta.foo');
 
     expect(actual).toThrow();
   });
 
   it('reserved channel name throws', () => {
-    const actual = () => decide('1.0.0-latest.5', null);
+    const actual = () => decide('1.0.0-latest.5');
 
     expect(actual).toThrow();
   });
 
   it('invalid semver throws', () => {
-    const actual = () => decide('not-a-version', null);
+    const actual = () => decide('not-a-version');
 
     expect(actual).toThrow();
   });


### PR DESCRIPTION
## Summary

- Add a bin entry to the macOS platform package so pnpm preserves the binary's execute bit when publishing
- Without it the published binary installs as 0644 and the launcher fails to spawn it (EACCES), so the CLI never starts
- Bump @shellicar/claude-sdk-cli and its darwin-arm64 platform package to 1.0.0-beta.12 to ship the fix (beta.11 is consumed and cannot be republished)