### PR TITLE
Executor-owned pipeline teardown (starting point)

### DIFF
--- a/packages/exec-core/src/Executor.ts
+++ b/packages/exec-core/src/Executor.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import type { Writable } from 'node:stream';
+import { PassThrough, type Writable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 import type { CommandSpec, ExitStatus, IExecutor, SpawnOpts } from './types.js';
 
@@ -132,6 +132,133 @@ export class Executor implements IExecutor {
         void finish({ exitCode: err.code === 'ENOENT' ? 127 : 1, signal: null });
       });
     });
+  }
+
+  /**
+   * Run a pipeline of stages, stdout[i] → stdin[i+1], as one owned unit. Because the
+   * Executor owns the whole pipeline it can do the SIGPIPE analogue itself: when a stage
+   * settles, the upstream feeding it has nowhere left to send output, so its bridge is
+   * destroyed and its process group is killed — which propagates upstream one hop at a
+   * time. THAT is what makes `yes | head` return promptly instead of hanging until the
+   * abort/timeout fires (a single-command `run()` can't own this — it never sees the
+   * sibling stages).
+   *
+   * STARTING POINT — the teardown mechanism is verified in isolation (`yes | head`
+   * resolves in ~66ms vs hanging), but this has NOT been type-checked or run against the
+   * package. Rough edges to settle: exit status of a torn-down upstream (SIGTERM here vs
+   * a synthesised 141/SIGPIPE), sink-flush ordering (run() awaits `finished`; this ends
+   * once), and error/redirect semantics.
+   */
+  public async runPipeline(commands: CommandSpec[], opts: SpawnOpts = {}): Promise<ExitStatus[]> {
+    const n = commands.length;
+    if (n === 0) {
+      return [];
+    }
+    if (n === 1) {
+      return [await this.run(commands[0], opts)];
+    }
+    if (opts.signal?.aborted) {
+      return commands.map(() => ({ exitCode: null, signal: 'SIGTERM' }));
+    }
+
+    const bridges = Array.from({ length: n - 1 }, () => new PassThrough());
+    const children = new Array<ReturnType<typeof spawn> | null>(n).fill(null);
+    const statuses = new Array<ExitStatus | null>(n).fill(null);
+
+    // Tear down the upstream feeder of stage i: its consumer is gone, so its output has
+    // nowhere to go. Destroy the bridge first (so nothing awaits an undrained stream),
+    // then group-kill. Guarded by `statuses` so an already-settled stage is never killed;
+    // the kill produces that stage's own 'close', which tears down ITS upstream in turn.
+    const teardownUpstreamOf = (i: number): void => {
+      const up = i - 1;
+      if (up < 0 || statuses[up] != null) {
+        return;
+      }
+      bridges[up]?.destroy();
+      const c = children[up];
+      if (c?.pid != null) {
+        this.#groupKill(c.pid);
+      }
+    };
+
+    const runStage = (i: number): Promise<void> =>
+      new Promise<void>((resolve) => {
+        const cmd = commands[i];
+        const child = spawn(cmd.program, cmd.args ?? [], { cwd: cmd.cwd, env: cmd.env, stdio: 'pipe', detached: true });
+        children[i] = child;
+        if (child.pid != null) {
+          this.#pids.add(child.pid);
+        }
+
+        // stdin: first stage from opts.stdin (or closed); later stages from the previous bridge.
+        const stdinSrc = i === 0 ? opts.stdin : bridges[i - 1];
+        if (stdinSrc) {
+          stdinSrc.pipe(child.stdin);
+          child.stdin.on('error', () => {
+            // Expected: the child may exit before its input finishes writing.
+          });
+        } else {
+          child.stdin.end();
+        }
+
+        // stdout: last stage to opts.stdout (or drained); earlier stages into the next bridge.
+        const stdoutDst = i === n - 1 ? opts.stdout : bridges[i];
+        if (stdoutDst) {
+          child.stdout.pipe(stdoutDst, { end: false });
+        } else {
+          child.stdout.resume();
+        }
+        if (opts.stderr) {
+          child.stderr.pipe(opts.stderr, { end: false });
+        } else {
+          child.stderr.resume();
+        }
+
+        const settle = (status: ExitStatus): void => {
+          if (statuses[i] != null) {
+            return;
+          }
+          statuses[i] = status;
+          if (child.pid != null) {
+            this.#pids.delete(child.pid);
+          }
+          teardownUpstreamOf(i); // the SIGPIPE analogue
+          resolve();
+        };
+
+        child.on('close', (code, sig) => settle({ exitCode: code, signal: sig ?? null }));
+        child.on('error', (err: NodeJS.ErrnoException) => {
+          opts.stderr?.write(err.code === 'ENOENT' ? `Command not found: ${cmd.program}` : err.message);
+          settle({ exitCode: err.code === 'ENOENT' ? 127 : 1, signal: null });
+        });
+      });
+
+    const onAbort = (): void => {
+      for (const c of children) {
+        if (c?.pid != null) {
+          this.#groupKill(c.pid);
+        }
+      }
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+
+    await Promise.all(commands.map((_, i) => runStage(i)));
+    opts.signal?.removeEventListener('abort', onAbort);
+
+    // The caller owns opts.stdout/stderr (possibly the same Writable — de-dupe); end once.
+    const sinks = new Set<Writable>();
+    if (opts.stdout) {
+      sinks.add(opts.stdout);
+    }
+    if (opts.stderr) {
+      sinks.add(opts.stderr);
+    }
+    for (const sink of sinks) {
+      sink.end();
+    }
+
+    // A stage torn down before its own 'close' fired leaves a null slot — treat as killed.
+    return statuses.map((s) => s ?? { exitCode: null, signal: 'SIGKILL' });
   }
 
   #groupKill(pid: number): void {


### PR DESCRIPTION
## New Executor: pipeline-owning teardown — **draft / starting point**

Not finished, not tested — a starting point for you to build on.
- **Unsigned** — my session's `gpg-agent` is dead; please re-sign.
- **Not type-checked or run** against the package (no `node_modules` in my sandbox). Treat this as the mechanism sketched in the real shapes, not a tested implementation.

### Problem
`run()` is single-command, so ExecV3's `runPipeline` bolts the pipe lifecycle onto a primitive that never sees its sibling stages. Nothing tears the upstream down when a downstream stage exits — so `yes | head` / `find / | head` / `cat big | grep -m1` don't short-circuit; the upstream runs until the abort/timeout fires.

### Change
A `runPipeline(commands, opts)` on the Executor — the thing that spawns the stages owns their inter-stage lifecycle. Mechanism: **when a stage settles, destroy its feeding bridge and group-kill the upstream** (its consumer is gone); propagates upstream one hop per `close`. The SIGPIPE analogue a single-command primitive structurally can't do.

### Verified vs not
- **Verified in isolation:** the teardown, via a standalone `spawn`+`PassThrough` repro — `yes | head` resolves in **~66ms** vs hanging to the timeout (repro on #380).
- **NOT verified:** this exact code — no type-check, no run.

### Rough edges (yours to settle)
- Exit status of a torn-down upstream: `SIGTERM` here vs a synthesised `141`/SIGPIPE.
- Sink-flush ordering: `run()` awaits `finished`; this ends once.
- Error/redirect semantics; `run()` as a length-1 pipeline vs coexisting.
