### PR TITLE
Count tool approval wait as tool time in the status-line clock

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `typescript` as a production dependency so consumers do not need it installed separately
 - Apply biome formatting fixes
+- Count tool approval wait time as tool time in the status-line clock
 - Default `compact.enabled` to `false`
 - Delete the whole grapheme cluster on backspace and forward delete, so an emoji like ❤️ is removed in one keypress instead of leaving a stray character behind
 - Disable extended thinking correctly: send `thinking: {type: "disabled"}` and omit `output_config` when thinking is off

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -92,3 +92,4 @@
 {"description":"Publish conversation activity as opt-in NATS tap events","category":"added"}
 {"description":"Add --system-identity flag so a conversation owns the actor it casts Claude as, persisted in sqlite and restored on resume","category":"added"}
 {"description":"Add the --system-identity flag: bind a system prompt to a conversation from a file, persisted and restored on resume","category":"added"}
+{"description":"Count tool approval wait time as tool time in the status-line clock","category":"fixed"}

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bracket the whole tool-handling method as tool time, so the tools clock includes the approval wait
 - Calculate costs for Opus 4.7
 - Carry structured API error detail (status, type, message) to consumers, not only the status
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -39,3 +39,4 @@
 {"description":"Keep CLAUDE.md context present in every request after compaction (it previously dropped out)","category":"fixed"}
 {"description":"Carry structured API error detail (status, type, message) to consumers, not only the status","category":"fixed"}
 {"description":"Add updateIdentityBody to the durable config provider, folding a live system-identity body in as the first system prompt on the next config read","category":"added"}
+{"description":"Bracket the whole tool-handling method as tool time, so the tools clock includes the approval wait","category":"fixed"}

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -177,6 +177,22 @@ export class QueryRunner extends IQueryRunner {
   }
 
   /**
+   * Tool-time bracket. The tools clock is on for the whole extent of tool
+   * handling: it starts on entry and stops on every exit — normal return,
+   * thrown error, or an empty/all-rejected batch where nothing runs. The
+   * approval wait, and any path where no tool actually runs, fall inside the
+   * bracket, so that time counts as tool time instead of going unattributed.
+   */
+  async #handleTools(toolUses: ToolUseResult[], transformToolResult: TransformToolResult | undefined) {
+    this.toolsClock.toolsStarted();
+    try {
+      return await this.#runTools(toolUses, transformToolResult);
+    } finally {
+      this.toolsClock.toolsStopped();
+    }
+  }
+
+  /**
    * Tool dispatch logic, structured around `IToolRegistry.resolve`.
    *
    * Two phases:
@@ -192,7 +208,7 @@ export class QueryRunner extends IQueryRunner {
    *    run sequentially in the model's order. Both paths respect the
    *    `cancelled` flag between items.
    */
-  async #handleTools(toolUses: ToolUseResult[], transformToolResult: TransformToolResult | undefined) {
+  async #runTools(toolUses: ToolUseResult[], transformToolResult: TransformToolResult | undefined) {
     const requireApproval = this.durableProvider.config.requireToolApproval ?? false;
     const toolResults: ToolResultBlock[] = [];
     // A tool-scoped controller, distinct from the query's AbortController. ESC
@@ -200,17 +216,6 @@ export class QueryRunner extends IQueryRunner {
     // delivery turn still has the query's live signal. One controller per batch:
     // a cancel aborts every Exec tool in the batch (see Open decision 2).
     const toolController = new AbortController();
-    // Tools clock: starts at the first tool that actually runs, stops after the last.
-    // Anything before that first run (resolving tools, waiting for the first approval)
-    // is not counted, because the clock has not started yet. Once it starts, pauses
-    // between tools (a later approval, or just the handoff) count as tools time.
-    let toolsRunning = false;
-    const beginToolExecution = (): void => {
-      if (!toolsRunning) {
-        toolsRunning = true;
-        this.toolsClock.toolsStarted();
-      }
-    };
 
     // Phase 1: resolve and filter. Parse every tool_use once; route errors
     // to immediate tool_result blocks without requesting approval or
@@ -263,7 +268,6 @@ export class QueryRunner extends IQueryRunner {
           continue;
         }
 
-        beginToolExecution();
         this.approval.toolRunStarted(toolController);
         try {
           toolResults.push(await run(transformToolResult));
@@ -276,7 +280,6 @@ export class QueryRunner extends IQueryRunner {
         if (this.approval.cancelled) {
           break;
         }
-        beginToolExecution();
         this.approval.toolRunStarted(toolController);
         try {
           toolResults.push(await run(transformToolResult));
@@ -284,10 +287,6 @@ export class QueryRunner extends IQueryRunner {
           this.approval.toolRunFinished();
         }
       }
-    }
-
-    if (toolsRunning) {
-      this.toolsClock.toolsStopped();
     }
     return toolResults;
   }

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -89,6 +89,19 @@ class NoopToolsClock extends IToolsClockListener {
   public toolsStopped(): void {}
 }
 
+// Records the tools-clock edges so a test can prove the bracket opened and
+// closed even on a path where no tool actually runs.
+class SpyToolsClock extends IToolsClockListener {
+  public startedCount = 0;
+  public stoppedCount = 0;
+  public toolsStarted(): void {
+    this.startedCount++;
+  }
+  public toolsStopped(): void {
+    this.stoppedCount++;
+  }
+}
+
 class NoopLogger extends ILogger {
   public trace(): void {}
   public debug(): void {}
@@ -219,7 +232,7 @@ type Wiring = {
   queryRunner: QueryRunner;
 };
 
-function makeWiring(responses: Array<MessageStreamResult | Error>, tools: AnyToolDefinition[] = [], durableOverrides: Partial<DurableConfig> = {}, conversation?: Conversation): Wiring {
+function makeWiring(responses: Array<MessageStreamResult | Error>, tools: AnyToolDefinition[] = [], durableOverrides: Partial<DurableConfig> = {}, conversation?: Conversation, toolsClock: IToolsClockListener = new NoopToolsClock()): Wiring {
   const turnRunner = new FakeTurnRunner(responses);
   const approval = new ApprovalCoordinator();
   const channel = new FakeSdkPublisher();
@@ -236,7 +249,7 @@ function makeWiring(responses: Array<MessageStreamResult | Error>, tools: AnyToo
   services.register(ISdkMessagePublisher).to(ISdkMessagePublisher, () => channel);
   services.register(IDurableConfigProvider).to(IDurableConfigProvider, () => durableProvider);
   services.register(ILogger).to(ILogger, () => new NoopLogger());
-  services.register(IToolsClockListener).to(IToolsClockListener, () => new NoopToolsClock());
+  services.register(IToolsClockListener).to(IToolsClockListener, () => toolsClock);
   services.register(QueryRunner).to(QueryRunner);
   const queryRunner = services.buildProvider().resolve(QueryRunner);
   return { turnRunner, registry, approval, channel, conversation: conv, queryRunner };
@@ -816,5 +829,49 @@ describe('QueryRunner — publishes client tool_result', () => {
     const expected = true;
     const actual = published?.type === 'tool_result' ? published.isError : undefined;
     expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tools-clock bracket. The clock brackets the whole tool-handling method, so
+// it opens and closes even when the batch reaches no tool run — the approval
+// wait the old first-run bracket left unattributed.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — tools-clock bracket', () => {
+  it('opens the tools clock when the batch runs no tool', async () => {
+    const clock = new SpyToolsClock();
+    const tool = makeTool('echo', async (input) => `got: ${input.value}`);
+    const w = makeWiring([toolUseResult('tu_1', 'echo', { value: 'hi' }), endTurnResult('done')], [tool], { requireToolApproval: true }, undefined, clock);
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    const approvalRequest = w.channel.messages.find((m) => m.type === 'tool_approval_request');
+    if (approvalRequest?.type !== 'tool_approval_request') {
+      throw new Error('unreachable');
+    }
+    w.approval.handle({ type: 'tool_approval_response', requestId: approvalRequest.requestId, approved: false, reason: 'no' });
+    await runPromise;
+
+    const actual = clock.startedCount;
+    expect(actual).toBe(1);
+  });
+
+  it('closes the tools clock when the batch runs no tool', async () => {
+    const clock = new SpyToolsClock();
+    const tool = makeTool('echo', async (input) => `got: ${input.value}`);
+    const w = makeWiring([toolUseResult('tu_1', 'echo', { value: 'hi' }), endTurnResult('done')], [tool], { requireToolApproval: true }, undefined, clock);
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    const approvalRequest = w.channel.messages.find((m) => m.type === 'tool_approval_request');
+    if (approvalRequest?.type !== 'tool_approval_request') {
+      throw new Error('unreachable');
+    }
+    w.approval.handle({ type: 'tool_approval_response', requestId: approvalRequest.requestId, approved: false, reason: 'no' });
+    await runPromise;
+
+    const actual = clock.stoppedCount;
+    expect(actual).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Bracket the entire tool-handling method as tool time, so the approval wait counts toward the tools clock
- Fixes the status-line chess clock miscounting time spent waiting for a tool to be approved