### PR TITLE
Fix OSC 8 link rendering in markdown

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve editor content when starting a new conversation
 - Prevent crashes from unhandled child process and socket errors
 - Reject unknown flags at launch instead of silently ignoring them
+- Rendered markdown links no longer leak the OSC 8 escape or double the URL; ctrl-click opens the correct address
 - Restore cursor visibility after exiting the CLI (#277)
 - Show the API error detail on a failed request instead of only the HTTP status
 - Show the permissions notice only when displayed permissions change, not on every config edit

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -96,3 +96,4 @@
 {"description":"Count tool approval wait time as tool time in the status-line clock","category":"fixed"}
 {"description":"Show the prompt block's start time when the prompt is entered, matching every other block","category":"fixed"}
 {"description":"Status line token stats reflect the current conversation, derived per conversation id, instead of accumulating over the process lifetime","category":"fixed"}
+{"description":"Rendered markdown links no longer leak the OSC 8 escape or double the URL; ctrl-click opens the correct address","category":"fixed"}

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -60,6 +60,7 @@
     "@shellicar/claude-sdk": "workspace:^",
     "@shellicar/claude-sdk-tools": "workspace:^",
     "@shellicar/core-di-lite": "^1.0.2",
+    "ansi-regex": "6.2.2",
     "cli-highlight": "^2.1.11",
     "marked": "^18.0.5",
     "string-width": "^8.2.1",

--- a/apps/claude-sdk-cli/src/view/ScreenBuffer.ts
+++ b/apps/claude-sdk-cli/src/view/ScreenBuffer.ts
@@ -1,4 +1,5 @@
 import { cursorAt } from '@shellicar/claude-core/ansi';
+import ansiRegex from 'ansi-regex';
 import stringWidth from 'string-width';
 
 /**
@@ -19,10 +20,12 @@ import stringWidth from 'string-width';
 export type Cell = string;
 export type Grid = Cell[][];
 
-// A CSI escape sequence (colour/style). Treated as zero width and carried onto
-// the next visible cell, so styling travels with its character.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: matching terminal escape sequences requires \x1b
-const ANSI_RE = /\u001b\[[^a-zA-Z]*[a-zA-Z]/g;
+// An ANSI escape sequence (CSI colour/style, or OSC 8 hyperlink introducer/
+// closer). Treated as zero width and carried onto the next visible cell, so
+// styling and link markers travel with their character. ansi-regex is the same
+// escape definition string-width uses to measure width, so the tokenizer and the
+// width authority agree — the fix for OSC 8 leaking as visible text (#391).
+const ANSI_RE = ansiRegex();
 const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
 
 /** Lay one styled row into `cols` cells, clipping anything past the margin. */

--- a/apps/claude-sdk-cli/test/ScreenBuffer.osc8.spec.ts
+++ b/apps/claude-sdk-cli/test/ScreenBuffer.osc8.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { osc8 } from '../src/model/markdown/palette.js';
+import { type Cell, layoutRow } from '../src/view/ScreenBuffer.js';
+
+// The columns a row actually occupies: every cell that isn't a blank pad.
+// An OSC 8 escape carries zero visible width, so the introducer and closer
+// never occupy a column of their own — only the visible label does. (Fixtures
+// use no wide graphemes, so a non-blank cell is exactly one occupied column.)
+const occupiedColumns = (cells: Cell[]): number => cells.filter((cell) => cell !== ' ').length;
+
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+
+describe('layoutRow — OSC 8 hyperlinks', () => {
+  it('lays a bare-URL link to its label width, the URL shown once', () => {
+    const url = 'https://ex.co/391';
+    const expected = url.length;
+    const actual = occupiedColumns(layoutRow(osc8(url, url), 80));
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves no visible column past the label — no leaked escape or doubled URL', () => {
+    const url = 'https://ex.co/391';
+    const expected = ' ';
+    const actual = layoutRow(osc8(url, url), 80)[url.length];
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('layoutRow — CSI/SGR rendering is unchanged', () => {
+  it('carries an SGR colour as zero width onto its character', () => {
+    const expected = [`${RED}A`, `B${RESET}`, ' ', ' '];
+    const actual = layoutRow(`${RED}AB${RESET}`, 4);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/claude-core/package.json
+++ b/packages/claude-core/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@js-joda/core": "^5.7.0",
     "@shellicar/core-di-lite": "^1.0.2",
+    "ansi-regex": "6.2.2",
     "string-width": "^8.2.1",
     "zod": "^4.4.3"
   }

--- a/packages/claude-core/src/reflow.ts
+++ b/packages/claude-core/src/reflow.ts
@@ -1,3 +1,4 @@
+import ansiRegex from 'ansi-regex';
 import stringWidth from 'string-width';
 import { RESET } from './ansi.js';
 import { sanitiseZwj } from './sanitise.js';
@@ -116,11 +117,13 @@ export function rewrapFromSegments(segments: LineSegment[], columns: number): st
 }
 
 /**
- * Matches a single CSI escape sequence: ESC [ <params> <final-letter>.
- * Used to tokenize lines into ANSI runs (zero visible width) and plain text.
+ * Matches a single ANSI escape sequence: CSI (ESC [ <params> <letter>) or OSC
+ * (including the OSC 8 hyperlink introducer/closer). Used to tokenize lines into
+ * ANSI runs (zero visible width) and plain text. ansi-regex is the same escape
+ * definition string-width uses to measure width, so wrap decisions and the width
+ * authority agree — the fix for OSC 8 mismeasurement (#391).
  */
-// biome-ignore lint/suspicious/noControlCharactersInRegex: matching terminal escape sequences requires \x1b
-const ANSI_RE = /\u001b\[[^a-zA-Z]*[a-zA-Z]/g;
+const ANSI_RE = ansiRegex();
 /**
  * Splits a logical line into visual rows by wrapping at `columns` visual width.
  * Returns at least one entry (empty string for empty input).

--- a/packages/claude-core/test/reflow.osc8.spec.ts
+++ b/packages/claude-core/test/reflow.osc8.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { RESET, YELLOW } from '../src/ansi';
+import { wrapLine } from '../src/reflow';
+
+// An OSC 8 hyperlink, emitted exactly as the markdown palette emits it:
+// introducer (ESC ]8;;URL ST) + visible label + closer (ESC ]8;; ST), ST = ESC \.
+const ST = '\x1b\\';
+const osc8 = (url: string, label: string): string => `\x1b]8;;${url}${ST}${label}\x1b]8;;${ST}`;
+
+describe('wrapLine — OSC 8 hyperlinks', () => {
+  it('measures a link at its label width when deciding where to wrap', () => {
+    const url = 'https://example.com/'; // 20 visible columns, wraps at 10
+    const expected = 2;
+    const actual = wrapLine(osc8(url, url), 10).length;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps active colour on the continuation line when the row also carries a link', () => {
+    const url = 'https://example.com/';
+    const line = `${YELLOW}${osc8(url, url)}${RESET}`;
+    const wrapped = wrapLine(line, 10);
+    const expected = true;
+    const actual = (wrapped[1] ?? '').startsWith(YELLOW);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('wrapLine — CSI/SGR rendering is unchanged', () => {
+  it('does not count an SGR colour toward the visible line width', () => {
+    const expected = [`${YELLOW}helloworld${RESET}`, `${YELLOW}!${RESET}`];
+    const actual = wrapLine(`${YELLOW}helloworld!${RESET}`, 10);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@shellicar/core-di-lite':
         specifier: ^1.0.2
         version: 1.0.2
+      ansi-regex:
+        specifier: 6.2.2
+        version: 6.2.2
       cli-highlight:
         specifier: ^2.1.11
         version: 2.1.11
@@ -125,6 +128,9 @@ importers:
       '@shellicar/core-di-lite':
         specifier: ^1.0.2
         version: 1.0.2
+      ansi-regex:
+        specifier: 6.2.2
+        version: 6.2.2
       string-width:
         specifier: ^8.2.1
         version: 8.2.1


### PR DESCRIPTION
## Summary

- Recognise OSC 8 hyperlink escapes in the render tokenizer (ScreenBuffer.ts, reflow.ts)
- Add ansi-regex as a direct dependency, matching the version string-width resolves to
- Fix leaked `]8;;` escape text and doubled URLs on rendered links

Closes #391