### PR TITLE
Wrap injected content markers in XML tags

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update runtime and build dependencies
 - Updated patch and minor dependencies
 - Updated patch dependencies
+- Wrap injected content presented to the model (attachments, git delta, CLAUDE.md, SYSTEM.md, system identity) in XML-like tags instead of custom markers, so the model-facing format is consistent
 - Write session ID marker on save instead of on creation
 
 ### Removed

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -99,3 +99,4 @@
 {"description":"Rendered markdown links no longer leak the OSC 8 escape or double the URL; ctrl-click opens the correct address","category":"fixed"}
 {"description":"Service `say` and `cancel` on the conversation over NATS and raise and answer tool approvals over the wire, so a client can address the CLI and drive a turn remotely","category":"added"}
 {"description":"Remove the one-way `tap.v1` telemetry stream, replaced by the `conv` and `approval` wire surface","category":"removed"}
+{"description":"Wrap injected content presented to the model (attachments, git delta, CLAUDE.md, SYSTEM.md, system identity) in XML-like tags instead of custom markers, so the model-facing format is consistent","category":"changed"}

--- a/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
+++ b/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { dependsOn } from '@shellicar/core-di-lite';
+import { readIfPresent, wrapBlock } from './promptSource.js';
 import { IRuntimeOptions } from './setup/IRuntimeOptions.js';
 
 const INSTRUCTION_PREFIX = 'Codebase and user instructions are shown below. Be sure to adhere to these instructions. ' + 'IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.';
@@ -45,15 +46,6 @@ function claudeMdFiles(cwd: string, home: string): ClaudeMdFile[] {
   ];
 }
 
-async function readIfPresent(fs: IFileSystem, path: string): Promise<string | null> {
-  try {
-    const content = (await fs.readFile(path)).trim();
-    return content.length > 0 ? content : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Loads CLAUDE.md files from standard locations on demand.
  * Call `getContent()` each time you need the content — files are read fresh
@@ -76,12 +68,12 @@ export class ClaudeMdLoader {
       }
       const content = await readIfPresent(this.fs, file.path);
       if (content != null) {
-        sections.push(`<claude-md>\nContents of ${file.path} (${file.label}):\n\n${content}\n</claude-md>`);
+        sections.push(wrapBlock('claude-md', `Contents of ${file.path} (${file.label}):`, content));
       }
     }
 
     if (this.runtime.claudeMdFlagText != null) {
-      sections.push(`<claude-md>\nContents of the --claudeMd launch flag:\n\n${this.runtime.claudeMdFlagText}\n</claude-md>`);
+      sections.push(wrapBlock('claude-md', 'Contents of the --claudeMd launch flag:', this.runtime.claudeMdFlagText));
     }
 
     if (sections.length === 0) {

--- a/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
+++ b/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
@@ -76,12 +76,12 @@ export class ClaudeMdLoader {
       }
       const content = await readIfPresent(this.fs, file.path);
       if (content != null) {
-        sections.push(`Contents of ${file.path} (${file.label}):\n\n${content}`);
+        sections.push(`<claude-md>\nContents of ${file.path} (${file.label}):\n\n${content}\n</claude-md>`);
       }
     }
 
     if (this.runtime.claudeMdFlagText != null) {
-      sections.push(`Contents of the --claudeMd launch flag:\n\n${this.runtime.claudeMdFlagText}`);
+      sections.push(`<claude-md>\nContents of the --claudeMd launch flag:\n\n${this.runtime.claudeMdFlagText}\n</claude-md>`);
     }
 
     if (sections.length === 0) {

--- a/apps/claude-sdk-cli/src/SystemPromptLoader.ts
+++ b/apps/claude-sdk-cli/src/SystemPromptLoader.ts
@@ -36,9 +36,11 @@ async function readIfPresent(fs: IFileSystem, path: string): Promise<string | nu
 
 /**
  * Loads SYSTEM.md files from the four standard locations on demand. Each
- * present, non-empty file becomes its own ordered entry. Unlike
- * ClaudeMdLoader, no instruction prefix or labels are added: these are the
- * real system-prompt blocks, composed additively into the API `system` param.
+ * present, non-empty file becomes its own ordered entry, wrapped in a
+ * `<system-md>` tag (bare — SYSTEM.md sources carry no label, unlike
+ * ClaudeMdLoader). Unlike ClaudeMdLoader, no instruction prefix is added:
+ * these are the real system-prompt blocks, composed additively into the
+ * API `system` param.
  *
  * Files are read fresh on every call, so a new session picks up current
  * contents without a watcher (resolution timing is the caller's policy).
@@ -55,7 +57,7 @@ export class SystemPromptLoader {
       }
       const content = await readIfPresent(this.fs, file.path);
       if (content != null) {
-        sections.push(content);
+        sections.push(`<system-md>\n${content}\n</system-md>`);
       }
     }
     return sections;

--- a/apps/claude-sdk-cli/src/SystemPromptLoader.ts
+++ b/apps/claude-sdk-cli/src/SystemPromptLoader.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { dependsOn } from '@shellicar/core-di-lite';
+import { readIfPresent, wrapBlock } from './promptSource.js';
 
 export type SystemPromptSources = {
   user: boolean;
@@ -23,15 +24,6 @@ function systemPromptFiles(cwd: string, home: string): SystemPromptFile[] {
     { path: resolve(cwd, '.claude', 'SYSTEM.md'), source: 'projectClaude' },
     { path: resolve(cwd, 'SYSTEM.local.md'), source: 'local' },
   ];
-}
-
-async function readIfPresent(fs: IFileSystem, path: string): Promise<string | null> {
-  try {
-    const content = (await fs.readFile(path)).trim();
-    return content.length > 0 ? content : null;
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -59,7 +51,7 @@ export class SystemPromptLoader {
       }
       const content = await readIfPresent(this.fs, file.path);
       if (content != null) {
-        sections.push(`<system-md>\nContents of ${file.path}:\n\n${content}\n</system-md>`);
+        sections.push(wrapBlock('system-md', `Contents of ${file.path}:`, content));
       }
     }
     return sections;

--- a/apps/claude-sdk-cli/src/SystemPromptLoader.ts
+++ b/apps/claude-sdk-cli/src/SystemPromptLoader.ts
@@ -37,8 +37,10 @@ async function readIfPresent(fs: IFileSystem, path: string): Promise<string | nu
 /**
  * Loads SYSTEM.md files from the four standard locations on demand. Each
  * present, non-empty file becomes its own ordered entry, wrapped in a
- * `<system-md>` tag (bare — SYSTEM.md sources carry no label, unlike
- * ClaudeMdLoader). Unlike ClaudeMdLoader, no instruction prefix is added:
+ * `<system-md>` tag with a `Contents of <path>:` header as the first inner
+ * line, so the model can see where each block came from. SYSTEM.md sources
+ * carry a path but no human label (unlike ClaudeMdLoader), so the header is
+ * the path alone. Unlike ClaudeMdLoader, no instruction prefix is added:
  * these are the real system-prompt blocks, composed additively into the
  * API `system` param.
  *
@@ -57,7 +59,7 @@ export class SystemPromptLoader {
       }
       const content = await readIfPresent(this.fs, file.path);
       if (content != null) {
-        sections.push(`<system-md>\n${content}\n</system-md>`);
+        sections.push(`<system-md>\nContents of ${file.path}:\n\n${content}\n</system-md>`);
       }
     }
     return sections;

--- a/apps/claude-sdk-cli/src/composeSystemPrompts.ts
+++ b/apps/claude-sdk-cli/src/composeSystemPrompts.ts
@@ -19,7 +19,7 @@ export function composeSystemPrompts({ fileSections, configText, flagText }: Sys
     blocks.push(configText);
   }
   if (flagText != null && flagText.length > 0) {
-    blocks.push(`<system-md>\n${flagText}\n</system-md>`);
+    blocks.push(`<system-md>\nContents of the --system launch flag:\n\n${flagText}\n</system-md>`);
   }
   return blocks;
 }

--- a/apps/claude-sdk-cli/src/composeSystemPrompts.ts
+++ b/apps/claude-sdk-cli/src/composeSystemPrompts.ts
@@ -1,3 +1,5 @@
+import { wrapBlock } from './promptSource.js';
+
 /**
  * Assembles the ordered system-prompt blocks from the three configured
  * sources. Order: SYSTEM.md sections (already user, project, projectClaude,
@@ -19,7 +21,7 @@ export function composeSystemPrompts({ fileSections, configText, flagText }: Sys
     blocks.push(configText);
   }
   if (flagText != null && flagText.length > 0) {
-    blocks.push(`<system-md>\nContents of the --system launch flag:\n\n${flagText}\n</system-md>`);
+    blocks.push(wrapBlock('system-md', 'Contents of the --system launch flag:', flagText));
   }
   return blocks;
 }

--- a/apps/claude-sdk-cli/src/composeSystemPrompts.ts
+++ b/apps/claude-sdk-cli/src/composeSystemPrompts.ts
@@ -1,7 +1,9 @@
 /**
  * Assembles the ordered system-prompt blocks from the three configured
  * sources. Order: SYSTEM.md sections (already user, project, projectClaude,
- * local), then the sdk-config inline value, then the --system flag.
+ * local), then the sdk-config inline value, then the --system flag. SYSTEM.md
+ * sections arrive already wrapped in `<system-md>` (SystemPromptLoader); the
+ * --system flag text is wrapped here, mirroring CLAUDE.md's --claudeMd flag.
  *
  * Each element becomes one entry in DurableConfig.systemPrompts.
  */
@@ -17,7 +19,7 @@ export function composeSystemPrompts({ fileSections, configText, flagText }: Sys
     blocks.push(configText);
   }
   if (flagText != null && flagText.length > 0) {
-    blocks.push(flagText);
+    blocks.push(`<system-md>\n${flagText}\n</system-md>`);
   }
   return blocks;
 }

--- a/apps/claude-sdk-cli/src/gitDelta.ts
+++ b/apps/claude-sdk-cli/src/gitDelta.ts
@@ -102,5 +102,5 @@ export function formatDelta(delta: DeltaValues): string {
     parts.push(`stash: ${delta.stashCount.from}\u2192${delta.stashCount.to}`);
   }
 
-  return `[git delta] ${parts.join(' | ')}`;
+  return `<git-delta>${parts.join(' | ')}</git-delta>`;
 }

--- a/apps/claude-sdk-cli/src/model/buildSubmitText.ts
+++ b/apps/claude-sdk-cli/src/model/buildSubmitText.ts
@@ -3,7 +3,8 @@ import type { Attachment } from './AttachmentStore.js';
 /**
  * Assemble the final message string from editor text and optional attachments.
  *
- * Each attachment becomes an [attachment #N] block appended after the main text.
+ * Attachments are appended as a single <attachments> block containing one
+ * <attachment> per item, in order.
  * The format is part of the system prompt contract — the agent is told how these
  * blocks are structured so it can reference attached content correctly.
  *
@@ -14,9 +15,8 @@ export function buildSubmitText(text: string, attachments: readonly Attachment[]
   if (!attachments || attachments.length === 0) {
     return text;
   }
-  const parts: string[] = [text];
-  for (let n = 0; n < attachments.length; n++) {
-    const att = attachments[n];
+  const items: string[] = [];
+  for (const att of attachments) {
     if (!att) {
       continue;
     }
@@ -24,7 +24,7 @@ export function buildSubmitText(text: string, attachments: readonly Attachment[]
       const showSize = att.sizeBytes >= 1024 ? `${(att.sizeBytes / 1024).toFixed(1)}KB` : `${att.sizeBytes}B`;
       const fullSize = att.fullSizeBytes >= 1024 ? `${(att.fullSizeBytes / 1024).toFixed(1)}KB` : `${att.fullSizeBytes}B`;
       const truncPrefix = att.truncated ? `// showing ${showSize} of ${fullSize} (truncated)\n` : '';
-      parts.push(`\n\n[attachment #${n + 1}]\n${truncPrefix}${att.text}\n[/attachment]`);
+      items.push(`<attachment>\n${truncPrefix}${att.text}\n</attachment>`);
     } else if (att.kind === 'file') {
       const lines: string[] = [`path: ${att.path}`];
       if (att.fileType === 'missing') {
@@ -37,10 +37,13 @@ export function buildSubmitText(text: string, attachments: readonly Attachment[]
           lines.push(`size: ${sizeStr}`);
         }
       }
-      parts.push(`\n\n[attachment #${n + 1}]\n${lines.join('\n')}\n[/attachment]`);
+      items.push(`<attachment>\n${lines.join('\n')}\n</attachment>`);
     }
     // Image attachments are not serialised to text; they are sent as native
     // BetaImageBlockParam content blocks via the structured message path.
   }
-  return parts.join('');
+  if (items.length === 0) {
+    return text;
+  }
+  return `${text}\n\n<attachments>\n${items.join('\n')}\n</attachments>`;
 }

--- a/apps/claude-sdk-cli/src/promptSource.ts
+++ b/apps/claude-sdk-cli/src/promptSource.ts
@@ -1,0 +1,24 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+
+/**
+ * Reads a prompt-source file, trimmed. Returns null when the file is absent
+ * or empty, so callers treat "not there" and "there but blank" the same way.
+ */
+export async function readIfPresent(fs: IFileSystem, path: string): Promise<string | null> {
+  try {
+    const content = (await fs.readFile(path)).trim();
+    return content.length > 0 ? content : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Frames injected content as a named XML-like block: the tag on its own lines,
+ * a header as the first inner line, then a blank line, then the body. This is
+ * the shared shape every CLAUDE.md / SYSTEM.md source is wrapped in, so the
+ * format lives in one place and cannot drift between injectors.
+ */
+export function wrapBlock(tag: string, header: string, body: string): string {
+  return `<${tag}>\n${header}\n\n${body}\n</${tag}>`;
+}

--- a/apps/claude-sdk-cli/src/setup/DurableConfigFactory.ts
+++ b/apps/claude-sdk-cli/src/setup/DurableConfigFactory.ts
@@ -105,7 +105,7 @@ export class DurableConfigFactory extends IDurableConfigProvider {
       }
     }
 
-    const identityBase = this.#identityBody != null && this.#identityBody.length > 0 ? [this.#identityBody] : [];
+    const identityBase = this.#identityBody != null && this.#identityBody.length > 0 ? [`<system-identity>\n${this.#identityBody}\n</system-identity>`] : [];
     return {
       model: this.getEffectiveModel(),
       maxTokens: this.configLoader.config.maxTokens,

--- a/apps/claude-sdk-cli/test/SystemPromptLoader.spec.ts
+++ b/apps/claude-sdk-cli/test/SystemPromptLoader.spec.ts
@@ -30,7 +30,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${HOME}/.claude/SYSTEM.md`]: 'User prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nUser prompt.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /home/user/.claude/SYSTEM.md:\n\nUser prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -40,7 +40,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: 'Project prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nProject prompt.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.md:\n\nProject prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -50,7 +50,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/.claude/SYSTEM.md`]: 'ProjectClaude prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nProjectClaude prompt.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/.claude/SYSTEM.md:\n\nProjectClaude prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -60,7 +60,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.local.md`]: 'Local prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nLocal prompt.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.local.md:\n\nLocal prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -79,7 +79,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nU\n</system-md>', '<system-md>\nP\n</system-md>', '<system-md>\nPC\n</system-md>', '<system-md>\nL\n</system-md>'];
+    const expected = ['<system-md>\nContents of /home/user/.claude/SYSTEM.md:\n\nU\n</system-md>', '<system-md>\nContents of /project/SYSTEM.md:\n\nP\n</system-md>', '<system-md>\nContents of /project/.claude/SYSTEM.md:\n\nPC\n</system-md>', '<system-md>\nContents of /project/SYSTEM.local.md:\n\nL\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -89,7 +89,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: 'Raw content.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nRaw content.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.md:\n\nRaw content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -99,7 +99,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: '  \n  Trimmed.  \n  ' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nTrimmed.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.md:\n\nTrimmed.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -116,7 +116,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nReal content.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.md:\n\nReal content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -133,7 +133,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['<system-md>\nReal content.\n</system-md>'];
+    const expected = ['<system-md>\nContents of /project/SYSTEM.md:\n\nReal content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);

--- a/apps/claude-sdk-cli/test/SystemPromptLoader.spec.ts
+++ b/apps/claude-sdk-cli/test/SystemPromptLoader.spec.ts
@@ -30,7 +30,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${HOME}/.claude/SYSTEM.md`]: 'User prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['User prompt.'];
+    const expected = ['<system-md>\nUser prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -40,7 +40,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: 'Project prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Project prompt.'];
+    const expected = ['<system-md>\nProject prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -50,7 +50,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/.claude/SYSTEM.md`]: 'ProjectClaude prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['ProjectClaude prompt.'];
+    const expected = ['<system-md>\nProjectClaude prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -60,7 +60,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.local.md`]: 'Local prompt.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Local prompt.'];
+    const expected = ['<system-md>\nLocal prompt.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -79,7 +79,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['U', 'P', 'PC', 'L'];
+    const expected = ['<system-md>\nU\n</system-md>', '<system-md>\nP\n</system-md>', '<system-md>\nPC\n</system-md>', '<system-md>\nL\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -89,7 +89,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: 'Raw content.' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Raw content.'];
+    const expected = ['<system-md>\nRaw content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -99,7 +99,7 @@ describe('SystemPromptLoader', () => {
     const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: '  \n  Trimmed.  \n  ' }, HOME, CWD);
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Trimmed.'];
+    const expected = ['<system-md>\nTrimmed.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -116,7 +116,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Real content.'];
+    const expected = ['<system-md>\nReal content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);
@@ -133,7 +133,7 @@ describe('SystemPromptLoader', () => {
     );
     const loader = buildSystemPromptLoader(fs);
 
-    const expected = ['Real content.'];
+    const expected = ['<system-md>\nReal content.\n</system-md>'];
     const actual = await loader.getSections();
 
     expect(actual).toEqual(expected);

--- a/apps/claude-sdk-cli/test/buildSubmitText.spec.ts
+++ b/apps/claude-sdk-cli/test/buildSubmitText.spec.ts
@@ -40,10 +40,10 @@ describe('buildSubmitText — text attachment', () => {
     truncated: false,
   };
 
-  it('appends [attachment #1] block', () => {
+  it('appends an <attachment> block', () => {
     const result = buildSubmitText('prompt', [textAtt]);
     const expected = true;
-    const actual = result.includes('[attachment #1]');
+    const actual = result.includes('<attachment>');
     expect(actual).toBe(expected);
   });
 
@@ -54,10 +54,17 @@ describe('buildSubmitText — text attachment', () => {
     expect(actual).toBe(expected);
   });
 
-  it('includes [/attachment] closing tag', () => {
+  it('includes </attachment> closing tag', () => {
     const result = buildSubmitText('prompt', [textAtt]);
     const expected = true;
-    const actual = result.includes('[/attachment]');
+    const actual = result.includes('</attachment>');
+    expect(actual).toBe(expected);
+  });
+
+  it('wraps the block in an <attachments> container', () => {
+    const result = buildSubmitText('prompt', [textAtt]);
+    const expected = true;
+    const actual = result.includes('<attachments>') && result.includes('</attachments>');
     expect(actual).toBe(expected);
   });
 
@@ -173,24 +180,17 @@ describe('buildSubmitText — multiple attachments', () => {
   const att1: Attachment = { kind: 'text', hash: 'h1', text: 'first', sizeBytes: 5, fullSizeBytes: 5, truncated: false };
   const att2: Attachment = { kind: 'file', path: '/tmp/second.txt', fileType: 'file', sizeBytes: 100 };
 
-  it('numbers attachments starting at #1', () => {
+  it('includes both attachments as separate <attachment> blocks', () => {
     const result = buildSubmitText('prompt', [att1, att2]);
-    const expected = true;
-    const actual = result.includes('[attachment #1]');
-    expect(actual).toBe(expected);
-  });
-
-  it('numbers second attachment #2', () => {
-    const result = buildSubmitText('prompt', [att1, att2]);
-    const expected = true;
-    const actual = result.includes('[attachment #2]');
+    const expected = 2;
+    const actual = result.split('<attachment>').length - 1;
     expect(actual).toBe(expected);
   });
 
   it('both attachments appear in order', () => {
     const result = buildSubmitText('prompt', [att1, att2]);
-    const pos1 = result.indexOf('[attachment #1]');
-    const pos2 = result.indexOf('[attachment #2]');
+    const pos1 = result.indexOf('first');
+    const pos2 = result.indexOf('/tmp/second.txt');
     const expected = true;
     const actual = pos1 < pos2;
     expect(actual).toBe(expected);

--- a/apps/claude-sdk-cli/test/composeSystemPrompts.spec.ts
+++ b/apps/claude-sdk-cli/test/composeSystemPrompts.spec.ts
@@ -3,19 +3,19 @@ import { composeSystemPrompts } from '../src/composeSystemPrompts.js';
 
 describe('composeSystemPrompts', () => {
   it('orders file sections, then config text, then flag text', () => {
-    const expected = ['file-a', 'file-b', 'config', '<system-md>\nflag\n</system-md>'];
+    const expected = ['file-a', 'file-b', 'config', '<system-md>\nContents of the --system launch flag:\n\nflag\n</system-md>'];
     const actual = composeSystemPrompts({ fileSections: ['file-a', 'file-b'], configText: 'config', flagText: 'flag' });
     expect(actual).toEqual(expected);
   });
 
   it('wraps the flag text in a <system-md> tag', () => {
-    const expected = '<system-md>\nflag\n</system-md>';
+    const expected = '<system-md>\nContents of the --system launch flag:\n\nflag\n</system-md>';
     const actual = composeSystemPrompts({ fileSections: [], configText: null, flagText: 'flag' });
     expect(actual).toEqual([expected]);
   });
 
   it('omits config text when null', () => {
-    const expected = ['file-a', '<system-md>\nflag\n</system-md>'];
+    const expected = ['file-a', '<system-md>\nContents of the --system launch flag:\n\nflag\n</system-md>'];
     const actual = composeSystemPrompts({ fileSections: ['file-a'], configText: null, flagText: 'flag' });
     expect(actual).toEqual(expected);
   });

--- a/apps/claude-sdk-cli/test/composeSystemPrompts.spec.ts
+++ b/apps/claude-sdk-cli/test/composeSystemPrompts.spec.ts
@@ -3,13 +3,19 @@ import { composeSystemPrompts } from '../src/composeSystemPrompts.js';
 
 describe('composeSystemPrompts', () => {
   it('orders file sections, then config text, then flag text', () => {
-    const expected = ['file-a', 'file-b', 'config', 'flag'];
+    const expected = ['file-a', 'file-b', 'config', '<system-md>\nflag\n</system-md>'];
     const actual = composeSystemPrompts({ fileSections: ['file-a', 'file-b'], configText: 'config', flagText: 'flag' });
     expect(actual).toEqual(expected);
   });
 
+  it('wraps the flag text in a <system-md> tag', () => {
+    const expected = '<system-md>\nflag\n</system-md>';
+    const actual = composeSystemPrompts({ fileSections: [], configText: null, flagText: 'flag' });
+    expect(actual).toEqual([expected]);
+  });
+
   it('omits config text when null', () => {
-    const expected = ['file-a', 'flag'];
+    const expected = ['file-a', '<system-md>\nflag\n</system-md>'];
     const actual = composeSystemPrompts({ fileSections: ['file-a'], configText: null, flagText: 'flag' });
     expect(actual).toEqual(expected);
   });

--- a/apps/claude-sdk-cli/test/gitDelta.spec.ts
+++ b/apps/claude-sdk-cli/test/gitDelta.spec.ts
@@ -127,18 +127,18 @@ describe('computeDelta — multiple changes', () => {
 // formatDelta
 // ---------------------------------------------------------------------------
 
-describe('formatDelta — prefix', () => {
-  it('starts with [git delta]', () => {
+describe('formatDelta — wrapper', () => {
+  it('wraps the delta in a <git-delta> tag', () => {
     const actual = formatDelta({ branch: { from: 'main', to: 'feature/x' } });
     const expected = true;
-    expect(actual.startsWith('[git delta]')).toEqual(expected);
+    expect(actual.startsWith('<git-delta>') && actual.endsWith('</git-delta>')).toEqual(expected);
   });
 });
 
 describe('formatDelta — branch', () => {
   it('formats branch change with arrow', () => {
     const actual = formatDelta({ branch: { from: 'main', to: 'feature/x' } });
-    const expected = '[git delta] branch: main \u2192 feature/x';
+    const expected = '<git-delta>branch: main \u2192 feature/x</git-delta>';
     expect(actual).toEqual(expected);
   });
 });
@@ -146,7 +146,7 @@ describe('formatDelta — branch', () => {
 describe('formatDelta — HEAD', () => {
   it('formats HEAD change with arrow', () => {
     const actual = formatDelta({ head: { from: 'abc1234', to: 'def5678' } });
-    const expected = '[git delta] HEAD: abc1234 \u2192 def5678';
+    const expected = '<git-delta>HEAD: abc1234 \u2192 def5678</git-delta>';
     expect(actual).toEqual(expected);
   });
 });
@@ -155,34 +155,34 @@ describe('formatDelta — file counts', () => {
   it('formats files added to staging', () => {
     const delta: FileDelta = { added: 3, removed: 0 };
     const actual = formatDelta({ staged: delta });
-    const expected = '[git delta] staged: +3 files';
+    const expected = '<git-delta>staged: +3 files</git-delta>';
     expect(actual).toEqual(expected);
   });
 
   it('formats files removed from staging', () => {
     const delta: FileDelta = { added: 0, removed: 2 };
     const actual = formatDelta({ staged: delta });
-    const expected = '[git delta] staged: -2 files';
+    const expected = '<git-delta>staged: -2 files</git-delta>';
     expect(actual).toEqual(expected);
   });
 
   it('formats both added and removed files in staging (the swap case)', () => {
     const delta: FileDelta = { added: 2, removed: 2 };
     const actual = formatDelta({ staged: delta });
-    const expected = '[git delta] staged: +2, -2 files';
+    const expected = '<git-delta>staged: +2, -2 files</git-delta>';
     expect(actual).toEqual(expected);
   });
 
   it('formats unstaged change', () => {
     const delta: FileDelta = { added: 1, removed: 0 };
     const actual = formatDelta({ unstaged: delta });
-    const expected = '[git delta] unstaged: +1 files';
+    const expected = '<git-delta>unstaged: +1 files</git-delta>';
     expect(actual).toEqual(expected);
   });
 
   it('formats stash change', () => {
     const actual = formatDelta({ stashCount: { from: 0, to: 2 } });
-    const expected = '[git delta] stash: 0\u21922';
+    const expected = '<git-delta>stash: 0\u21922</git-delta>';
     expect(actual).toEqual(expected);
   });
 });
@@ -193,7 +193,7 @@ describe('formatDelta — multiple fields joined with pipe', () => {
       branch: { from: 'main', to: 'fix/y' },
       head: { from: 'abc1234', to: 'def5678' },
     });
-    const expected = '[git delta] branch: main \u2192 fix/y | HEAD: abc1234 \u2192 def5678';
+    const expected = '<git-delta>branch: main \u2192 fix/y | HEAD: abc1234 \u2192 def5678</git-delta>';
     expect(actual).toEqual(expected);
   });
 });
@@ -226,7 +226,7 @@ describe('GitStateMonitor — change between calls', () => {
     const monitor = new GitStateMonitor(() => Promise.resolve({ ...(snapshots[call++] ?? base) }));
     await monitor.takeSnapshot(); // baseline: snapshot[0] = base
     const actual = await monitor.getDelta(); // diffs snapshot[1] against base
-    const expected = '[git delta] branch: main \u2192 feature/x';
+    const expected = '<git-delta>branch: main \u2192 feature/x</git-delta>';
     expect(actual).toEqual(expected);
   });
 

--- a/apps/claude-sdk-cli/test/promptSource.spec.ts
+++ b/apps/claude-sdk-cli/test/promptSource.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readIfPresent, wrapBlock } from '../src/promptSource.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+const HOME = '/home/user';
+const CWD = '/project';
+
+describe('wrapBlock', () => {
+  it('frames content as a named block with header, blank line, then body', () => {
+    const expected = '<system-md>\nContents of /project/SYSTEM.md:\n\nBody.\n</system-md>';
+    const actual = wrapBlock('system-md', 'Contents of /project/SYSTEM.md:', 'Body.');
+
+    expect(actual).toBe(expected);
+  });
+
+  it('uses the given tag for both the opening and closing tag', () => {
+    const expected = '<claude-md>\nheader\n\nbody\n</claude-md>';
+    const actual = wrapBlock('claude-md', 'header', 'body');
+
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('readIfPresent', () => {
+  it('returns the trimmed file content when present', async () => {
+    const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: '  Trimmed.  ' }, HOME, CWD);
+
+    const expected = 'Trimmed.';
+    const actual = await readIfPresent(fs, `${CWD}/SYSTEM.md`);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('returns null when the file is absent', async () => {
+    const fs = new MemoryFileSystem({}, HOME, CWD);
+
+    const expected = null;
+    const actual = await readIfPresent(fs, `${CWD}/SYSTEM.md`);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('returns null when the file is empty after trimming', async () => {
+    const fs = new MemoryFileSystem({ [`${CWD}/SYSTEM.md`]: '   \n  ' }, HOME, CWD);
+
+    const expected = null;
+    const actual = await readIfPresent(fs, `${CWD}/SYSTEM.md`);
+
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap injected attachment blocks in `<attachments>`/`<attachment>` tags
- Convert the git-delta label to a nested `<git-delta>` tag inside the system reminder
- Frame CLAUDE.md and SYSTEM.md sources in `<claude-md>` and `<system-md>` tags, each headed with its source path
- Wrap the injected actor identity in a `<system-identity>` tag
- Route the shared headed-block framing through one helper so the markers cannot drift