### PR TITLE
Show the prompt block's start time when the prompt is entered

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore cursor visibility after exiting the CLI (#277)
 - Show the API error detail on a failed request instead of only the HTTP status
 - Show the permissions notice only when displayed permissions change, not on every config edit
+- Show the prompt block's start time when the prompt is entered, matching every other block
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -93,3 +93,4 @@
 {"description":"Add --system-identity flag so a conversation owns the actor it casts Claude as, persisted in sqlite and restored on resume","category":"added"}
 {"description":"Add the --system-identity flag: bind a system prompt to a conversation from a file, persisted and restored on resume","category":"added"}
 {"description":"Count tool approval wait time as tool time in the status-line clock","category":"fixed"}
+{"description":"Show the prompt block's start time when the prompt is entered, matching every other block","category":"fixed"}

--- a/apps/claude-sdk-cli/src/model/ConversationState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationState.ts
@@ -64,6 +64,15 @@ export class ConversationState {
     return this.#activeBlock;
   }
 
+  /**
+   * The instant the prompt was entered (set by markPromptStart), or null once
+   * consumed by transitionBlock('prompt'). The view reads this so the active
+   * prompt divider can show its start when entered, like every other block.
+   */
+  public get promptStartedAt(): Instant | null {
+    return this.#promptStartedAt;
+  }
+
   /** Push one or more pre-built blocks (e.g. from history replay or startup banner). */
   public addBlocks(blocks: ReadonlyArray<Block>): void {
     for (const block of blocks) {

--- a/apps/claude-sdk-cli/src/view/PrimaryView.ts
+++ b/apps/claude-sdk-cli/src/view/PrimaryView.ts
@@ -1,5 +1,5 @@
 import { renderCommandMode } from './renderCommandMode.js';
-import { buildDivider, renderConversation } from './renderConversation.js';
+import { blockTimestamps, buildDivider, renderConversation } from './renderConversation.js';
 import { renderEditor } from './renderEditor.js';
 import { renderClock, renderModel, renderStatus } from './renderStatus.js';
 import { renderToolApproval } from './renderToolApproval.js';
@@ -26,7 +26,7 @@ export class PrimaryView implements View {
 
     const allContent = renderConversation(conversationState, cols, configLoader.config.markdown);
     if (primaryViewState.phase === 'editor') {
-      allContent.push(buildDivider('prompt', cols));
+      allContent.push(buildDivider('prompt', cols, blockTimestamps(conversationState.promptStartedAt ?? undefined, undefined)));
       allContent.push('');
       allContent.push(...renderEditor(editorState, cols));
     }

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -76,7 +76,7 @@ function formatInstantToTime(instant: Instant): string {
   return instant.atZone(ZoneId.systemDefault()).toLocalTime().format(TIME_FORMAT);
 }
 
-function blockTimestamps(createdAt: Instant | undefined, exitedAt: Instant | undefined): DividerTimestamps | undefined {
+export function blockTimestamps(createdAt: Instant | undefined, exitedAt: Instant | undefined): DividerTimestamps | undefined {
   if (!createdAt) {
     return undefined;
   }

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -1,4 +1,4 @@
-import { Clock } from '@js-joda/core';
+import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import { AppModeState } from '../src/model/AppModeState.js';
@@ -15,6 +15,13 @@ import { ToolApprovalState } from '../src/model/ToolApprovalState.js';
 import { TurnClock } from '../src/model/TurnClock.js';
 import { PrimaryView } from '../src/view/PrimaryView.js';
 import type { ViewModel } from '../src/view/View.js';
+
+function makeConversationState(clock: Clock): ConversationState {
+  const services = createServiceCollection();
+  services.register(Clock).to(Clock, () => clock);
+  services.register(ConversationState).to(ConversationState);
+  return services.buildProvider().resolve(ConversationState);
+}
 
 function makeTurnClock(): ITurnClock {
   const services = createServiceCollection();
@@ -48,6 +55,20 @@ describe('PrimaryView — editor region', () => {
     const rows = new PrimaryView().render(model);
     const expected = true;
     const actual = rows.join('\n').includes('prompt');
+    expect(actual).toBe(expected);
+  });
+
+  it('shows the prompt start time once the prompt is entered', () => {
+    const clock = Clock.fixed(Instant.parse('2026-07-07T13:38:00Z'), ZoneId.systemDefault());
+    const model = makeModel();
+    model.conversationState = makeConversationState(clock);
+    model.conversationState.markPromptStart();
+
+    const rows = new PrimaryView().render(model);
+    const promptRow = rows.find((row) => row.includes('prompt'));
+    const expected = true;
+    const actual = /\d{2}:\d{2}:\d{2}/.test(promptRow ?? '');
+
     expect(actual).toBe(expected);
   });
 


### PR DESCRIPTION
## Summary

- Show the prompt block's start time the moment it is entered, like every other block
- Previously the prompt divider appeared without a time until the prompt was submitted