### PR TITLE
Release 1.0.0-beta.15

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ All releases are pre-releases until 1.0.0. The current version series is `1.0.0-
    ```
    The script puts all entries under `[Unreleased]` (no release markers exist). If it produces changes for a package that was not bumped, stop and investigate.
 
-4. Verify: `pnpm build && pnpm type-check && pnpm test`
+4. Verify: `pnpm turbo run build type-check test`
 
 5. Single PR with all version bumps, changelog updates, and lock file changes.
 

--- a/apps/claude-sdk-cli/package.json
+++ b/apps/claude-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "description": "Interactive CLI for Claude AI built on the Anthropic SDK",
   "license": "MIT",

--- a/packages/claude-core/package.json
+++ b/packages/claude-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-core",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "description": "",
   "license": "MIT",

--- a/packages/claude-sdk-tools/package.json
+++ b/packages/claude-sdk-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-tools",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/mcp-exec",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "description": "MCP server wrapping the Exec tool from @shellicar/claude-sdk-tools",
   "scripts": {

--- a/platforms/claude-sdk-cli-darwin-arm64/package.json
+++ b/platforms/claude-sdk-cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shellicar/claude-sdk-cli-darwin-arm64",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "private": false,
   "description": "macOS arm64 prebuilt binary for @shellicar/claude-sdk-cli",
   "license": "MIT",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "incremental": true,
     "skipLibCheck": true,
     "composite": false,
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/turbo/schema.json",
   "ui": "stream",
-  "daemon": false,
+  "noUpdateNotifier": true,
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Bump claude-core, claude-sdk, claude-sdk-tools, claude-sdk-cli, mcp-exec, and the darwin-arm64 CLI binary to 1.0.0-beta.15
- Adds NATS-based conversation and approval support to the CLI, Sonnet 5 pricing, status-line and terminal-link fixes from prior merges