### PR TITLE
Bundle first-party @shellicar libraries into mcp-exec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,20 @@ Full detail: `.claude/five-banana-pillars.md`
 | `packages/claude-sdk/` | SDK wrapper: agent session, tool registry, query runner, stream processor |
 | `packages/claude-sdk-tools/` | Tool definitions: Find, ReadFile, Grep, Head, Tail, Range, SearchFiles, Pipe, EditFile, PreviewEdit, CreateFile, DeleteFile, DeleteDirectory, Exec, Ref, TsDiagnostics, TsHover, TsDefinition, TsReferences |
 | `packages/claude-core/` | Shared: IFileSystem, expandPath, ANSI/terminal utilities |
-| `packages/mcp-exec/` | MCP server wrapping Exec tool |
+| `packages/mcp-exec/` | MCP server wrapping Exec tool. Bundles its first-party `@shellicar` deps into the output; third-party (`@modelcontextprotocol/sdk`) stays external |
+| `packages/mcp-internals/` | Private, never-published source-of-truth for MCP helpers (e.g. `getDataDir`), designed to be inlined by any MCP server that uses it rather than shipped as a runtime dependency. `private: true` |
 | `packages/exec-core/` | Process-spawning core: stream-based single-process spawn behind a shared interface |
 | `platforms/claude-sdk-cli-darwin-arm64/` | Published prebuilt SEA binary (macOS arm64) for the CLI, selected via the CLI's optional dependency. Bumped in lockstep whenever `claude-sdk-cli` is released. |
+
+### Bundling: bundled and published are separate axes
+
+Whether a package is bundled and whether it is published are two independent decisions. That a package is inlined into another's output says nothing about whether it ships to npm.
+
+`mcp-exec` shows the bundled side: it inlines its first-party `@shellicar` dependencies into its own output and leaves third-party ones external (`@modelcontextprotocol/sdk`, which the consumer brings). `@shellicar/claude-sdk-tools` is one such bundled dependency, and it is also published and depended on directly by other packages: bundled here, yet public and shared.
+
+`@shellicar/mcp-internals` sits at the other end of the published axis. It is `private: true` and never published: a source-of-truth for MCP helpers meant to be inlined by any MCP server that uses it, so that server's consumers carry no dependency on it. Being bundled into a server is how it is meant to be consumed; being unpublished is a separate, independent fact.
+
+So bundling is a build-time inlining choice, published is a distribution choice, and one does not imply the other. A first-party package is bundled to keep the consumer's dependency surface small; whether it is also published depends only on whether it is a shared, public API.
 
 ### Tool System
 

--- a/packages/mcp-exec/CHANGELOG.md
+++ b/packages/mcp-exec/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bundle first-party @shellicar libraries into the output; third-party dependencies stay external
 - Content and structuredContent derived from a single canonical result
 - Example added to tool description
 - ExecRule.check now receives Command[] instead of Step

--- a/packages/mcp-exec/changes.jsonl
+++ b/packages/mcp-exec/changes.jsonl
@@ -28,3 +28,4 @@
 {"description":"Updated patch and minor dependencies","category":"changed"}
 {"description":"Add a README covering what the MCP server does, how to install it, and how to wire it into an MCP client","category":"added"}
 {"description":"Wrap the ExecV3 tool (structured commands array with per-command operators) instead of the v1 Exec tool","category":"changed"}
+{"description":"Bundle first-party @shellicar libraries into the output; third-party dependencies stay external","category":"changed"}

--- a/packages/mcp-exec/package.json
+++ b/packages/mcp-exec/package.json
@@ -37,12 +37,12 @@
     "Claude (Anthropic) <noreply@anthropic.com>"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@shellicar/claude-sdk-tools": "workspace:^"
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@shellicar/build-clean": "^1.3.6",
     "@shellicar/build-version": "^1.3.10",
+    "@shellicar/claude-sdk-tools": "workspace:^",
     "@shellicar/typescript-config": "workspace:^",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^25.9.5",

--- a/packages/mcp-internals/README.md
+++ b/packages/mcp-internals/README.md
@@ -1,0 +1,7 @@
+# @shellicar/mcp-internals
+
+> Private helpers for the claude-cli MCP servers, inlined at build time.
+
+This package is `private: true` and is never published. It is a source-of-truth for MCP helpers, designed to be inlined by any MCP server that uses it: the server bundles the source into its own output, so that server's consumers install no extra dependency. Bundled and published are separate axes: a package can be inlined into a server and, like this one, still never be published.
+
+See the [main documentation](https://github.com/shellicar/claude-cli#readme).

--- a/packages/mcp-internals/package.json
+++ b/packages/mcp-internals/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@shellicar/mcp-internals",
+  "version": "1.0.0-beta.15",
+  "description": "Private helpers bundled into @shellicar MCP servers. Never published; inlined at build time so consumers carry no dependency.",
+  "private": true,
+  "license": "MIT",
+  "author": "Stephen Hellicar",
+  "contributors": [
+    "BananaBot9000 <bananabot9000@bananabot.dev>",
+    "Claude (Anthropic) <noreply@anthropic.com>"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shellicar/claude-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shellicar/claude-cli/issues"
+  },
+  "homepage": "https://github.com/shellicar/claude-cli#readme",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "watch": "tsup --watch",
+    "type-check": "tsc -p tsconfig.check.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@shellicar/build-clean": "^1.3.6",
+    "@shellicar/build-version": "^1.3.10",
+    "@shellicar/typescript-config": "workspace:^",
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^25.9.5",
+    "esbuild": "^0.28.0",
+    "tsup": "^8.5.1",
+    "tsx": "^4.22.5",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/mcp-internals/src/entry/index.ts
+++ b/packages/mcp-internals/src/entry/index.ts
@@ -1,0 +1,3 @@
+import { getDataDir } from '../getDataDir.js';
+
+export { getDataDir };

--- a/packages/mcp-internals/src/getDataDir.ts
+++ b/packages/mcp-internals/src/getDataDir.ts
@@ -1,0 +1,24 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Resolve the platform-appropriate persistent-data directory for `appName`.
+ * Honours $XDG_DATA_HOME on Linux if set (still the escape hatch everywhere,
+ * since anyone can export it), falls back to each OS's real convention.
+ */
+export function getDataDir(appName: string) {
+  const home = homedir();
+
+  if (process.env.XDG_DATA_HOME) {
+    return join(process.env.XDG_DATA_HOME, appName);
+  }
+
+  switch (process.platform) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', appName);
+    case 'win32':
+      return join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), appName);
+    default: // linux and friends
+      return join(home, '.local', 'share', appName);
+  }
+}

--- a/packages/mcp-internals/test/getDataDir.spec.ts
+++ b/packages/mcp-internals/test/getDataDir.spec.ts
@@ -1,0 +1,24 @@
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDataDir } from '../src/entry/index.js';
+
+describe('getDataDir', () => {
+  const original = process.env.XDG_DATA_HOME;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = original;
+    }
+  });
+
+  it('honours XDG_DATA_HOME when it is set', () => {
+    process.env.XDG_DATA_HOME = '/tmp/xdg-data';
+    const expected = join('/tmp/xdg-data', 'my-app');
+
+    const actual = getDataDir('my-app');
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/mcp-internals/tsconfig.check.json
+++ b/packages/mcp-internals/tsconfig.check.json
@@ -1,0 +1,1 @@
+../../tsconfig.check.json

--- a/packages/mcp-internals/tsconfig.json
+++ b/packages/mcp-internals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@shellicar/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/mcp-internals/tsup.config.ts
+++ b/packages/mcp-internals/tsup.config.ts
@@ -8,6 +8,7 @@ const commonOptions = (config: Options) =>
     bundle: true,
     clean: true,
     dts: true,
+    entry: ['src/entry/*.ts'],
     esbuildPlugins,
     esbuildOptions: (options) => {
       options.chunkNames = 'chunks/[name]-[hash]';
@@ -20,7 +21,7 @@ const commonOptions = (config: Options) =>
     sourcemap: true,
     splitting: true,
     target: 'node24',
-    treeshake: true,
+    treeshake: false,
     watch: config.watch,
     tsconfig: 'tsconfig.json',
   }) satisfies Options;
@@ -30,12 +31,10 @@ export default defineConfig((config) => [
     ...commonOptions(config),
     format: 'esm',
     outDir: 'dist/esm',
-    entry: ['src/entry/*.ts'],
   },
   {
     ...commonOptions(config),
     format: 'cjs',
     outDir: 'dist/cjs',
-    entry: ['src/entry/index.ts'],
   },
 ]);

--- a/packages/mcp-internals/vitest.config.ts
+++ b/packages/mcp-internals/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,9 +317,42 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+    devDependencies:
+      '@shellicar/build-clean':
+        specifier: ^1.3.6
+        version: 1.3.6(esbuild@0.28.1)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+      '@shellicar/build-version':
+        specifier: ^1.3.10
+        version: 1.3.10(esbuild@0.28.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
       '@shellicar/claude-sdk-tools':
         specifier: workspace:^
         version: link:../claude-sdk-tools
+      '@shellicar/typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      '@tsconfig/node24':
+        specifier: ^24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: ^25.9.5
+        version: 25.9.5
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+
+  packages/mcp-internals:
     devDependencies:
       '@shellicar/build-clean':
         specifier: ^1.3.6


### PR DESCRIPTION
## Summary

- Inline first-party @shellicar libraries into mcp-exec's output; @modelcontextprotocol/sdk stays external
- Consumers of @shellicar/mcp-exec now install only the third-party externals, not the @shellicar tree
- Add private, never-published @shellicar/mcp-internals as a bundle-ready helper source-of-truth
- Document that bundled and published are separate axes in CLAUDE.md