### PR TITLE
Fix Dependabot pnpm-workspace config: root directory + patch-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/apps/*"
-      - "/packages/*"
-      - "/scripts"
+    directory: "/"
     schedule:
       interval: "weekly"
     versioning-strategy: increase
@@ -15,4 +11,4 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## Why

Our Dependabot npm config lists subdirectories (`/apps/*`, `/packages/*`, `/scripts`) alongside `/`. In a pnpm workspace the lockfile is shared and lives only at the repo root, so a subdirectory-anchored update's scope is that folder — Dependabot updates the member `package.json` but **not** the root `pnpm-lock.yaml`, leaving manifest and lockfile inconsistent. Those PRs fail `pnpm install --frozen-lockfile` (CI sets `CI=true`, which makes pnpm frozen by default) and can't merge.

Exactly what happened:
- **#365** (no root dep in the batch → anchored at `apps/claude-sdk-cli`): six `package.json` bumps, **zero lockfile** → unmergeable.
- **#361** (had a root dep → anchored at `/`): updated every member `package.json` **and** the root `pnpm-lock.yaml` → consistent.

Known Dependabot limitation — [dependabot/dependabot-core#11135](https://github.com/dependabot/dependabot-core/issues/11135) ("fails to update root `pnpm-lock.yaml` when splitting updates by `directory` in pnpm workspaces"). The documented fix ([#11487](https://github.com/dependabot/dependabot-core/pull/11487)) is to target the **root directory only**; Dependabot reads `pnpm-workspace.yaml` and updates all members + the root lockfile in one PR.

## Changes

1. `directories: ["/", "/apps/*", "/packages/*", "/scripts"]` → `directory: "/"`. Root-anchored updates cover the whole workspace + the root lockfile, so PRs are mergeable.
2. Add `version-update:semver-minor` to the ignore → **patch-only**. Keeps fast-moving 0.x deps (e.g. `@anthropic-ai/sdk`, which leapt `0.92`→`0.105` in #365) from jumping minors — for 0.x the minor is the breaking axis, but the `semver-major` ignore only blocks the literal major slot.

Net: Dependabot PRs that update the lockfile and stay patch-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
