### PR TITLE
Condition attached images to a safe size on attach

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - List --file in --help output
 - Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement
 - Repaint every TUI row each frame, resilient to external grid mutation (e.g. tmux reflow)
+- Resize and normalise a pasted image before it is attached, so an oversized image can no longer exceed the request-size limit and take down the conversation
 - Rewrite the project documentation: what the CLI is, why you would use it, and how to install, configure, run, and extend it
 - Serve the assembled CLAUDE.md prefix from cache on repeat launches instead of paying for it each turn
 - Set the launcher process title to claude-sdk-cli so the launcher process can be matched by name, alongside the SEA binary it runs

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -88,3 +88,4 @@
 {"description":"Add a --claudeMd flag to contribute a string to the assembled CLAUDE.md content at launch","category":"added"}
 {"description":"Serve the assembled CLAUDE.md prefix from cache on repeat launches instead of paying for it each turn","category":"changed"}
 {"description":"Show the API error detail on a failed request instead of only the HTTP status","category":"fixed"}
+{"description":"Resize and normalise a pasted image before it is attached, so an oversized image can no longer exceed the request-size limit and take down the conversation","category":"changed"}

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { detectMediaType } from '../clipboard.js';
 import { AttachmentSource } from '../model/AttachmentSource.js';
@@ -36,6 +37,7 @@ export class CommandIntentExecutor {
   @dependsOn(AttachmentSource) private readonly source!: AttachmentSource;
   @dependsOn(ModelSettings) private readonly modelSettings!: ModelSettings;
   @dependsOn(SipsBridge) private readonly sips!: SipsBridge;
+  @dependsOn(ILogger) private readonly logger!: ILogger;
 
   public async execute(intent: CommandIntent): Promise<void> {
     try {
@@ -110,7 +112,7 @@ export class CommandIntentExecutor {
     if (result.kind === 'image') {
       const mediaType = detectMediaType(result.data);
       if (mediaType) {
-        const conditioned = await conditionImage(result.data, mediaType, this.sips);
+        const conditioned = await conditionImage(result.data, mediaType, this.sips, this.logger);
         this.commandModeState.addImage(conditioned.data, conditioned.mediaType);
       }
     }

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -1,4 +1,6 @@
 import { resolve } from 'node:path';
+import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
+import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { detectMediaType } from '../clipboard.js';
 import { AttachmentSource } from '../model/AttachmentSource.js';
@@ -33,6 +35,7 @@ export class CommandIntentExecutor {
   @dependsOn(ConversationSession) private readonly session!: ConversationSession;
   @dependsOn(AttachmentSource) private readonly source!: AttachmentSource;
   @dependsOn(ModelSettings) private readonly modelSettings!: ModelSettings;
+  @dependsOn(SipsBridge) private readonly sips!: SipsBridge;
 
   public async execute(intent: CommandIntent): Promise<void> {
     try {
@@ -107,7 +110,8 @@ export class CommandIntentExecutor {
     if (result.kind === 'image') {
       const mediaType = detectMediaType(result.data);
       if (mediaType) {
-        this.commandModeState.addImage(result.data, mediaType);
+        const conditioned = await conditionImage(result.data, mediaType, this.sips);
+        this.commandModeState.addImage(conditioned.data, conditioned.mediaType);
       }
     }
   }

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -1,4 +1,5 @@
 import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { IMemoryStore } from '@shellicar/claude-core/memory/interfaces';
 import type { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
 import type { AnyToolDefinition } from '@shellicar/claude-sdk';
@@ -19,7 +20,7 @@ import { Paths } from '@shellicar/claude-sdk-tools/Paths';
 import { createPipe } from '@shellicar/claude-sdk-tools/Pipe';
 import { Range } from '@shellicar/claude-sdk-tools/Range';
 import { Read } from '@shellicar/claude-sdk-tools/Read';
-import { ReadFile } from '@shellicar/claude-sdk-tools/ReadFile';
+import { createReadFileTool } from '@shellicar/claude-sdk-tools/ReadFile';
 import { createRef } from '@shellicar/claude-sdk-tools/Ref';
 import { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
 import { Tail } from '@shellicar/claude-sdk-tools/Tail';
@@ -47,10 +48,12 @@ export type CreateAppToolsOptions = {
   objects: IObjectStore;
   memory: IMemoryStore;
   tsAvailable: boolean;
+  logger: ILogger;
 };
 
-export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, tsAvailable }: CreateAppToolsOptions): AppTools {
+export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, tsAvailable, logger }: CreateAppToolsOptions): AppTools {
   const store = new RefStore(objects);
+  const ReadFile = createReadFileTool(logger);
   const { previewEdit: PreviewEdit, editFile: EditFile } = createEditFilePair(fs, objects);
   const { tool: Ref, transformToolResult: refTransform } = createRef(store, 50_000);
   // Composable sources start a pipe and are also useful standalone; stages run only inside a pipe.

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -195,7 +195,8 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
     const objects = x.resolve(IObjectStore);
     const memory = x.resolve(IMemoryStore);
     const runtime = x.resolve(IRuntimeOptions);
-    const tools = createAppTools({ fs, tsServer, toolsConfig: loader.config.tools, objects, memory, tsAvailable: runtime.tsAvailable });
+    const appLogger = x.resolve(ILogger);
+    const tools = createAppTools({ fs, tsServer, toolsConfig: loader.config.tools, objects, memory, tsAvailable: runtime.tsAvailable, logger: appLogger });
     return new AppToolsService(tools);
   });
   // AppToolsService is factory-built, so its cache key is the factory; alias the

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -9,6 +9,8 @@ import { NodeDirectoryWatcher } from '@shellicar/claude-core/Config/NodeDirector
 import { readConfig } from '@shellicar/claude-core/Config/readConfig';
 import { ConfigWatchHandle } from '@shellicar/claude-core/Config/types';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { NodeSipsBridge } from '@shellicar/claude-core/image/NodeSipsBridge';
+import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IMemoryEnvironmentProvider } from '@shellicar/claude-core/memory/environment-provider';
 import { IMemoryStore } from '@shellicar/claude-core/memory/interfaces';
@@ -230,6 +232,8 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(Screen).to(StdoutScreen);
   services.register(IProcessLauncher).to(NodeProcessLauncher);
   services.register(AttachmentSource).to(NodeAttachmentSource);
+  services.register(SipsBridge).to(NodeSipsBridge);
+  services.register(NodeSipsBridge).to(NodeSipsBridge);
   services.register(ModelSettings).to(ModelOverrides);
   services.register(ModelOverrides).to(ModelOverrides);
 

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { Conversation } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
@@ -20,6 +21,9 @@ const passthroughSips: SipsBridge = {
   dimensions: () => Promise.reject(new Error('no sips in tests')),
   resizeToPng: () => Promise.reject(new Error('no sips in tests')),
 };
+
+/** Test double: a logger that discards everything, so the executor resolves without the app's logger. */
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 function makeExecutor(source: AttachmentSource) {
   const commandModeState = new CommandModeState();
@@ -45,6 +49,7 @@ function makeExecutor(source: AttachmentSource) {
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
   services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
+  services.register(ILogger).to(ILogger, () => noopLogger);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   const provider = services.buildProvider();
   const executor = provider.resolve(CommandIntentExecutor);

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { Conversation } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
@@ -13,6 +14,12 @@ import { ModelSettings } from '../src/model/ModelSettings.js';
 import { SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
 import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+/** Test double: sips unavailable, so pasted images pass through unconditioned. */
+const passthroughSips: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('no sips in tests')),
+  resizeToPng: () => Promise.reject(new Error('no sips in tests')),
+};
 
 function makeExecutor(source: AttachmentSource) {
   const commandModeState = new CommandModeState();
@@ -37,6 +44,7 @@ function makeExecutor(source: AttachmentSource) {
   services.register(ConversationSession).to(ConversationSession);
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
+  services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   const provider = services.buildProvider();
   const executor = provider.resolve(CommandIntentExecutor);

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { Conversation } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
@@ -16,6 +17,12 @@ import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Test double: sips unavailable, so pasted images pass through unconditioned. */
+const passthroughSips: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('no sips in tests')),
+  resizeToPng: () => Promise.reject(new Error('no sips in tests')),
+};
 
 function makeHandler(sourceText: string | null = null) {
   const commandModeState = new CommandModeState();
@@ -41,6 +48,7 @@ function makeHandler(sourceText: string | null = null) {
   services.register(ConversationSession).to(ConversationSession);
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
+  services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   services.register(CommandKeyHandler).to(CommandKeyHandler);
   const handler = services.buildProvider().resolve(CommandKeyHandler);

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { Conversation } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
@@ -23,6 +24,9 @@ const passthroughSips: SipsBridge = {
   dimensions: () => Promise.reject(new Error('no sips in tests')),
   resizeToPng: () => Promise.reject(new Error('no sips in tests')),
 };
+
+/** Test double: a logger that discards everything, so the executor resolves without the app's logger. */
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 function makeHandler(sourceText: string | null = null) {
   const commandModeState = new CommandModeState();
@@ -49,6 +53,7 @@ function makeHandler(sourceText: string | null = null) {
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
   services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
+  services.register(ILogger).to(ILogger, () => noopLogger);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   services.register(CommandKeyHandler).to(CommandKeyHandler);
   const handler = services.buildProvider().resolve(CommandKeyHandler);

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -1,6 +1,7 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { type ConsumerMessage, Conversation } from '@shellicar/claude-sdk';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import type { Presentation } from '../src/app/Presentation.js';
@@ -59,6 +60,9 @@ const passthroughSips: SipsBridge = {
   dimensions: () => Promise.reject(new Error('no sips in tests')),
   resizeToPng: () => Promise.reject(new Error('no sips in tests')),
 };
+
+/** Test double: a logger that discards everything, so the executor resolves without the app's logger. */
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 function makeModel(): ViewModel {
   const terminalState = new TerminalState();
@@ -213,6 +217,7 @@ describe('ViewHost — escape routing through the primary chains', () => {
     services.register(AttachmentSource).to(AttachmentSource, () => new FakeAttachmentSource());
     services.register(ModelSettings).to(ModelSettings, () => ({ cycleThinking: () => {}, cycleEffort: () => {} }));
     services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
+    services.register(ILogger).to(ILogger, () => noopLogger);
     services.register(ConsumerChannel).to(ConsumerChannel, () => new RecordingConsumerChannel(cancelLog));
     services.register(CommandIntentExecutor).to(CommandIntentExecutor);
     services.register(ApprovalHandler).to(ApprovalHandler);

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -1,7 +1,7 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
-import { type ConsumerMessage, Conversation } from '@shellicar/claude-sdk';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { type ConsumerMessage, Conversation } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import type { Presentation } from '../src/app/Presentation.js';

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -1,5 +1,6 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { type ConsumerMessage, Conversation } from '@shellicar/claude-sdk';
+import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import type { Presentation } from '../src/app/Presentation.js';
@@ -52,6 +53,12 @@ function makeTurnClock(): ITurnClock {
   services.register(ITurnClock).to(TurnClock);
   return services.buildProvider().resolve(ITurnClock);
 }
+
+/** Test double: sips unavailable, so pasted images pass through unconditioned. */
+const passthroughSips: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('no sips in tests')),
+  resizeToPng: () => Promise.reject(new Error('no sips in tests')),
+};
 
 function makeModel(): ViewModel {
   const terminalState = new TerminalState();
@@ -205,6 +212,7 @@ describe('ViewHost — escape routing through the primary chains', () => {
     services.register(Conversation).to(Conversation, () => new Conversation());
     services.register(AttachmentSource).to(AttachmentSource, () => new FakeAttachmentSource());
     services.register(ModelSettings).to(ModelSettings, () => ({ cycleThinking: () => {}, cycleEffort: () => {} }));
+    services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
     services.register(ConsumerChannel).to(ConsumerChannel, () => new RecordingConsumerChannel(cancelLog));
     services.register(CommandIntentExecutor).to(CommandIntentExecutor);
     services.register(ApprovalHandler).to(ApprovalHandler);

--- a/apps/claude-sdk-cli/test/createAppTools.spec.ts
+++ b/apps/claude-sdk-cli/test/createAppTools.spec.ts
@@ -1,5 +1,6 @@
 import type { Definition, DefinitionOptions, Diagnostic, DiagnosticsOptions, HoverInfo, HoverOptions, ITypeScriptService, Reference, ReferencesOptions } from '@shellicar/claude-sdk-tools/TsService';
 import { describe, expect, it } from 'vitest';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createAppTools } from '../src/createAppTools.js';
 import { getPermission, PermissionAction, type PermissionConfig } from '../src/permissions.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
@@ -9,6 +10,7 @@ import { RecordingMemoryStore } from './RecordingMemoryStore.js';
 // createAppTools now takes the filesystem as its first parameter (the container
 // passes the resolved IFileSystem instead of the nodeFs singleton).
 const fs = new MemoryFileSystem({}, '/home/user', '/project');
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 // ITypeScriptService is a type-only export from the package entry — it has no runtime
 // value there. Build a plain structural stub and cast it; no class inheritance needed.
@@ -31,7 +33,7 @@ const permMatrix: PermissionConfig = {
 
 describe('createAppTools — permission resolution for pipe stages', () => {
   it('exposes every pipe stage in permissionTools so a stage step resolves', () => {
-    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = PIPE_STAGES.every((name) => permissionTools.some((t) => t.name === name));
@@ -39,7 +41,7 @@ describe('createAppTools — permission resolution for pipe stages', () => {
   });
 
   it('does not auto-deny a pipe containing a stage', () => {
-    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
     const pipe = {
       name: 'Pipe',
       input: {
@@ -59,7 +61,7 @@ describe('createAppTools — permission resolution for pipe stages', () => {
 
 describe('createAppTools — tool selection', () => {
   it('includes ExecV2 when execV2 is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -67,7 +69,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes Exec when exec is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -75,7 +77,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes Exec when exec is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -83,7 +85,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes ExecV2 when execV2 is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -91,7 +93,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes ExecV3 when execV3 is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: true }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: true }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV3');
@@ -99,7 +101,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes ExecV3 when execV3 is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'ExecV3');
@@ -107,7 +109,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes Exec when both are true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -115,7 +117,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes ExecV2 when both are true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -125,7 +127,7 @@ describe('createAppTools — tool selection', () => {
 
 describe('createAppTools — TS tool availability', () => {
   it('includes TsDiagnostics when typescript is available', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: true, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'TsDiagnostics');
@@ -133,7 +135,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('excludes TsDiagnostics when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false, logger: noopLogger });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'TsDiagnostics');
@@ -141,7 +143,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('excludes every TS tool when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false, logger: noopLogger });
 
     const expected = 0;
     const actual = tools.filter((t) => ['TsDiagnostics', 'TsHover', 'TsReferences', 'TsDefinition'].includes(t.name)).length;
@@ -149,7 +151,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('keeps non-TS tools when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), tsAvailable: false, logger: noopLogger });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ReadFile');

--- a/apps/claude-sdk-cli/test/createAppTools.spec.ts
+++ b/apps/claude-sdk-cli/test/createAppTools.spec.ts
@@ -1,6 +1,6 @@
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { Definition, DefinitionOptions, Diagnostic, DiagnosticsOptions, HoverInfo, HoverOptions, ITypeScriptService, Reference, ReferencesOptions } from '@shellicar/claude-sdk-tools/TsService';
 import { describe, expect, it } from 'vitest';
-import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createAppTools } from '../src/createAppTools.js';
 import { getPermission, PermissionAction, type PermissionConfig } from '../src/permissions.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add overrides option to ConfigLoader for a highest-precedence config layer
 - Add rename and platform operations to the IFileSystem contract
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions
+- Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged
 - Support binary file reads through encoding parameter on IFileSystem.readFile
 
 ### Changed

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -12,3 +12,4 @@
 {"description":"Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions","category":"added"}
 {"description":"File discovery returns records carrying type, size, and symlink target instead of bare path strings","category":"changed"}
 {"description":"Add rename and platform operations to the IFileSystem contract","category":"added"}
+{"description":"Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged","category":"added"}

--- a/packages/claude-core/src/image/NodeSipsBridge.ts
+++ b/packages/claude-core/src/image/NodeSipsBridge.ts
@@ -17,7 +17,7 @@ const SIPS_TIMEOUT_MS = 10_000;
  * which conditionImage turns into attach-as-is.
  */
 export class NodeSipsBridge extends SipsBridge {
-  async dimensions(input: Buffer): Promise<ImageDimensions> {
+  public async dimensions(input: Buffer): Promise<ImageDimensions> {
     return this.#withTempDir(async (dir) => {
       const inputPath = join(dir, 'input');
       await writeFile(inputPath, input);
@@ -26,7 +26,7 @@ export class NodeSipsBridge extends SipsBridge {
     });
   }
 
-  async resizeToPng(input: Buffer): Promise<Buffer> {
+  public async resizeToPng(input: Buffer): Promise<Buffer> {
     return this.#withTempDir(async (dir) => {
       const inputPath = join(dir, 'input');
       const outputPath = join(dir, 'output.png');

--- a/packages/claude-core/src/image/NodeSipsBridge.ts
+++ b/packages/claude-core/src/image/NodeSipsBridge.ts
@@ -1,0 +1,47 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { buildDimensionArgs, buildResizeArgs, parseDimensions } from './conditionImage.js';
+import { type ImageDimensions, SipsBridge } from './SipsBridge.js';
+
+const execFileAsync = promisify(execFile);
+const SIPS_TIMEOUT_MS = 10_000;
+
+/**
+ * Real sips bridge. `sips` is invoked bare (resolved on PATH) — a base macOS tool, like the bare
+ * pngpaste/osascript calls in clipboard.ts. It reads and writes files only (no stdin/stdout image
+ * mode), so every call stages the bytes in a throwaway temp dir and removes it afterwards.
+ * Any spawn error (absent binary → ENOENT) or non-zero exit (a failure on the image → 13) rejects,
+ * which conditionImage turns into attach-as-is.
+ */
+export class NodeSipsBridge extends SipsBridge {
+  async dimensions(input: Buffer): Promise<ImageDimensions> {
+    return this.#withTempDir(async (dir) => {
+      const inputPath = join(dir, 'input');
+      await writeFile(inputPath, input);
+      const { stdout } = await execFileAsync('sips', buildDimensionArgs(inputPath), { timeout: SIPS_TIMEOUT_MS });
+      return parseDimensions(stdout);
+    });
+  }
+
+  async resizeToPng(input: Buffer): Promise<Buffer> {
+    return this.#withTempDir(async (dir) => {
+      const inputPath = join(dir, 'input');
+      const outputPath = join(dir, 'output.png');
+      await writeFile(inputPath, input);
+      await execFileAsync('sips', buildResizeArgs(inputPath, outputPath), { timeout: SIPS_TIMEOUT_MS });
+      return readFile(outputPath);
+    });
+  }
+
+  async #withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+    const dir = await mkdtemp(join(tmpdir(), 'claude-sips-'));
+    try {
+      return await fn(dir);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/claude-core/src/image/SipsBridge.ts
+++ b/packages/claude-core/src/image/SipsBridge.ts
@@ -1,0 +1,11 @@
+export type ImageDimensions = { readonly width: number; readonly height: number };
+
+/**
+ * The child-process boundary for image conditioning — the one place the real `sips` binary runs.
+ * Injected so `conditionImage` is tested without the binary. Every method rejects when sips is
+ * absent, not invocable, or fails on the image; `conditionImage` turns any rejection into attach-as-is.
+ */
+export abstract class SipsBridge {
+  abstract dimensions(input: Buffer): Promise<ImageDimensions>;
+  abstract resizeToPng(input: Buffer): Promise<Buffer>;
+}

--- a/packages/claude-core/src/image/SipsBridge.ts
+++ b/packages/claude-core/src/image/SipsBridge.ts
@@ -6,6 +6,6 @@ export type ImageDimensions = { readonly width: number; readonly height: number 
  * absent, not invocable, or fails on the image; `conditionImage` turns any rejection into attach-as-is.
  */
 export abstract class SipsBridge {
-  abstract dimensions(input: Buffer): Promise<ImageDimensions>;
-  abstract resizeToPng(input: Buffer): Promise<Buffer>;
+  public abstract dimensions(input: Buffer): Promise<ImageDimensions>;
+  public abstract resizeToPng(input: Buffer): Promise<Buffer>;
 }

--- a/packages/claude-core/src/image/conditionImage.ts
+++ b/packages/claude-core/src/image/conditionImage.ts
@@ -1,4 +1,5 @@
 import type { SipsBridge } from './SipsBridge.js';
+import type { ILogger } from '../logging/ILogger.js';
 
 /** The image media types both attach paths already emit (paste: clipboard.ts detectMediaType; ReadFile: file-type sniff). */
 export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
@@ -36,16 +37,24 @@ export function parseDimensions(stdout: string): { width: number; height: number
  * Condition an image for attachment: downscale to a <=2000px long edge as PNG when it is larger,
  * otherwise leave it exactly as-is. Any sips problem (absent, not invocable, or a failure on this
  * image) degrades to the original bytes and media type — a conditioner must never block an attachment.
+ *
+ * Each outcome is logged the moment it happens (not aggregated at the call site) so the timestamp is
+ * the real event time. The degrade path logs at `warn` because attaching an unconditioned image is the
+ * one outcome an operator needs to notice in the field; the successful paths log at `debug`.
  */
-export async function conditionImage(input: Buffer, mediaType: ImageMediaType, sips: SipsBridge): Promise<ConditionedImage> {
+export async function conditionImage(input: Buffer, mediaType: ImageMediaType, sips: SipsBridge, logger: ILogger): Promise<ConditionedImage> {
   try {
     const { width, height } = await sips.dimensions(input);
+    logger.debug(`image conditioning: source image is ${width}x${height}px (${input.length} bytes)`);
     if (Math.max(width, height) <= MAX_LONG_EDGE) {
+      logger.debug(`image conditioning: long edge is within ${MAX_LONG_EDGE}px, attaching unchanged`);
       return { data: input, mediaType };
     }
     const data = await sips.resizeToPng(input);
+    logger.debug(`image conditioning: long edge exceeds ${MAX_LONG_EDGE}px, downscaled to a ${MAX_LONG_EDGE}px long edge and re-encoded as PNG (${input.length} -> ${data.length} bytes)`);
     return { data, mediaType: 'image/png' };
-  } catch {
+  } catch (error) {
+    logger.warn(`image conditioning: sips unavailable or failed, attaching image unchanged (${input.length} bytes)`, { error });
     return { data: input, mediaType };
   }
 }

--- a/packages/claude-core/src/image/conditionImage.ts
+++ b/packages/claude-core/src/image/conditionImage.ts
@@ -1,0 +1,51 @@
+import type { SipsBridge } from './SipsBridge.js';
+
+/** The image media types both attach paths already emit (paste: clipboard.ts detectMediaType; ReadFile: file-type sniff). */
+export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+export type ConditionedImage = { readonly data: Buffer; readonly mediaType: ImageMediaType };
+
+/** Longest edge (px) an attached image may keep. Above this, downscale; at or below, leave as-is.
+ *  A fixed safety number under the API's per-image dimension cap — deliberately not model-aware. */
+export const MAX_LONG_EDGE = 2000;
+
+/** sips argument vector that reads an image's pixel dimensions. */
+export function buildDimensionArgs(inputPath: string): string[] {
+  return ['-g', 'pixelWidth', '-g', 'pixelHeight', inputPath];
+}
+
+/** sips argument vector that downscales to a <=2000px long edge (aspect kept) and re-encodes as PNG.
+ *  `-Z` never enlarges *once gated by dimensions* — it is only ever invoked here for an oversized image. */
+export function buildResizeArgs(inputPath: string, outputPath: string): string[] {
+  return ['-Z', String(MAX_LONG_EDGE), '-s', 'format', 'png', inputPath, '--out', outputPath];
+}
+
+/** Parse `pixelWidth: N` / `pixelHeight: N` out of `sips -g` stdout.
+ *  Throws on output we cannot read, so an unreadable sips response degrades to attach-as-is
+ *  (required by the "degrade, never fail" contract) rather than silently mis-gating the resize. */
+export function parseDimensions(stdout: string): { width: number; height: number } {
+  const width = Number(stdout.match(/pixelWidth:\s*(\d+)/)?.[1]);
+  const height = Number(stdout.match(/pixelHeight:\s*(\d+)/)?.[1]);
+  if (!Number.isInteger(width) || !Number.isInteger(height)) {
+    throw new Error(`sips returned unparseable dimensions: ${stdout}`);
+  }
+  return { width, height };
+}
+
+/**
+ * Condition an image for attachment: downscale to a <=2000px long edge as PNG when it is larger,
+ * otherwise leave it exactly as-is. Any sips problem (absent, not invocable, or a failure on this
+ * image) degrades to the original bytes and media type — a conditioner must never block an attachment.
+ */
+export async function conditionImage(input: Buffer, mediaType: ImageMediaType, sips: SipsBridge): Promise<ConditionedImage> {
+  try {
+    const { width, height } = await sips.dimensions(input);
+    if (Math.max(width, height) <= MAX_LONG_EDGE) {
+      return { data: input, mediaType };
+    }
+    const data = await sips.resizeToPng(input);
+    return { data, mediaType: 'image/png' };
+  } catch {
+    return { data: input, mediaType };
+  }
+}

--- a/packages/claude-core/src/image/conditionImage.ts
+++ b/packages/claude-core/src/image/conditionImage.ts
@@ -1,5 +1,5 @@
-import type { SipsBridge } from './SipsBridge.js';
 import type { ILogger } from '../logging/ILogger.js';
+import type { SipsBridge } from './SipsBridge.js';
 
 /** The image media types both attach paths already emit (paste: clipboard.ts detectMediaType; ReadFile: file-type sniff). */
 export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';

--- a/packages/claude-core/test/conditionImage.spec.ts
+++ b/packages/claude-core/test/conditionImage.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { buildDimensionArgs, buildResizeArgs, conditionImage, parseDimensions } from '../src/image/conditionImage';
 import type { SipsBridge } from '../src/image/SipsBridge';
+import type { ILogger } from '../src/logging/ILogger';
+
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 const PNG_BYTES = Buffer.from('conditioned-png-bytes');
 
@@ -52,13 +55,13 @@ describe('parseDimensions', () => {
 describe('conditionImage — resizes an oversized image', () => {
   it('uses the conditioned bytes', async () => {
     const expected = PNG_BYTES;
-    const { data: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes);
+    const { data: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes, noopLogger);
     expect(actual).toBe(expected);
   });
 
   it('reports image/png after resizing', async () => {
     const expected = 'image/png';
-    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes);
+    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes, noopLogger);
     expect(actual).toBe(expected);
   });
 });
@@ -67,13 +70,13 @@ describe('conditionImage — image within the cap', () => {
   it('returns the original bytes unchanged', async () => {
     const original = Buffer.from('small-original');
     const expected = original;
-    const { data: actual } = await conditionImage(original, 'image/png', smallEnough);
+    const { data: actual } = await conditionImage(original, 'image/png', smallEnough, noopLogger);
     expect(actual).toBe(expected);
   });
 
   it('keeps the original media type', async () => {
     const expected = 'image/png';
-    const { mediaType: actual } = await conditionImage(Buffer.from('small-original'), 'image/png', smallEnough);
+    const { mediaType: actual } = await conditionImage(Buffer.from('small-original'), 'image/png', smallEnough, noopLogger);
     expect(actual).toBe(expected);
   });
 });
@@ -82,27 +85,27 @@ describe('conditionImage — degrades to attach-as-is', () => {
   it('passes the original through when sips is absent', async () => {
     const original = Buffer.from('orig');
     const expected = original;
-    const { data: actual } = await conditionImage(original, 'image/jpeg', absent);
+    const { data: actual } = await conditionImage(original, 'image/jpeg', absent, noopLogger);
     expect(actual).toBe(expected);
   });
 
   it('passes the original through when sips is not invocable', async () => {
     const original = Buffer.from('orig');
     const expected = original;
-    const { data: actual } = await conditionImage(original, 'image/jpeg', notInvocable);
+    const { data: actual } = await conditionImage(original, 'image/jpeg', notInvocable, noopLogger);
     expect(actual).toBe(expected);
   });
 
   it('passes the original through when sips fails on the image', async () => {
     const original = Buffer.from('orig');
     const expected = original;
-    const { data: actual } = await conditionImage(original, 'image/jpeg', failsOnImage);
+    const { data: actual } = await conditionImage(original, 'image/jpeg', failsOnImage, noopLogger);
     expect(actual).toBe(expected);
   });
 
   it('keeps the original media type when sips fails on the image', async () => {
     const expected = 'image/jpeg';
-    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', failsOnImage);
+    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', failsOnImage, noopLogger);
     expect(actual).toBe(expected);
   });
 });

--- a/packages/claude-core/test/conditionImage.spec.ts
+++ b/packages/claude-core/test/conditionImage.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { buildDimensionArgs, buildResizeArgs, conditionImage, parseDimensions } from '../src/image/conditionImage';
+import type { SipsBridge } from '../src/image/SipsBridge';
+
+const PNG_BYTES = Buffer.from('conditioned-png-bytes');
+
+const resizes: SipsBridge = {
+  dimensions: () => Promise.resolve({ width: 4000, height: 3000 }),
+  resizeToPng: () => Promise.resolve(PNG_BYTES),
+};
+const smallEnough: SipsBridge = {
+  dimensions: () => Promise.resolve({ width: 1500, height: 800 }),
+  resizeToPng: () => Promise.reject(new Error('resize must not be called for a small image')),
+};
+const absent: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('spawn sips ENOENT')),
+  resizeToPng: () => Promise.reject(new Error('spawn sips ENOENT')),
+};
+const notInvocable: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('spawn sips EACCES')),
+  resizeToPng: () => Promise.reject(new Error('spawn sips EACCES')),
+};
+const failsOnImage: SipsBridge = {
+  dimensions: () => Promise.resolve({ width: 4000, height: 3000 }),
+  resizeToPng: () => Promise.reject(new Error('sips exited 13')),
+};
+
+describe('buildResizeArgs', () => {
+  it('builds a 2000px downscale-to-PNG sips invocation', () => {
+    const expected = ['-Z', '2000', '-s', 'format', 'png', '/tmp/in', '--out', '/tmp/out.png'];
+    const actual = buildResizeArgs('/tmp/in', '/tmp/out.png');
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('buildDimensionArgs', () => {
+  it('builds a pixel-dimension query invocation', () => {
+    const expected = ['-g', 'pixelWidth', '-g', 'pixelHeight', '/tmp/in'];
+    const actual = buildDimensionArgs('/tmp/in');
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('parseDimensions', () => {
+  it('reads pixelWidth and pixelHeight from sips output', () => {
+    const expected = { width: 3000, height: 2000 };
+    const actual = parseDimensions('/tmp/in\n  pixelWidth: 3000\n  pixelHeight: 2000\n');
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('conditionImage — resizes an oversized image', () => {
+  it('uses the conditioned bytes', async () => {
+    const expected = PNG_BYTES;
+    const { data: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes);
+    expect(actual).toBe(expected);
+  });
+
+  it('reports image/png after resizing', async () => {
+    const expected = 'image/png';
+    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', resizes);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('conditionImage — image within the cap', () => {
+  it('returns the original bytes unchanged', async () => {
+    const original = Buffer.from('small-original');
+    const expected = original;
+    const { data: actual } = await conditionImage(original, 'image/png', smallEnough);
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the original media type', async () => {
+    const expected = 'image/png';
+    const { mediaType: actual } = await conditionImage(Buffer.from('small-original'), 'image/png', smallEnough);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('conditionImage — degrades to attach-as-is', () => {
+  it('passes the original through when sips is absent', async () => {
+    const original = Buffer.from('orig');
+    const expected = original;
+    const { data: actual } = await conditionImage(original, 'image/jpeg', absent);
+    expect(actual).toBe(expected);
+  });
+
+  it('passes the original through when sips is not invocable', async () => {
+    const original = Buffer.from('orig');
+    const expected = original;
+    const { data: actual } = await conditionImage(original, 'image/jpeg', notInvocable);
+    expect(actual).toBe(expected);
+  });
+
+  it('passes the original through when sips fails on the image', async () => {
+    const original = Buffer.from('orig');
+    const expected = original;
+    const { data: actual } = await conditionImage(original, 'image/jpeg', failsOnImage);
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the original media type when sips fails on the image', async () => {
+    const expected = 'image/jpeg';
+    const { mediaType: actual } = await conditionImage(Buffer.from('orig'), 'image/jpeg', failsOnImage);
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ReadFile accepts image/* to read any supported image format; the format is detected from file content rather than the declared type
 - Regex pattern fields now reject a malformed pattern as a schema validation error, naming the cause, before any tool runs
 - Removed the 500KB limit on text file reads
+- Resize and normalise an image ReadFile result before it is attached, leaving non-image documents untouched
 - Tool handlers return structured output with textContent and optional attachments
 - Update runtime and build dependencies
 - Updated patch and minor dependencies

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -36,3 +36,4 @@
 {"description":"Regex pattern fields now reject a malformed pattern as a schema validation error, naming the cause, before any tool runs","category":"changed"}
 {"description":"Add ExecV3 structured execution tool","category":"added"}
 {"description":"Add atomic rename and platform lookup to the Node filesystem implementation","category":"added"}
+{"description":"Resize and normalise an image ReadFile result before it is attached, leaving non-image documents untouched","category":"changed"}

--- a/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
@@ -1,6 +1,7 @@
 import { expandPath } from '@shellicar/claude-core/fs/expandPath';
 import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import type { ToolAttachmentBlock } from '@shellicar/claude-sdk';
 import { defineTool } from '@shellicar/claude-sdk';
@@ -17,7 +18,7 @@ const HEADER_BASE64_CHARS = 5600;
 
 type DetectResult = { kind: 'text'; lines: string[] } | { kind: 'binary'; mimeType: BinaryMimeType; block: ToolAttachmentBlock };
 
-async function detectBlock(header: Buffer, data: string, inputMimeType: InputMimeType, sips: SipsBridge): Promise<DetectResult | null> {
+async function detectBlock(header: Buffer, data: string, inputMimeType: InputMimeType, sips: SipsBridge, logger: ILogger): Promise<DetectResult | null> {
   const type = await fileTypeFromBuffer(header);
 
   switch (type?.mime) {
@@ -38,7 +39,7 @@ async function detectBlock(header: Buffer, data: string, inputMimeType: InputMim
       if (inputMimeType !== 'image/*') {
         return null;
       }
-      const conditioned = await conditionImage(Buffer.from(data, 'base64'), type.mime, sips);
+      const conditioned = await conditionImage(Buffer.from(data, 'base64'), type.mime, sips, logger);
       const outData = conditioned.data.toString('base64');
       return { kind: 'binary', mimeType: conditioned.mediaType, block: { type: 'image', source: { type: 'base64', media_type: conditioned.mediaType, data: outData } } };
     }
@@ -47,7 +48,7 @@ async function detectBlock(header: Buffer, data: string, inputMimeType: InputMim
   }
 }
 
-export function createReadFile(fs: IFileSystem, sips: SipsBridge) {
+export function createReadFile(fs: IFileSystem, sips: SipsBridge, logger: ILogger) {
   return defineTool({
     name: 'ReadFile',
     description: 'Read a single file outside a pipe. Text returns as line-numbered content; PDFs and images (png, jpeg, gif, webp) return as native document/image blocks via the mimeType parameter. To read files inside a pipe, use Paths | Read.',
@@ -91,7 +92,7 @@ export function createReadFile(fs: IFileSystem, sips: SipsBridge) {
       }
 
       const header = Buffer.from(data.slice(0, HEADER_BASE64_CHARS), 'base64');
-      const result = await detectBlock(header, data, input.mimeType, sips);
+      const result = await detectBlock(header, data, input.mimeType, sips, logger);
 
       if (!result) {
         return {

--- a/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
@@ -1,5 +1,7 @@
 import { expandPath } from '@shellicar/claude-core/fs/expandPath';
 import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
+import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import type { ToolAttachmentBlock } from '@shellicar/claude-sdk';
 import { defineTool } from '@shellicar/claude-sdk';
 import { fileTypeFromBuffer } from 'file-type';
@@ -15,7 +17,7 @@ const HEADER_BASE64_CHARS = 5600;
 
 type DetectResult = { kind: 'text'; lines: string[] } | { kind: 'binary'; mimeType: BinaryMimeType; block: ToolAttachmentBlock };
 
-async function detectBlock(header: Buffer, data: string, inputMimeType: InputMimeType): Promise<DetectResult | null> {
+async function detectBlock(header: Buffer, data: string, inputMimeType: InputMimeType, sips: SipsBridge): Promise<DetectResult | null> {
   const type = await fileTypeFromBuffer(header);
 
   switch (type?.mime) {
@@ -32,17 +34,20 @@ async function detectBlock(header: Buffer, data: string, inputMimeType: InputMim
     case 'image/jpeg':
     case 'image/png':
     case 'image/gif':
-    case 'image/webp':
+    case 'image/webp': {
       if (inputMimeType !== 'image/*') {
         return null;
       }
-      return { kind: 'binary', mimeType: type.mime, block: { type: 'image', source: { type: 'base64', media_type: type.mime, data } } };
+      const conditioned = await conditionImage(Buffer.from(data, 'base64'), type.mime, sips);
+      const outData = conditioned.data.toString('base64');
+      return { kind: 'binary', mimeType: conditioned.mediaType, block: { type: 'image', source: { type: 'base64', media_type: conditioned.mediaType, data: outData } } };
+    }
     default:
       return null;
   }
 }
 
-export function createReadFile(fs: IFileSystem) {
+export function createReadFile(fs: IFileSystem, sips: SipsBridge) {
   return defineTool({
     name: 'ReadFile',
     description: 'Read a single file outside a pipe. Text returns as line-numbered content; PDFs and images (png, jpeg, gif, webp) return as native document/image blocks via the mimeType parameter. To read files inside a pipe, use Paths | Read.',
@@ -86,7 +91,7 @@ export function createReadFile(fs: IFileSystem) {
       }
 
       const header = Buffer.from(data.slice(0, HEADER_BASE64_CHARS), 'base64');
-      const result = await detectBlock(header, data, input.mimeType);
+      const result = await detectBlock(header, data, input.mimeType, sips);
 
       if (!result) {
         return {
@@ -99,8 +104,9 @@ export function createReadFile(fs: IFileSystem) {
       }
 
       if (result.kind === 'binary' && result.mimeType.startsWith('image/')) {
-        if (data.length > IMAGE_BASE64_MAX_BYTES) {
-          const kb = Math.round(data.length / 1024);
+        const imageData = result.block.source.data;
+        if (imageData.length > IMAGE_BASE64_MAX_BYTES) {
+          const kb = Math.round(imageData.length / 1024);
           return {
             textContent: {
               error: true,

--- a/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
@@ -1,8 +1,8 @@
 import { expandPath } from '@shellicar/claude-core/fs/expandPath';
 import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
-import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { ToolAttachmentBlock } from '@shellicar/claude-sdk';
 import { defineTool } from '@shellicar/claude-sdk';
 import { fileTypeFromBuffer } from 'file-type';

--- a/packages/claude-sdk-tools/src/entry/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/entry/ReadFile.ts
@@ -1,4 +1,5 @@
+import { NodeSipsBridge } from '@shellicar/claude-core/image/NodeSipsBridge';
 import { nodeFs } from '../fs/nodeFs.js';
 import { createReadFile } from '../ReadFile/ReadFile';
 
-export const ReadFile = createReadFile(nodeFs);
+export const ReadFile = createReadFile(nodeFs, new NodeSipsBridge());

--- a/packages/claude-sdk-tools/src/entry/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/entry/ReadFile.ts
@@ -1,5 +1,8 @@
 import { NodeSipsBridge } from '@shellicar/claude-core/image/NodeSipsBridge';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { nodeFs } from '../fs/nodeFs.js';
 import { createReadFile } from '../ReadFile/ReadFile';
 
-export const ReadFile = createReadFile(nodeFs, new NodeSipsBridge());
+// The real sips bridge is constructed here, but the logger is injected by the app so the tool's
+// conditioning outcomes land in the app's debug log (this package has no logger of its own).
+export const createReadFileTool = (logger: ILogger) => createReadFile(nodeFs, new NodeSipsBridge(), logger);

--- a/packages/claude-sdk-tools/test/ReadFile.spec.ts
+++ b/packages/claude-sdk-tools/test/ReadFile.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createReadFile } from '../src/ReadFile/ReadFile';
 import type { ReadFileBinarySuccess, ReadFileOutputFailure } from '../src/ReadFile/types';
-import { call, callFull } from './helpers';
+import { call, callFull, passthroughSips } from './helpers';
 import { MemoryFileSystem } from './MemoryFileSystem';
 
 const makeFs = () =>
@@ -12,7 +12,7 @@ const makeFs = () =>
 
 describe('createReadFile \u2014 success', () => {
   it('returns lines as content output', async () => {
-    const ReadFile = createReadFile(makeFs());
+    const ReadFile = createReadFile(makeFs(), passthroughSips);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     expect(result).toMatchObject({
       type: 'content',
@@ -23,20 +23,20 @@ describe('createReadFile \u2014 success', () => {
   });
 
   it('returns a single-element array for a single-line file', async () => {
-    const ReadFile = createReadFile(makeFs());
+    const ReadFile = createReadFile(makeFs(), passthroughSips);
     const result = await call(ReadFile, { path: '/src/single.ts' });
     expect(result).toMatchObject({ type: 'content', values: ['single line'], totalLines: 1 });
   });
 
   it('returns correct totalLines matching values length', async () => {
-    const ReadFile = createReadFile(makeFs());
+    const ReadFile = createReadFile(makeFs(), passthroughSips);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     const content = result as { values: string[]; totalLines: number };
     expect(content.totalLines).toBe(content.values.length);
   });
 
   it('echoes the resolved path in the output', async () => {
-    const ReadFile = createReadFile(makeFs());
+    const ReadFile = createReadFile(makeFs(), passthroughSips);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     expect((result as { path: string }).path).toBe('/src/hello.ts');
   });
@@ -44,7 +44,7 @@ describe('createReadFile \u2014 success', () => {
 
 describe('createReadFile \u2014 error handling', () => {
   it('returns an error object for a missing file', async () => {
-    const ReadFile = createReadFile(makeFs());
+    const ReadFile = createReadFile(makeFs(), passthroughSips);
     const result = await call(ReadFile, { path: '/src/missing.ts' });
     expect(result).toMatchObject({ error: true, message: 'File not found', path: '/src/missing.ts' });
   });
@@ -54,7 +54,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent type is binary for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'binary';
@@ -65,7 +65,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent mimeType is application/pdf', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'application/pdf';
@@ -76,7 +76,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent has no data field for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -87,7 +87,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachments has one entry for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 1;
@@ -98,7 +98,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment type is document for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'document';
@@ -109,7 +109,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment source media_type is application/pdf', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'application/pdf';
@@ -120,7 +120,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment source data is base64 encoded file content', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = Buffer.from(pdfContent).toString('base64');
@@ -131,7 +131,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('sets error flag for PDFs exceeding 32 MB', async () => {
     const bigContent = 'x'.repeat(33 * 1024 * 1024);
     const fs = new MemoryFileSystem({ '/docs/huge.pdf': bigContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/huge.pdf', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -142,7 +142,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('omits attachments for PDFs exceeding 32 MB', async () => {
     const bigContent = 'x'.repeat(33 * 1024 * 1024);
     const fs = new MemoryFileSystem({ '/docs/huge.pdf': bigContent });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/huge.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -152,7 +152,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('sets error flag when file content does not match declared mime type', async () => {
     const fs = new MemoryFileSystem({ '/docs/fake.pdf': 'not-a-pdf content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/fake.pdf', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -162,7 +162,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments when file content does not match declared mime type', async () => {
     const fs = new MemoryFileSystem({ '/docs/fake.pdf': 'not-a-pdf content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/fake.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -172,7 +172,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('textContent type is content for text/plain', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'text/plain' });
 
     const expected = 'content';
@@ -182,7 +182,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments for text/plain', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'text/plain' });
 
     const expected = undefined;
@@ -192,7 +192,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('textContent type is content when mimeType defaults', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'line1' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts' });
 
     const expected = 'content';
@@ -202,7 +202,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments when mimeType defaults', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'line1' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts' });
 
     const expected = undefined;
@@ -227,7 +227,7 @@ const webpMagic = Buffer.concat([Buffer.from('RIFF'), Buffer.from([0x00, 0x00, 0
 describe('createReadFile — image/* wildcard', () => {
   it('detects GIF mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'image/*' });
 
     const expected = 'image/gif';
@@ -237,7 +237,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for GIF', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'image/*' });
 
     const expected = 'image/gif';
@@ -247,7 +247,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects JPEG mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/photo.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/photo.jpg', mimeType: 'image/*' });
 
     const expected = 'image/jpeg';
@@ -257,7 +257,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for JPEG', async () => {
     const fs = new MemoryFileSystem({ '/images/photo.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/photo.jpg', mimeType: 'image/*' });
 
     const expected = 'image/jpeg';
@@ -267,7 +267,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects PNG mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/icon.png': pngMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/icon.png', mimeType: 'image/*' });
 
     const expected = 'image/png';
@@ -277,7 +277,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for PNG', async () => {
     const fs = new MemoryFileSystem({ '/images/icon.png': pngMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/icon.png', mimeType: 'image/*' });
 
     const expected = 'image/png';
@@ -287,7 +287,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects WebP mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/img.webp': webpMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/img.webp', mimeType: 'image/*' });
 
     const expected = 'image/webp';
@@ -297,7 +297,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for WebP', async () => {
     const fs = new MemoryFileSystem({ '/images/img.webp': webpMagic });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/img.webp', mimeType: 'image/*' });
 
     const expected = 'image/webp';
@@ -307,7 +307,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when a PDF is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'image/*' });
 
     const expected = true;
@@ -317,7 +317,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when a PDF is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'image/*' });
 
     const expected = undefined;
@@ -327,7 +327,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when plain text is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'image/*' });
 
     const expected = true;
@@ -337,7 +337,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when plain text is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'image/*' });
 
     const expected = undefined;
@@ -347,7 +347,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when a GIF is requested as application/pdf', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -357,7 +357,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when a GIF is requested as application/pdf', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -374,7 +374,7 @@ describe('createReadFile — unsupported binary type', () => {
   it('sets error flag for a recognised but unsupported binary file read as text/plain', async () => {
     // ELF magic bytes (0x7F E L F) are all < 0x80 and survive UTF-8 encoding in MemoryFileSystem
     const fs = new MemoryFileSystem({ '/bin/tool': '\x7FELF fake elf content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/bin/tool' });
 
     const expected = true;
@@ -384,7 +384,7 @@ describe('createReadFile — unsupported binary type', () => {
 
   it('omits attachments for a recognised but unsupported binary file read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/bin/tool': '\x7FELF fake elf content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/bin/tool' });
 
     const expected = undefined;
@@ -400,7 +400,7 @@ describe('createReadFile — unsupported binary type', () => {
 describe('createReadFile — mime type mismatch', () => {
   it('sets error flag when a PDF file is read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf' });
 
     const expected = true;
@@ -410,7 +410,7 @@ describe('createReadFile — mime type mismatch', () => {
 
   it('omits attachments when a PDF file is read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf' });
 
     const expected = undefined;
@@ -421,7 +421,7 @@ describe('createReadFile — mime type mismatch', () => {
   it('sets error flag when a GIF file is read as text/plain', async () => {
     // GIF magic bytes 'GIF8' are ASCII — correct round-trip through MemoryFileSystem
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs);
+    const ReadFile = createReadFile(fs, passthroughSips);
     const result = await callFull(ReadFile, { path: '/images/anim.gif' });
 
     const expected = true;
@@ -446,7 +446,7 @@ describe('createReadFile — image size limit', () => {
   describe('when image base64 payload exceeds the 5 MB cap', () => {
     it('returns the failure shape', async () => {
       const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
 
       const expected = true;
@@ -456,7 +456,7 @@ describe('createReadFile — image size limit', () => {
 
     it('message identifies the breach', async () => {
       const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
 
       const actual = (result.textContent as ReadFileOutputFailure).message;
@@ -467,7 +467,7 @@ describe('createReadFile — image size limit', () => {
   describe('when image base64 payload is at or below the 5 MB cap', () => {
     it('returns a binary result when payload is exactly at the cap', async () => {
       const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
 
       const expected = 'binary';
@@ -477,7 +477,7 @@ describe('createReadFile — image size limit', () => {
 
     it('includes an attachment when payload is exactly at the cap', async () => {
       const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
 
       const expected = 1;
@@ -487,7 +487,7 @@ describe('createReadFile — image size limit', () => {
 
     it('a small PNG returns a binary result', async () => {
       const fs = new MemoryFileSystem({ '/images/small.png': pngMagic });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/images/small.png', mimeType: 'image/*' });
 
       const expected = 'binary';
@@ -499,7 +499,7 @@ describe('createReadFile — image size limit', () => {
   describe('when a PDF exceeds 5 MB base64', () => {
     it('returns a binary result because PDFs are not subject to the image cap', async () => {
       const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
 
       const expected = 'binary';
@@ -509,12 +509,64 @@ describe('createReadFile — image size limit', () => {
 
     it('includes an attachment for the PDF', async () => {
       const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
-      const ReadFile = createReadFile(fs);
+      const ReadFile = createReadFile(fs, passthroughSips);
       const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
 
       const expected = 1;
       const actual = result.attachments?.length;
       expect(actual).toBe(expected);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// image conditioning on attach
+// ---------------------------------------------------------------------------
+
+import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+
+const neverSips: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('sips must not run for a non-image')),
+  resizeToPng: () => Promise.reject(new Error('sips must not run for a non-image')),
+};
+
+describe('createReadFile — conditioning leaves non-images alone', () => {
+  it('emits the PDF bytes untouched', async () => {
+    const pdf = '%PDF-1.4 fake content';
+    const fs = new MemoryFileSystem({ '/docs/report.pdf': pdf });
+    const ReadFile = createReadFile(fs, neverSips);
+    const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
+
+    const expected = Buffer.from(pdf).toString('base64');
+    const actual = result.attachments?.[0]?.source.data;
+    expect(actual).toBe(expected);
+  });
+});
+
+const conditionedPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xaa, 0xbb]);
+const resizes: SipsBridge = {
+  dimensions: () => Promise.resolve({ width: 4000, height: 3000 }),
+  resizeToPng: () => Promise.resolve(conditionedPng),
+};
+
+describe('createReadFile — conditions an oversized image', () => {
+  it('emits the conditioned PNG bytes', async () => {
+    const fs = new MemoryFileSystem({ '/images/big.jpg': jpegMagic });
+    const ReadFile = createReadFile(fs, resizes);
+    const result = await callFull(ReadFile, { path: '/images/big.jpg', mimeType: 'image/*' });
+
+    const expected = conditionedPng.toString('base64');
+    const actual = result.attachments?.[0]?.source.data;
+    expect(actual).toBe(expected);
+  });
+
+  it('re-labels the conditioned image as image/png', async () => {
+    const fs = new MemoryFileSystem({ '/images/big.jpg': jpegMagic });
+    const ReadFile = createReadFile(fs, resizes);
+    const result = await callFull(ReadFile, { path: '/images/big.jpg', mimeType: 'image/*' });
+
+    const expected = 'image/png';
+    const actual = result.attachments?.[0]?.source.media_type;
+    expect(actual).toBe(expected);
   });
 });

--- a/packages/claude-sdk-tools/test/ReadFile.spec.ts
+++ b/packages/claude-sdk-tools/test/ReadFile.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createReadFile } from '../src/ReadFile/ReadFile';
 import type { ReadFileBinarySuccess, ReadFileOutputFailure } from '../src/ReadFile/types';
-import { call, callFull, passthroughSips } from './helpers';
+import { call, callFull, noopLogger, passthroughSips } from './helpers';
 import { MemoryFileSystem } from './MemoryFileSystem';
 
 const makeFs = () =>
@@ -12,7 +12,7 @@ const makeFs = () =>
 
 describe('createReadFile \u2014 success', () => {
   it('returns lines as content output', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips);
+    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     expect(result).toMatchObject({
       type: 'content',
@@ -23,20 +23,20 @@ describe('createReadFile \u2014 success', () => {
   });
 
   it('returns a single-element array for a single-line file', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips);
+    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/single.ts' });
     expect(result).toMatchObject({ type: 'content', values: ['single line'], totalLines: 1 });
   });
 
   it('returns correct totalLines matching values length', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips);
+    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     const content = result as { values: string[]; totalLines: number };
     expect(content.totalLines).toBe(content.values.length);
   });
 
   it('echoes the resolved path in the output', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips);
+    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
     expect((result as { path: string }).path).toBe('/src/hello.ts');
   });
@@ -44,7 +44,7 @@ describe('createReadFile \u2014 success', () => {
 
 describe('createReadFile \u2014 error handling', () => {
   it('returns an error object for a missing file', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips);
+    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/missing.ts' });
     expect(result).toMatchObject({ error: true, message: 'File not found', path: '/src/missing.ts' });
   });
@@ -54,7 +54,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent type is binary for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'binary';
@@ -65,7 +65,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent mimeType is application/pdf', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'application/pdf';
@@ -76,7 +76,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('textContent has no data field for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -87,7 +87,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachments has one entry for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 1;
@@ -98,7 +98,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment type is document for PDF', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'document';
@@ -109,7 +109,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment source media_type is application/pdf', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = 'application/pdf';
@@ -120,7 +120,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('attachment source data is base64 encoded file content', async () => {
     const pdfContent = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdfContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = Buffer.from(pdfContent).toString('base64');
@@ -131,7 +131,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('sets error flag for PDFs exceeding 32 MB', async () => {
     const bigContent = 'x'.repeat(33 * 1024 * 1024);
     const fs = new MemoryFileSystem({ '/docs/huge.pdf': bigContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/huge.pdf', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -142,7 +142,7 @@ describe('createReadFile — binary files (mimeType)', () => {
   it('omits attachments for PDFs exceeding 32 MB', async () => {
     const bigContent = 'x'.repeat(33 * 1024 * 1024);
     const fs = new MemoryFileSystem({ '/docs/huge.pdf': bigContent });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/huge.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -152,7 +152,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('sets error flag when file content does not match declared mime type', async () => {
     const fs = new MemoryFileSystem({ '/docs/fake.pdf': 'not-a-pdf content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/fake.pdf', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -162,7 +162,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments when file content does not match declared mime type', async () => {
     const fs = new MemoryFileSystem({ '/docs/fake.pdf': 'not-a-pdf content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/fake.pdf', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -172,7 +172,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('textContent type is content for text/plain', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'text/plain' });
 
     const expected = 'content';
@@ -182,7 +182,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments for text/plain', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'text/plain' });
 
     const expected = undefined;
@@ -192,7 +192,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('textContent type is content when mimeType defaults', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'line1' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts' });
 
     const expected = 'content';
@@ -202,7 +202,7 @@ describe('createReadFile — binary files (mimeType)', () => {
 
   it('omits attachments when mimeType defaults', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'line1' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts' });
 
     const expected = undefined;
@@ -227,7 +227,7 @@ const webpMagic = Buffer.concat([Buffer.from('RIFF'), Buffer.from([0x00, 0x00, 0
 describe('createReadFile — image/* wildcard', () => {
   it('detects GIF mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'image/*' });
 
     const expected = 'image/gif';
@@ -237,7 +237,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for GIF', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'image/*' });
 
     const expected = 'image/gif';
@@ -247,7 +247,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects JPEG mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/photo.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/photo.jpg', mimeType: 'image/*' });
 
     const expected = 'image/jpeg';
@@ -257,7 +257,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for JPEG', async () => {
     const fs = new MemoryFileSystem({ '/images/photo.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/photo.jpg', mimeType: 'image/*' });
 
     const expected = 'image/jpeg';
@@ -267,7 +267,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects PNG mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/icon.png': pngMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/icon.png', mimeType: 'image/*' });
 
     const expected = 'image/png';
@@ -277,7 +277,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for PNG', async () => {
     const fs = new MemoryFileSystem({ '/images/icon.png': pngMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/icon.png', mimeType: 'image/*' });
 
     const expected = 'image/png';
@@ -287,7 +287,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('detects WebP mimeType from content', async () => {
     const fs = new MemoryFileSystem({ '/images/img.webp': webpMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/img.webp', mimeType: 'image/*' });
 
     const expected = 'image/webp';
@@ -297,7 +297,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('returns an image attachment for WebP', async () => {
     const fs = new MemoryFileSystem({ '/images/img.webp': webpMagic });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/img.webp', mimeType: 'image/*' });
 
     const expected = 'image/webp';
@@ -307,7 +307,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when a PDF is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'image/*' });
 
     const expected = true;
@@ -317,7 +317,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when a PDF is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'image/*' });
 
     const expected = undefined;
@@ -327,7 +327,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when plain text is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'image/*' });
 
     const expected = true;
@@ -337,7 +337,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when plain text is requested as image/*', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'image/*' });
 
     const expected = undefined;
@@ -347,7 +347,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('sets error flag when a GIF is requested as application/pdf', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'application/pdf' });
 
     const expected = true;
@@ -357,7 +357,7 @@ describe('createReadFile — image/* wildcard', () => {
 
   it('omits attachments when a GIF is requested as application/pdf', async () => {
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/anim.gif', mimeType: 'application/pdf' });
 
     const expected = undefined;
@@ -374,7 +374,7 @@ describe('createReadFile — unsupported binary type', () => {
   it('sets error flag for a recognised but unsupported binary file read as text/plain', async () => {
     // ELF magic bytes (0x7F E L F) are all < 0x80 and survive UTF-8 encoding in MemoryFileSystem
     const fs = new MemoryFileSystem({ '/bin/tool': '\x7FELF fake elf content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/bin/tool' });
 
     const expected = true;
@@ -384,7 +384,7 @@ describe('createReadFile — unsupported binary type', () => {
 
   it('omits attachments for a recognised but unsupported binary file read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/bin/tool': '\x7FELF fake elf content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/bin/tool' });
 
     const expected = undefined;
@@ -400,7 +400,7 @@ describe('createReadFile — unsupported binary type', () => {
 describe('createReadFile — mime type mismatch', () => {
   it('sets error flag when a PDF file is read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf' });
 
     const expected = true;
@@ -410,7 +410,7 @@ describe('createReadFile — mime type mismatch', () => {
 
   it('omits attachments when a PDF file is read as text/plain', async () => {
     const fs = new MemoryFileSystem({ '/docs/report.pdf': '%PDF-1.4 fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf' });
 
     const expected = undefined;
@@ -421,7 +421,7 @@ describe('createReadFile — mime type mismatch', () => {
   it('sets error flag when a GIF file is read as text/plain', async () => {
     // GIF magic bytes 'GIF8' are ASCII — correct round-trip through MemoryFileSystem
     const fs = new MemoryFileSystem({ '/images/anim.gif': 'GIF89a fake content' });
-    const ReadFile = createReadFile(fs, passthroughSips);
+    const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/anim.gif' });
 
     const expected = true;
@@ -446,7 +446,7 @@ describe('createReadFile — image size limit', () => {
   describe('when image base64 payload exceeds the 5 MB cap', () => {
     it('returns the failure shape', async () => {
       const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
 
       const expected = true;
@@ -456,7 +456,7 @@ describe('createReadFile — image size limit', () => {
 
     it('message identifies the breach', async () => {
       const fs = new MemoryFileSystem({ '/images/big.png': overLimitPng });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/images/big.png', mimeType: 'image/*' });
 
       const actual = (result.textContent as ReadFileOutputFailure).message;
@@ -467,7 +467,7 @@ describe('createReadFile — image size limit', () => {
   describe('when image base64 payload is at or below the 5 MB cap', () => {
     it('returns a binary result when payload is exactly at the cap', async () => {
       const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
 
       const expected = 'binary';
@@ -477,7 +477,7 @@ describe('createReadFile — image size limit', () => {
 
     it('includes an attachment when payload is exactly at the cap', async () => {
       const fs = new MemoryFileSystem({ '/images/ok.png': atLimitPng });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/images/ok.png', mimeType: 'image/*' });
 
       const expected = 1;
@@ -487,7 +487,7 @@ describe('createReadFile — image size limit', () => {
 
     it('a small PNG returns a binary result', async () => {
       const fs = new MemoryFileSystem({ '/images/small.png': pngMagic });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/images/small.png', mimeType: 'image/*' });
 
       const expected = 'binary';
@@ -499,7 +499,7 @@ describe('createReadFile — image size limit', () => {
   describe('when a PDF exceeds 5 MB base64', () => {
     it('returns a binary result because PDFs are not subject to the image cap', async () => {
       const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
 
       const expected = 'binary';
@@ -509,7 +509,7 @@ describe('createReadFile — image size limit', () => {
 
     it('includes an attachment for the PDF', async () => {
       const fs = new MemoryFileSystem({ '/docs/big.pdf': overLimitPdf });
-      const ReadFile = createReadFile(fs, passthroughSips);
+      const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
       const result = await callFull(ReadFile, { path: '/docs/big.pdf', mimeType: 'application/pdf' });
 
       const expected = 1;
@@ -534,7 +534,7 @@ describe('createReadFile — conditioning leaves non-images alone', () => {
   it('emits the PDF bytes untouched', async () => {
     const pdf = '%PDF-1.4 fake content';
     const fs = new MemoryFileSystem({ '/docs/report.pdf': pdf });
-    const ReadFile = createReadFile(fs, neverSips);
+    const ReadFile = createReadFile(fs, neverSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/docs/report.pdf', mimeType: 'application/pdf' });
 
     const expected = Buffer.from(pdf).toString('base64');
@@ -552,7 +552,7 @@ const resizes: SipsBridge = {
 describe('createReadFile — conditions an oversized image', () => {
   it('emits the conditioned PNG bytes', async () => {
     const fs = new MemoryFileSystem({ '/images/big.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs, resizes);
+    const ReadFile = createReadFile(fs, resizes, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/big.jpg', mimeType: 'image/*' });
 
     const expected = conditionedPng.toString('base64');
@@ -562,7 +562,7 @@ describe('createReadFile — conditions an oversized image', () => {
 
   it('re-labels the conditioned image as image/png', async () => {
     const fs = new MemoryFileSystem({ '/images/big.jpg': jpegMagic });
-    const ReadFile = createReadFile(fs, resizes);
+    const ReadFile = createReadFile(fs, resizes, noopLogger);
     const result = await callFull(ReadFile, { path: '/images/big.jpg', mimeType: 'image/*' });
 
     const expected = 'image/png';

--- a/packages/claude-sdk-tools/test/helpers.ts
+++ b/packages/claude-sdk-tools/test/helpers.ts
@@ -1,5 +1,12 @@
+import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import type { ToolAttachmentBlock, ToolDefinition } from '@shellicar/claude-sdk';
 import type { z } from 'zod';
+
+/** Test double: sips unavailable, so ReadFile images pass through unconditioned. */
+export const passthroughSips: SipsBridge = {
+  dimensions: () => Promise.reject(new Error('no sips in tests')),
+  resizeToPng: () => Promise.reject(new Error('no sips in tests')),
+};
 
 export async function call<T extends z.ZodType, TOut extends z.ZodType>(tool: ToolDefinition<T, TOut>, input: z.input<T>): Promise<z.output<TOut>> {
   const { textContent } = await tool.handler(tool.input_schema.parse(input));

--- a/packages/claude-sdk-tools/test/helpers.ts
+++ b/packages/claude-sdk-tools/test/helpers.ts
@@ -1,4 +1,5 @@
 import type { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { ToolAttachmentBlock, ToolDefinition } from '@shellicar/claude-sdk';
 import type { z } from 'zod';
 
@@ -7,6 +8,9 @@ export const passthroughSips: SipsBridge = {
   dimensions: () => Promise.reject(new Error('no sips in tests')),
   resizeToPng: () => Promise.reject(new Error('no sips in tests')),
 };
+
+/** Test double: a logger that discards everything, so the tool builds without the app's logger. */
+export const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 export async function call<T extends z.ZodType, TOut extends z.ZodType>(tool: ToolDefinition<T, TOut>, input: z.input<T>): Promise<z.output<TOut>> {
   const { textContent } = await tool.handler(tool.input_schema.parse(input));


### PR DESCRIPTION
## Summary

- Resize and normalise every attached image to a 2000px PNG long edge via sips, downscaling only, so an oversized image can no longer exceed the request-size limit and take down the conversation
- Cover both attach paths: clipboard paste and image ReadFile results, leaving non-image documents untouched
- Degrade to attach-as-is when sips is absent or fails on an image, never blocking the attachment or the turn
- Log each conditioning outcome to the debug log, so the silent passthrough is visible in the field