### PR TITLE
Bump platform package to beta.13, name launcher process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ Full detail: `.claude/five-banana-pillars.md`
 | `packages/claude-sdk-tools/` | Tool definitions: Find, ReadFile, Grep, Head, Tail, Range, SearchFiles, Pipe, EditFile, PreviewEdit, CreateFile, DeleteFile, DeleteDirectory, Exec, Ref, TsDiagnostics, TsHover, TsDefinition, TsReferences |
 | `packages/claude-core/` | Shared: IFileSystem, expandPath, ANSI/terminal utilities |
 | `packages/mcp-exec/` | MCP server wrapping Exec tool |
+| `packages/exec-core/` | Process-spawning core: stream-based single-process spawn behind a shared interface |
+| `platforms/claude-sdk-cli-darwin-arm64/` | Published prebuilt SEA binary (macOS arm64) for the CLI, selected via the CLI's optional dependency. Bumped in lockstep whenever `claude-sdk-cli` is released. |
 
 ### Tool System
 
@@ -95,6 +97,8 @@ That runs the generator over every package with a `changes.jsonl`. To regenerate
 ### Lockstep versioning
 
 All packages share the same version number. If a package has source changes since the last release, it gets bumped to the new version. Packages without changes are not bumped. A package whose published dependency is bumping is also bumped, even without source changes of its own — republishing re-pins it to the new dependency version so consumers resolving that package get the new dependency.
+
+**Platform packages bump with the CLI.** The prebuilt per-platform binaries under `platforms/*` (e.g. `@shellicar/claude-sdk-cli-darwin-arm64`) are published packages selected through the CLI's optional dependencies. When enumerating release targets, walk `platforms/*` alongside `apps/*` and `packages/*` — not just the latter two. The rule: *if `claude-sdk-cli` is released or bumped, every platform package is bumped to the same version in the same release.* The CLI's publish workflow enforces this — its `publish-platforms` job fails on a version mismatch between a platform package and the release tag.
 
 ### Pre-release process (current)
 

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement
 - Repaint every TUI row each frame, resilient to external grid mutation (e.g. tmux reflow)
 - Rewrite the project documentation: what the CLI is, why you would use it, and how to install, configure, run, and extend it
+- Set the launcher process title to claude-sdk-cli so the launcher process can be matched by name, alongside the SEA binary it runs
 - Ship the CLI as a prebuilt Single Executable Application: a per-platform binary (macOS arm64) is selected via an optional dependency and run through a launcher, so the node:sqlite store runs on the bundled Node 26 regardless of the Node the shell resolves
 - Show model version alongside model name in the status bar
 - Show tool input JSON as it streams

--- a/apps/claude-sdk-cli/bin/launcher.mjs
+++ b/apps/claude-sdk-cli/bin/launcher.mjs
@@ -17,6 +17,11 @@ import { dirname, join } from 'node:path';
 
 const require = createRequire(import.meta.url);
 
+// Name this launcher process so it can be matched by name (e.g. pkill
+// claude-sdk-cli). The SEA child sets the same title from main.ts, so both the
+// launcher and the binary it runs are findable under the one name.
+process.title = 'claude-sdk-cli';
+
 const pkg = `@shellicar/claude-sdk-cli-${process.platform}-${process.arch}`;
 
 let binary;

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -79,3 +79,4 @@
 {"description":"Repaint every TUI row each frame, resilient to external grid mutation (e.g. tmux reflow)","category":"changed"}
 {"description":"Rewrite the project documentation: what the CLI is, why you would use it, and how to install, configure, run, and extend it","category":"changed"}
 {"description":"Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions","category":"added"}
+{"description":"Set the launcher process title to claude-sdk-cli so the launcher process can be matched by name, alongside the SEA binary it runs","category":"changed"}

--- a/platforms/claude-sdk-cli-darwin-arm64/package.json
+++ b/platforms/claude-sdk-cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli-darwin-arm64",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "private": false,
   "description": "macOS arm64 prebuilt binary for @shellicar/claude-sdk-cli",
   "license": "MIT",


### PR DESCRIPTION
## Summary

The beta.13 release missed the per-platform binary package. Its version stayed at beta.12, so the CLI's publish workflow failed on a version mismatch and claude-sdk-cli never published. This bumps the platform package to beta.13 so the CLI release can publish, names the launcher process so it can be matched by name, and documents the rule so the platform package is not missed in future releases.

## Changes

- Bump @shellicar/claude-sdk-cli-darwin-arm64 to 1.0.0-beta.13 so the CLI release publishes
- Set the launcher process title to claude-sdk-cli, so the launcher process is findable by name alongside the SEA binary it runs (the binary already sets the same title from main.ts)
- Document the platform package in CLAUDE.md and the rule that every platform package bumps with claude-sdk-cli; also add exec-core and the platform package to the Packages table