### PR TITLE
Surface the API error detail on a failed request, not just the status

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent crashes from unhandled child process and socket errors
 - Reject unknown flags at launch instead of silently ignoring them
 - Restore cursor visibility after exiting the CLI (#277)
+- Show the API error detail on a failed request instead of only the HTTP status
 - Show the permissions notice only when displayed permissions change, not on every config edit
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -84,3 +84,4 @@
 {"description":"Fix pipe stages being silently auto-denied by the permission system, and report an unknown tool as a lookup failure rather than a false user rejection","category":"fixed"}
 {"description":"Survive a mid-turn network drop: keep the machine awake during a request, persist the conversation as each message is sent and answered, and resume an interrupted turn from an empty submit","category":"added"}
 {"description":"Show user, tools, and claude time totals in the status line","category":"added"}
+{"description":"Show the API error detail on a failed request instead of only the HTTP status","category":"fixed"}

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -2,7 +2,7 @@ import { relative } from 'node:path';
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
-import { CacheTtl, calculateCost, type DurableConfig, IDurableConfigProvider, type SdkMessage, type SdkMessageUsage, type SdkToolApprovalRequest } from '@shellicar/claude-sdk';
+import { CacheTtl, calculateCost, type DurableConfig, IDurableConfigProvider, type SdkError, type SdkMessage, type SdkMessageUsage, type SdkToolApprovalRequest } from '@shellicar/claude-sdk';
 import type { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { ApprovalNotifier } from '../model/ApprovalNotifier.js';
@@ -25,6 +25,19 @@ function fmtBytes(n: number): string {
     return `${(n / 1024).toFixed(1)}kb`;
   }
   return `${n}b`;
+}
+
+/** Renders an SDK error for display. When the SDK carried structured detail (status, API
+ * error type, and the body's message), compose a line that names all three; otherwise fall
+ * back to the error's plain message. The status/type prefix is dropped when neither is
+ * present, so a detail carrying only a message reads as that message alone. */
+function formatSdkError(msg: SdkError): string {
+  const detail = msg.detail;
+  if (detail == null) {
+    return msg.message;
+  }
+  const prefix = [detail.status != null ? `HTTP ${detail.status}` : undefined, detail.type].filter((part) => part != null).join(' ');
+  return prefix.length > 0 ? `${prefix}: ${detail.message}` : detail.message;
 }
 
 function primaryArg(input: Record<string, unknown>, cwd: string): string | null {
@@ -365,8 +378,8 @@ export class AgentMessageHandler {
         }
         break;
       case 'error':
-        this.conversation.appendStreaming(`\n\n[error: ${msg.message}]`);
-        this.logger.error('error', { message: msg.message });
+        this.conversation.appendStreaming(`\n\n[error: ${formatSdkError(msg)}]`);
+        this.logger.error('error', { message: msg.message, detail: msg.detail });
         break;
       case 'turn_content':
         // Persist after each assistant turn. The assistant content cannot be

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Calculate costs for Opus 4.7
+- Carry structured API error detail (status, type, message) to consumers, not only the status
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
 - Fix context window size for Sonnet 4 (200k to 1M)
 - Package now publishes CJS alongside ESM with working sourcemaps

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -36,3 +36,4 @@
 {"description":"Replace the placeholder README with a short description and a link to the main documentation","category":"changed"}
 {"description":"Adopt core-di-lite property injection across the SDK: dependencies resolve through declared injected properties instead of hand-wired constructors, and the injection contracts are exported as abstract-class tokens","category":"changed"}
 {"description":"Classify a mid-stream connection drop and retry it on a bounded fixed schedule instead of surfacing it as a fatal error, with injection seams to hold a wake lock and signal a reconnect","category":"added"}
+{"description":"Carry structured API error detail (status, type, message) to consumers, not only the status","category":"fixed"}

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -9,7 +9,7 @@ import type { PerQueryInput, SdkMessage, ToolOutcome, ToolResultBlock, Transform
 import { IToolsClockListener } from '../public/types';
 import { ApprovalCoordinator } from './ApprovalCoordinator';
 import { Conversation } from './Conversation';
-import { AccountLimitStoppedError } from './http/errors';
+import { AccountLimitStoppedError, toSdkErrorDetail } from './http/errors';
 import { calculateCost, getContextWindow } from './pricing';
 import type { ToolUseResult } from './types';
 
@@ -133,7 +133,8 @@ export class QueryRunner extends IQueryRunner {
           return;
         }
         if (err instanceof Error) {
-          this.publisher.send({ type: 'error', message: err.message });
+          const detail = toSdkErrorDetail(err);
+          this.publisher.send({ type: 'error', message: err.message, ...(detail ? { detail } : {}) });
         }
         return;
       }

--- a/packages/claude-sdk/src/private/http/errors.ts
+++ b/packages/claude-sdk/src/private/http/errors.ts
@@ -1,3 +1,5 @@
+import type { SdkErrorDetail } from '../../public/types';
+
 /** Base for every error the owned transport raises. */
 export class TransportError extends Error {}
 
@@ -93,6 +95,38 @@ export function safeJsonParse(text: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+/** Reads the `{ error: { type, message } }` shape an Anthropic error response carries in its
+ * parsed body. The body is `unknown` off the wire, so every field is guarded; a body that
+ * does not match the shape yields undefined. */
+function readBodyError(body: unknown): { type?: string; message?: string } | undefined {
+  if (typeof body !== 'object' || body === null || !('error' in body)) {
+    return undefined;
+  }
+  const inner = (body as { error: unknown }).error;
+  if (typeof inner !== 'object' || inner === null) {
+    return undefined;
+  }
+  const type = 'type' in inner && typeof inner.type === 'string' ? inner.type : undefined;
+  const message = 'message' in inner && typeof inner.message === 'string' ? inner.message : undefined;
+  return { type, message };
+}
+
+/** Extracts the structured detail the CLI needs to render a transport failure — status, the
+ * API error type, and the human-readable message from the response body. Returns undefined
+ * for anything that is not a transport error carrying that detail, so a plain give-up error
+ * surfaces as its message alone. */
+export function toSdkErrorDetail(err: unknown): SdkErrorDetail | undefined {
+  if (err instanceof HttpError) {
+    const bodyError = readBodyError(err.body);
+    return { status: err.status, type: bodyError?.type, message: bodyError?.message ?? `HTTP ${err.status}` };
+  }
+  if (err instanceof ApiStreamError) {
+    const bodyError = readBodyError(err.body);
+    return { type: err.type ?? bodyError?.type, message: bodyError?.message ?? err.message };
+  }
+  return undefined;
 }
 
 export async function safeReadBody(response: Response): Promise<unknown> {

--- a/packages/claude-sdk/src/public/types.ts
+++ b/packages/claude-sdk/src/public/types.ts
@@ -180,7 +180,12 @@ export type SdkBlockEnter = { type: 'block_enter'; blockType: string };
 export type SdkBlockExit = { type: 'block_exit'; blockType: string };
 export type SdkToolBatchStart = { type: 'tool_batch_start' };
 export type SdkToolBatchEnd = { type: 'tool_batch_end' };
-export type SdkError = { type: 'error'; message: string };
+/** The structured pieces of an API failure the CLI formats for display. Present when the
+ * error is a transport error carrying a parsed body; absent for errors that have only a
+ * message (e.g. an internal give-up). `message` is the human-readable detail from the
+ * response body, falling back to the error's own message when the body carried none. */
+export type SdkErrorDetail = { status?: number; type?: string; message: string };
+export type SdkError = { type: 'error'; message: string; detail?: SdkErrorDetail };
 export type SdkMessageUsage = { type: 'message_usage'; inputTokens: number; cacheCreationTokens: number; cacheReadTokens: number; outputTokens: number; costUsd: number; contextWindow: number };
 export type SdkQuerySummary = { type: 'query_summary'; systemPrompts: number; userMessages: number; assistantMessages: number; thinkingBlocks: number; systemReminder?: string };
 

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { ApprovalCoordinator } from '../src/private/ApprovalCoordinator.js';
 import type { IPublisher } from '../src/private/ControlChannel.js';
 import { Conversation } from '../src/private/Conversation.js';
-import { AccountLimitStoppedError } from '../src/private/http/errors.js';
+import { AccountLimitStoppedError, ApiStreamError, HttpError } from '../src/private/http/errors.js';
 import { QueryRunner } from '../src/private/QueryRunner.js';
 import { ToolRegistry } from '../src/private/ToolRegistry.js';
 import type { MessageStreamResult } from '../src/private/types.js';
@@ -728,6 +728,62 @@ describe('QueryRunner — account-limit give-up', () => {
     await w.queryRunner.run(makeInput());
     const actual = w.channel.messages.filter((m) => m.type === 'error').length;
     expect(actual).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured error detail surfacing (the drop point this mission fixes)
+// ---------------------------------------------------------------------------
+
+function findError(w: Wiring): Extract<SdkMessage, { type: 'error' }> | undefined {
+  return w.channel.messages.find((m): m is Extract<SdkMessage, { type: 'error' }> => m.type === 'error');
+}
+
+function anthropicErrorBody(type: string, message: string) {
+  return { type: 'error', error: { type, message } };
+}
+
+describe('QueryRunner — error detail surfacing', () => {
+  it('carries the HTTP status in the error event detail', async () => {
+    const w = makeWiring([new HttpError(404, undefined, anthropicErrorBody('not_found_error', 'model: hello-world not found'), new Headers())]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail?.status;
+    expect(actual).toBe(404);
+  });
+
+  it('carries the API error type in the error event detail', async () => {
+    const w = makeWiring([new HttpError(404, undefined, anthropicErrorBody('not_found_error', 'model: hello-world not found'), new Headers())]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail?.type;
+    expect(actual).toBe('not_found_error');
+  });
+
+  it('carries the body message in the error event detail', async () => {
+    const w = makeWiring([new HttpError(404, undefined, anthropicErrorBody('not_found_error', 'model: hello-world not found'), new Headers())]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail?.message;
+    expect(actual).toBe('model: hello-world not found');
+  });
+
+  it('falls back to the status string when the body carries no message', async () => {
+    const w = makeWiring([new HttpError(500, undefined, undefined, new Headers())]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail?.message;
+    expect(actual).toBe('HTTP 500');
+  });
+
+  it('carries the detail for a mid-stream ApiStreamError', async () => {
+    const w = makeWiring([new ApiStreamError('overloaded_error', anthropicErrorBody('overloaded_error', 'Overloaded'))]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail?.message;
+    expect(actual).toBe('Overloaded');
+  });
+
+  it('leaves detail undefined for a non-transport error', async () => {
+    const w = makeWiring([new Error('boom')]);
+    await w.queryRunner.run(makeInput());
+    const actual = findError(w)?.detail;
+    expect(actual).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Carry structured API error detail (status, type, message) across the SDK to CLI channel
- Bring non-HTTP stream error detail across the same way
- Format the error in the CLI so a failed request shows what went wrong, not a bare HTTP status

Closes #392