### PR TITLE
Move a running session to a new directory from command mode

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A running session can now move to another working directory from command mode, without restarting the process
 - Add --config flag to override any config value with a JSON object
 - Add --file flag to start with a file as the first message
 - Add --model flag: launch-time model override

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -102,3 +102,4 @@
 {"description":"Wrap injected content presented to the model (attachments, git delta, CLAUDE.md, SYSTEM.md, system identity) in XML-like tags instead of custom markers, so the model-facing format is consistent","category":"changed"}
 {"description":"Spawn the TypeScript server on demand for each tool block and tear it down after, replacing the always-on server that ran for the whole session","category":"changed"}
 {"description":"The --verify check now boot-checks the tsserver with a one-shot spawn instead of only looking for its path","category":"changed"}
+{"description":"A running session can now move to another working directory from command mode, without restarting the process","category":"added"}

--- a/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
+++ b/apps/claude-sdk-cli/src/ClaudeMdLoader.ts
@@ -1,75 +1,40 @@
-import { resolve } from 'node:path';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { dependsOn } from '@shellicar/core-di-lite';
-import { readIfPresent, wrapBlock } from './promptSource.js';
+import { ALL_PROMPT_SOURCES, loadPromptFiles, type PromptSources } from './promptFiles.js';
+import { wrapBlock } from './promptSource.js';
 import { IRuntimeOptions } from './setup/IRuntimeOptions.js';
 
 const INSTRUCTION_PREFIX = 'Codebase and user instructions are shown below. Be sure to adhere to these instructions. ' + 'IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.';
 
-export type ClaudeMdSources = {
-  user: boolean;
-  project: boolean;
-  projectClaude: boolean;
-  local: boolean;
+export type ClaudeMdSources = PromptSources;
+
+const SOURCE_LABELS: Record<keyof PromptSources, string> = {
+  user: "user's private global instructions for all projects",
+  project: 'project instructions',
+  projectClaude: 'project-scoped instructions',
+  local: 'local machine instructions (not committed)',
 };
-
-const DEFAULT_SOURCES: ClaudeMdSources = { user: true, project: true, projectClaude: true, local: true };
-
-type ClaudeMdFile = {
-  path: string;
-  label: string;
-  source: keyof ClaudeMdSources;
-};
-
-function claudeMdFiles(cwd: string, home: string): ClaudeMdFile[] {
-  return [
-    {
-      path: resolve(home, '.claude', 'CLAUDE.md'),
-      label: "user's private global instructions for all projects",
-      source: 'user',
-    },
-    {
-      path: resolve(cwd, 'CLAUDE.md'),
-      label: 'project instructions',
-      source: 'project',
-    },
-    {
-      path: resolve(cwd, '.claude', 'CLAUDE.md'),
-      label: 'project-scoped instructions',
-      source: 'projectClaude',
-    },
-    {
-      path: resolve(cwd, 'CLAUDE.local.md'),
-      label: 'local machine instructions (not committed)',
-      source: 'local',
-    },
-  ];
-}
 
 /**
- * Loads CLAUDE.md files from standard locations on demand.
- * Call `getContent()` each time you need the content — files are read fresh
- * on every call, so the read never needs a watcher. Note that once the content
- * is injected into a conversation's first message it is pinned there for cache
- * stability; a mid-session edit changes the read but not what the model sees
- * until a fresh conversation.
+ * Loads CLAUDE.md files from standard locations on demand, labels each and wraps
+ * them in a `<claude-md>` block behind the instruction prefix. Shares its
+ * file-loading with SystemPromptLoader via `loadPromptFiles`; only the formatting
+ * below is CLAUDE.md-specific. Call `getContent()` each time you need the content
+ * — files are read fresh on every call, so the read never needs a watcher. Note
+ * that once the content is injected into a conversation's first message it is
+ * pinned there for cache stability; a mid-session edit changes the read but not
+ * what the model sees until a fresh conversation.
  */
 export class ClaudeMdLoader {
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IRuntimeOptions) private readonly runtime!: IRuntimeOptions;
 
   /** Reads all CLAUDE.md files and returns the formatted content, or null if none were found. */
-  public async getContent(sources: ClaudeMdSources = DEFAULT_SOURCES): Promise<string | null> {
+  public async getContent(sources: ClaudeMdSources = ALL_PROMPT_SOURCES): Promise<string | null> {
     const sections: string[] = [];
 
-    for (const file of claudeMdFiles(this.fs.cwd(), this.fs.homedir())) {
-      if (!sources[file.source]) {
-        continue;
-      }
-      const content = await readIfPresent(this.fs, file.path);
-      if (content != null) {
-        sections.push(wrapBlock('claude-md', `Contents of ${file.path} (${file.label}):`, content));
-      }
+    for (const file of await loadPromptFiles(this.fs, 'CLAUDE', sources)) {
+      sections.push(wrapBlock('claude-md', `Contents of ${file.path} (${SOURCE_LABELS[file.source]}):`, file.content));
     }
 
     if (this.runtime.claudeMdFlagText != null) {

--- a/apps/claude-sdk-cli/src/SystemPromptLoader.ts
+++ b/apps/claude-sdk-cli/src/SystemPromptLoader.ts
@@ -1,59 +1,28 @@
-import { resolve } from 'node:path';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { dependsOn } from '@shellicar/core-di-lite';
-import { readIfPresent, wrapBlock } from './promptSource.js';
+import { ALL_PROMPT_SOURCES, loadPromptFiles, type PromptSources } from './promptFiles.js';
+import { wrapBlock } from './promptSource.js';
 
-export type SystemPromptSources = {
-  user: boolean;
-  project: boolean;
-  projectClaude: boolean;
-  local: boolean;
-};
-
-const DEFAULT_SOURCES: SystemPromptSources = { user: true, project: true, projectClaude: true, local: true };
-
-type SystemPromptFile = {
-  path: string;
-  source: keyof SystemPromptSources;
-};
-
-function systemPromptFiles(cwd: string, home: string): SystemPromptFile[] {
-  return [
-    { path: resolve(home, '.claude', 'SYSTEM.md'), source: 'user' },
-    { path: resolve(cwd, 'SYSTEM.md'), source: 'project' },
-    { path: resolve(cwd, '.claude', 'SYSTEM.md'), source: 'projectClaude' },
-    { path: resolve(cwd, 'SYSTEM.local.md'), source: 'local' },
-  ];
-}
+export type SystemPromptSources = PromptSources;
 
 /**
- * Loads SYSTEM.md files from the four standard locations on demand. Each
- * present, non-empty file becomes its own ordered entry, wrapped in a
- * `<system-md>` tag with a `Contents of <path>:` header as the first inner
- * line, so the model can see where each block came from. SYSTEM.md sources
- * carry a path but no human label (unlike ClaudeMdLoader), so the header is
- * the path alone. Unlike ClaudeMdLoader, no instruction prefix is added:
- * these are the real system-prompt blocks, composed additively into the
+ * Loads SYSTEM.md files from the four standard locations on demand. Each present,
+ * non-empty file becomes its own ordered entry, wrapped in a `<system-md>` tag
+ * with a `Contents of <path>:` header as the first inner line, so the model can
+ * see where each block came from. Shares its file-loading with ClaudeMdLoader via
+ * `loadPromptFiles`; unlike CLAUDE.md, no instruction prefix or human label is
+ * added — these are the real system-prompt blocks, composed additively into the
  * API `system` param.
  *
- * Files are read fresh on every call, so a new session picks up current
- * contents without a watcher (resolution timing is the caller's policy).
+ * Files are read fresh on every call, so a new session picks up current contents
+ * without a watcher (resolution timing is the caller's policy).
  */
 export class SystemPromptLoader {
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
 
   /** Returns the non-empty SYSTEM.md contents in source order, filtered by `sources`. */
-  public async getSections(sources: SystemPromptSources = DEFAULT_SOURCES): Promise<string[]> {
-    const sections: string[] = [];
-    for (const file of systemPromptFiles(this.fs.cwd(), this.fs.homedir())) {
-      if (!sources[file.source]) {
-        continue;
-      }
-      const content = await readIfPresent(this.fs, file.path);
-      if (content != null) {
-        sections.push(wrapBlock('system-md', `Contents of ${file.path}:`, content));
-      }
-    }
-    return sections;
+  public async getSections(sources: SystemPromptSources = ALL_PROMPT_SOURCES): Promise<string[]> {
+    const loaded = await loadPromptFiles(this.fs, 'SYSTEM', sources);
+    return loaded.map((file) => wrapBlock('system-md', `Contents of ${file.path}:`, file.content));
   }
 }

--- a/apps/claude-sdk-cli/src/cli-config/consts.ts
+++ b/apps/claude-sdk-cli/src/cli-config/consts.ts
@@ -2,6 +2,12 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
 export const CONFIG_PATH = resolve(homedir(), '.claude', 'sdk-config.json');
-export const LOCAL_CONFIG_PATH = resolve(process.cwd(), '.claude', 'sdk-config.json');
+
+/**
+ * The project-local config path, resolved against the *current* working
+ * directory on every call. Read live (not captured at module load) so that
+ * after the session moves it points at the new directory's config.
+ */
+export const localConfigPath = (): string => resolve(process.cwd(), '.claude', 'sdk-config.json');
 
 export const SCHEMA_URL = 'https://raw.githubusercontent.com/shellicar/claude-cli/main/schema/sdk-config.schema.json';

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -14,8 +15,9 @@ import { ConversationState } from '../model/ConversationState.js';
 import { ISystemIdentity } from '../model/ISystemIdentity.js';
 import { ModelSettings } from '../model/ModelSettings.js';
 import { StatusState } from '../model/StatusState.js';
+import { WorkingDirectory } from '../model/WorkingDirectory.js';
 
-export type CommandIntent = 'pasteText' | 'pasteFile' | 'pasteImage' | 'removeAttachment' | 'togglePreview' | 'newSession' | 'selectPrev' | 'selectNext' | 'enterModelSubMode' | 'cycleThinking' | 'cycleEffort';
+export type CommandIntent = 'pasteText' | 'pasteFile' | 'pasteImage' | 'removeAttachment' | 'togglePreview' | 'newSession' | 'selectPrev' | 'selectNext' | 'enterModelSubMode' | 'cycleThinking' | 'cycleEffort' | 'enterCdSubMode' | 'openCdEditor' | 'submitCd';
 
 /** Deliberate-path test for the missing-file chip (was AppLayout.isLikelyPath). */
 function isLikelyPath(s: string): boolean {
@@ -47,6 +49,8 @@ export class CommandIntentExecutor {
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(AuditStats) private readonly auditStats!: AuditStats;
   @dependsOn(IConvServe) private readonly convServe!: IConvServe;
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  @dependsOn(WorkingDirectory) private readonly workingDirectory!: WorkingDirectory;
 
   public async execute(intent: CommandIntent): Promise<void> {
     try {
@@ -93,9 +97,36 @@ export class CommandIntentExecutor {
         case 'cycleEffort':
           this.modelSettings.cycleEffort();
           return;
+        case 'enterCdSubMode':
+          this.commandModeState.enterCdSubMode();
+          return;
+        case 'openCdEditor':
+          this.commandModeState.openCdEditor(this.fs.cwd());
+          return;
+        case 'submitCd':
+          this.#submitCd();
+          return;
       }
     } catch {
       // Fire-and-forget: a failed clipboard read leaves state untouched.
+    }
+  }
+
+  /**
+   * Attempt the move to the typed path. The chdir is the only authoritative
+   * check: success closes the editor back to the cd sub-menu; failure keeps it
+   * open and shows the reason. The follow-on reloads ride the change event.
+   */
+  #submitCd(): void {
+    const editor = this.commandModeState.cdEditor;
+    if (editor == null) {
+      return;
+    }
+    const result = this.workingDirectory.change(editor.text);
+    if (result.ok) {
+      this.commandModeState.closeCdEditor();
+    } else {
+      this.commandModeState.setCdError(result.message);
     }
   }
 

--- a/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
@@ -11,9 +11,15 @@ export const PRIMARY_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new 
   ['i', 'pasteImage'],
   ['d', 'removeAttachment'],
   ['p', 'togglePreview'],
+  ['c', 'enterCdSubMode'],
   ['n', 'newSession'],
   ['m', 'enterModelSubMode'],
 ]);
+
+/** cd sub-menu command set: d opens the path editor. One entry by design — the
+ * sub-menu exists now so its shape does not have to change when more directory
+ * operations join it later. */
+export const CD_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new Map([['d', 'openCdEditor']]);
 
 /** Model sub-mode command set: t/e cycle the per-session thinking and effort. */
 export const MODEL_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new Map([
@@ -25,6 +31,7 @@ export const MODEL_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new Ma
 export const COMMAND_BINDINGS_BY_CONTEXT: ReadonlyMap<CommandContext, ReadonlyMap<string, CommandIntent>> = new Map([
   ['root', PRIMARY_COMMAND_BINDINGS],
   ['model', MODEL_COMMAND_BINDINGS],
+  ['cd', CD_COMMAND_BINDINGS],
 ]);
 
 /**
@@ -52,8 +59,13 @@ export class CommandKeyHandler implements InputHandler {
     if (!this.commandModeState.commandMode) {
       return false;
     }
+    if (this.commandModeState.context === 'cdEdit') {
+      return this.#handleCdEditorKey(key);
+    }
     if (key.type === 'escape') {
-      if (this.commandModeState.context === 'model') {
+      if (this.commandModeState.context === 'cd') {
+        this.commandModeState.exitCdSubMode();
+      } else if (this.commandModeState.context === 'model') {
         this.commandModeState.exitModelSubMode();
       } else {
         this.commandModeState.exitCommandMode();
@@ -77,6 +89,28 @@ export class CommandKeyHandler implements InputHandler {
       }
       return true;
     }
+    return true;
+  }
+
+  /**
+   * Modal path-editor keys. Enter is the authoritative submit (attempt the
+   * chdir); Escape backs out to the cd sub-menu with the cwd unchanged. Up/down
+   * are swallowed — a path is a single line. Every other key is forwarded to the
+   * editor buffer.
+   */
+  #handleCdEditorKey(key: KeyAction): boolean {
+    if (key.type === 'escape') {
+      this.commandModeState.closeCdEditor();
+      return true;
+    }
+    if (key.type === 'enter') {
+      void this.executor.execute('submitCd');
+      return true;
+    }
+    if (key.type === 'up' || key.type === 'down') {
+      return true;
+    }
+    this.commandModeState.handleCdEditorKey(key);
     return true;
   }
 }

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -1,8 +1,9 @@
 import { stat } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { Clock } from '@js-joda/core';
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { ConfigReloader } from '@shellicar/claude-core/Config/ConfigReloader';
 import type { IConfigOptions } from '@shellicar/claude-core/Config/IConfigOptions';
 import { IConfigWatcher } from '@shellicar/claude-core/Config/interfaces';
 import { ConfigWatchHandle } from '@shellicar/claude-core/Config/types';
@@ -15,7 +16,7 @@ import { AuditWriter } from './AuditWriter.js';
 import { ViewHost } from './app/ViewHost.js';
 import { IBus } from './bus/IBus.js';
 import { ClaudeMdLoader } from './ClaudeMdLoader.js';
-import { CONFIG_PATH, LOCAL_CONFIG_PATH } from './cli-config/consts.js';
+import { CONFIG_PATH, localConfigPath } from './cli-config/consts.js';
 import { formatEffectiveConfig } from './cli-config/formatEffectiveConfig.js';
 import { initConfig } from './cli-config/initConfig.js';
 import { parseConfigOverride } from './cli-config/parseConfigOverride.js';
@@ -44,6 +45,7 @@ import { PrimaryViewState } from './model/PrimaryViewState.js';
 import { StatusState } from './model/StatusState.js';
 import { TerminalState } from './model/TerminalState.js';
 import { ToolApprovalState } from './model/ToolApprovalState.js';
+import { WorkingDirectory } from './model/WorkingDirectory.js';
 import { ReadLine } from './ReadLine.js';
 import { replayHistory } from './replayHistory.js';
 import { buildRunAgentInput, runAgent, type UserInput } from './runAgent.js';
@@ -219,7 +221,11 @@ export const main = async (): Promise<void> => {
   const tsserverPath = resolveTsServerPath();
   const configOptions = {
     schema: sdkConfigSchema,
-    paths: [CONFIG_PATH, LOCAL_CONFIG_PATH],
+    // Read live so a mid-session move re-points the local override at the new
+    // directory's .claude/sdk-config.json — nothing is captured at startup.
+    get paths() {
+      return [CONFIG_PATH, localConfigPath()];
+    },
     // Hook commands may be written as `~`, `$HOME`, or config-relative paths;
     // the loader resolves them per-source so a relative path always refers to
     // the directory of the file it was authored in.
@@ -246,9 +252,10 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
 
   const provider = buildContainer({ configOptions, runtimeOptions, tsServerOptions, databaseOptions });
   // The config holder is built (and read) eagerly at buildProvider, and the
-  // watch is started by the ConfigWatchHandle factory at buildProvider. Bind
-  // the handle here so it disposes when this scope exits.
-  using _watch = provider.resolve(ConfigWatchHandle);
+  // watch is started by the ConfigWatchHandle factory at buildProvider. Held in
+  // a reassignable binding, not `using`, because a move re-points it: on cd the
+  // old handle is disposed and a fresh watch on the new directory replaces it.
+  let configWatch = provider.resolve(ConfigWatchHandle);
   const configLoader = provider.resolve(ConfigLoader);
 
   // Activation: async startup
@@ -328,8 +335,9 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
     // run_ended is clean-exit only; an ungraceful death is covered by heartbeat silence, not this.
     await Promise.race([bus.stop(), new Promise<void>((done) => setTimeout(done, 500).unref())]);
     // SIGINT exits abruptly (process.exit bypasses `using` disposal), so stop
-    // the config watch explicitly. Re-resolving returns the same started handle.
-    provider.resolve(ConfigWatchHandle)[Symbol.dispose]();
+    // the config watch explicitly. Dispose the current handle — after a move it
+    // is a re-pointed watch, not the one the factory first built.
+    configWatch[Symbol.dispose]();
     identityWatch?.[Symbol.dispose]();
     provider.resolve(TerminalRenderer).exit();
     process.exit(0);
@@ -473,6 +481,28 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
   const gitMonitor = provider.resolve(GitStateMonitor);
   const claudeMdLoader = provider.resolve(ClaudeMdLoader);
   const editorHandler = provider.resolve(EditorHandler);
+
+  // The move is the trigger. On a successful cd, re-point the config load and
+  // its watcher at the new directory and reload immediately, re-load SYSTEM.md
+  // and CLAUDE.md so their content follows the cwd, and refresh the status
+  // basename. This touches only the LOAD (which file applies + its content);
+  // the per-turn use/timing that consumes these values is left untouched. The
+  // permission fence needs no re-pointing — it already reads the live cwd on
+  // every tool-approval check, so it follows the move on its own.
+  const workingDirectory = provider.resolve(WorkingDirectory);
+  const configReloader = provider.resolve(ConfigReloader);
+  const configWatcher = provider.resolve(IConfigWatcher);
+  workingDirectory.on('change', (cwd) => {
+    configWatch[Symbol.dispose]();
+    configWatch = configWatcher.watch(configOptions.paths, () => configReloader.scheduleReload());
+    configReloader.reload();
+    statusState.setCwdBasename(basename(cwd));
+    void (async () => {
+      await configFactory.resolveSystemPromptsFor(session.id);
+      const claudeMdContent = configLoader.config.claudeMd.enabled ? await claudeMdLoader.getContent(configLoader.config.claudeMd.sources) : null;
+      configFactory.update(claudeMdContent);
+    })();
+  });
 
   const runTurn = async (userInput: UserInput) => {
     // A turn is live: a concurrent wire `say` against the tip is rejected until it ends (cancel frees it).

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -492,16 +492,21 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
   const workingDirectory = provider.resolve(WorkingDirectory);
   const configReloader = provider.resolve(ConfigReloader);
   const configWatcher = provider.resolve(IConfigWatcher);
+  const reloadPromptsAfterMove = async (): Promise<void> => {
+    try {
+      await configFactory.resolveSystemPromptsFor(session.id);
+      const claudeMdContent = configLoader.config.claudeMd.enabled ? await claudeMdLoader.getContent(configLoader.config.claudeMd.sources) : null;
+      configFactory.update(claudeMdContent);
+    } catch (err) {
+      logger.error('failed to reload prompt files after directory change', err);
+    }
+  };
   workingDirectory.on('change', (cwd) => {
     configWatch[Symbol.dispose]();
     configWatch = configWatcher.watch(configOptions.paths, () => configReloader.scheduleReload());
     configReloader.reload();
     statusState.setCwdBasename(basename(cwd));
-    void (async () => {
-      await configFactory.resolveSystemPromptsFor(session.id);
-      const claudeMdContent = configLoader.config.claudeMd.enabled ? await claudeMdLoader.getContent(configLoader.config.claudeMd.sources) : null;
-      configFactory.update(claudeMdContent);
-    })();
+    void reloadPromptsAfterMove();
   });
 
   const runTurn = async (userInput: UserInput) => {

--- a/apps/claude-sdk-cli/src/model/CommandModeState.ts
+++ b/apps/claude-sdk-cli/src/model/CommandModeState.ts
@@ -1,7 +1,9 @@
 import EventEmitter from 'node:events';
+import type { KeyAction } from '@shellicar/claude-core/input';
 import type { ImageMediaType } from '../clipboard.js';
 import type { Attachment } from './AttachmentStore.js';
 import { AttachmentStore } from './AttachmentStore.js';
+import { EditorState } from './EditorState.js';
 
 export type { Attachment, FileAttachment, ImageAttachment, TextAttachment } from './AttachmentStore.js';
 
@@ -16,12 +18,14 @@ type CommandModeStateEvents = {
  * No async I/O, no rendering. The clipboard reads and file-stat calls that happen
  * when the user presses t or f stay in AppLayout — they are I/O, not state.
  */
-export type CommandContext = 'root' | 'model';
+export type CommandContext = 'root' | 'model' | 'cd' | 'cdEdit';
 
 export class CommandModeState {
   #commandMode = false;
   #previewMode = false;
   #context: CommandContext = 'root';
+  #cdEditor: EditorState | null = null;
+  #cdError: string | null = null;
   #attachments = new AttachmentStore();
   readonly #emitter = new EventEmitter<CommandModeStateEvents>();
 
@@ -43,6 +47,16 @@ export class CommandModeState {
 
   public get context(): CommandContext {
     return this.#context;
+  }
+
+  /** The pre-filled path editor, present only while the cd editor is open. */
+  public get cdEditor(): EditorState | null {
+    return this.#cdEditor;
+  }
+
+  /** The last failed-move message, shown under the editor until the next edit. */
+  public get cdError(): string | null {
+    return this.#cdError;
   }
 
   public get hasAttachments(): boolean {
@@ -69,11 +83,60 @@ export class CommandModeState {
     this.#emitter.emit('change');
   }
 
+  /** Enter the cd sub-menu (root → cd). */
+  public enterCdSubMode(): void {
+    this.#context = 'cd';
+    this.#cdEditor = null;
+    this.#cdError = null;
+    this.#emitter.emit('change');
+  }
+
+  /** Pop the cd sub-menu (cd → root). */
+  public exitCdSubMode(): void {
+    this.#context = 'root';
+    this.#emitter.emit('change');
+  }
+
+  /** Open the path editor pre-filled with the current directory (cd → cdEdit). */
+  public openCdEditor(cwd: string): void {
+    this.#context = 'cdEdit';
+    this.#cdEditor = new EditorState({ lines: [cwd], cursorLine: 0, cursorCol: cwd.length });
+    this.#cdError = null;
+    this.#emitter.emit('change');
+  }
+
+  /** Close the path editor and return to the cd sub-menu (cdEdit → cd). */
+  public closeCdEditor(): void {
+    this.#context = 'cd';
+    this.#cdEditor = null;
+    this.#cdError = null;
+    this.#emitter.emit('change');
+  }
+
+  /** Show a failed-move message; the editor stays open. */
+  public setCdError(message: string): void {
+    this.#cdError = message;
+    this.#emitter.emit('change');
+  }
+
+  /** Forward an editing key to the open path editor, clearing any error on edit. */
+  public handleCdEditorKey(key: KeyAction): boolean {
+    if (this.#cdEditor == null) {
+      return false;
+    }
+    const consumed = this.#cdEditor.handleKey(key);
+    if (consumed) {
+      this.#cdError = null;
+      this.#emitter.emit('change');
+    }
+    return consumed;
+  }
+
   /** Enter or exit command mode. Only meaningful in editor mode. */
   public toggleCommandMode(): void {
     this.#commandMode = !this.#commandMode;
     if (!this.#commandMode) {
-      this.#context = 'root';
+      this.#resetContext();
     }
     this.#emitter.emit('change');
   }
@@ -82,8 +145,14 @@ export class CommandModeState {
   public exitCommandMode(): void {
     this.#commandMode = false;
     this.#previewMode = false;
-    this.#context = 'root';
+    this.#resetContext();
     this.#emitter.emit('change');
+  }
+
+  #resetContext(): void {
+    this.#context = 'root';
+    this.#cdEditor = null;
+    this.#cdError = null;
   }
 
   /** Reset all command mode state — used when streaming completes. */

--- a/apps/claude-sdk-cli/src/model/StatusState.ts
+++ b/apps/claude-sdk-cli/src/model/StatusState.ts
@@ -36,7 +36,7 @@ export class StatusState {
   #showConversationId = false;
   #thinkingOverride: 'on' | 'off' | null = null;
   #effortOverride: ThinkingEffort | null = null;
-  readonly #cwdBasename: string;
+  #cwdBasename: string;
   readonly #emitter = new EventEmitter<StatusStateEvents>();
 
   public get totalInputTokens(): number {
@@ -95,6 +95,13 @@ export class StatusState {
 
   public off<K extends keyof StatusStateEvents>(event: K, listener: (...args: StatusStateEvents[K]) => void): void {
     this.#emitter.off(event, listener);
+  }
+
+  /** Update the working-directory label. Called when the session moves so the
+   * status bar reflects the new directory (used only when no --name is set). */
+  public setCwdBasename(name: string): void {
+    this.#cwdBasename = name;
+    this.#emitter.emit('change');
   }
 
   public setModel(name: string, overridden = false): void {

--- a/apps/claude-sdk-cli/src/model/WorkingDirectory.ts
+++ b/apps/claude-sdk-cli/src/model/WorkingDirectory.ts
@@ -1,0 +1,72 @@
+import EventEmitter from 'node:events';
+import path from 'node:path';
+import { expandPath } from '@shellicar/claude-core/fs/expandPath';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { dependsOn } from '@shellicar/core-di-lite';
+
+type WorkingDirectoryEvents = {
+  /** Fires only after the move succeeds, carrying the new working directory. */
+  change: [cwd: string];
+};
+
+/** The outcome of an attempted move: success, or a failure carrying a display message. */
+export type ChangeDirectoryResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * The authority for moving a running session to a new working directory.
+ *
+ * `change` resolves the target against the current cwd (so `../` and relative
+ * segments behave as typed), then performs the one authoritative check — the
+ * `chdir` itself. Everything before it is advisory: a path can look valid and
+ * be gone the instant the move is attempted. On success it emits `change` with
+ * the new cwd; on failure it reports the reason and the cwd is untouched.
+ *
+ * The follow-on reloads (config, SYSTEM.md, CLAUDE.md, the status basename)
+ * hang off the `change` event, wired in `main`: the move is the trigger, the
+ * subscribers re-point and reload.
+ */
+export class WorkingDirectory {
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  readonly #emitter = new EventEmitter<WorkingDirectoryEvents>();
+
+  public on<K extends keyof WorkingDirectoryEvents>(event: K, listener: (...args: WorkingDirectoryEvents[K]) => void): void {
+    this.#emitter.on(event, listener);
+  }
+
+  public off<K extends keyof WorkingDirectoryEvents>(event: K, listener: (...args: WorkingDirectoryEvents[K]) => void): void {
+    this.#emitter.off(event, listener);
+  }
+
+  /**
+   * Attempt to move to `target`. A blank target is rejected rather than
+   * silently resolving to the current directory (which would chdir to where we
+   * already are and read as a successful no-op). Otherwise resolves `~`/`$VAR`
+   * and any relative or `..` segments against the current cwd, then chdirs.
+   * Returns success or a failure message; emits `change` only on success.
+   */
+  public change(target: string): ChangeDirectoryResult {
+    const trimmed = target.trim();
+    if (trimmed === '') {
+      return { ok: false, message: 'no directory entered' };
+    }
+    const resolved = path.resolve(this.fs.cwd(), expandPath(trimmed, this.fs));
+    try {
+      this.fs.chdir(resolved);
+    } catch (err) {
+      return { ok: false, message: describeChdirError(err) };
+    }
+    this.#emitter.emit('change', this.fs.cwd());
+    return { ok: true };
+  }
+}
+
+function describeChdirError(err: unknown): string {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ENOENT') {
+    return 'no such directory';
+  }
+  if (code === 'ENOTDIR') {
+    return 'not a directory';
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/claude-sdk-cli/src/promptFiles.ts
+++ b/apps/claude-sdk-cli/src/promptFiles.ts
@@ -1,0 +1,59 @@
+import { resolve } from 'node:path';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+
+/** The four standard locations a prompt file (CLAUDE.md, SYSTEM.md) is loaded from. */
+export type PromptSources = {
+  user: boolean;
+  project: boolean;
+  projectClaude: boolean;
+  local: boolean;
+};
+
+export const ALL_PROMPT_SOURCES: PromptSources = { user: true, project: true, projectClaude: true, local: true };
+
+/** A prompt file that was present on disk: its source slot, path, and trimmed content. */
+export type LoadedPromptFile = {
+  source: keyof PromptSources;
+  path: string;
+  content: string;
+};
+
+function promptFilePaths(baseName: string, cwd: string, home: string): { source: keyof PromptSources; path: string }[] {
+  return [
+    { source: 'user', path: resolve(home, '.claude', `${baseName}.md`) },
+    { source: 'project', path: resolve(cwd, `${baseName}.md`) },
+    { source: 'projectClaude', path: resolve(cwd, '.claude', `${baseName}.md`) },
+    { source: 'local', path: resolve(cwd, `${baseName}.local.md`) },
+  ];
+}
+
+async function readIfPresent(fs: IFileSystem, path: string): Promise<string | null> {
+  try {
+    const content = (await fs.readFile(path)).trim();
+    return content.length > 0 ? content : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The one loading mechanism shared by the CLAUDE.md and SYSTEM.md loaders:
+ * resolve the four standard locations for `baseName` against the live cwd/home,
+ * read each present, non-empty file (trimmed), and return them in source order,
+ * filtered by `sources`. Files are read fresh on every call, so the load follows
+ * a cwd change without a watcher. How the sections are labelled or joined is the
+ * caller's concern, not the load's.
+ */
+export async function loadPromptFiles(fs: IFileSystem, baseName: string, sources: PromptSources): Promise<LoadedPromptFile[]> {
+  const loaded: LoadedPromptFile[] = [];
+  for (const file of promptFilePaths(baseName, fs.cwd(), fs.homedir())) {
+    if (!sources[file.source]) {
+      continue;
+    }
+    const content = await readIfPresent(fs, file.path);
+    if (content != null) {
+      loaded.push({ source: file.source, path: file.path, content });
+    }
+  }
+  return loaded;
+}

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -106,6 +106,7 @@ import { SystemIdentity } from '../model/SystemIdentity.js';
 import { TerminalState } from '../model/TerminalState.js';
 import { ToolApprovalState } from '../model/ToolApprovalState.js';
 import { TurnClock } from '../model/TurnClock.js';
+import { WorkingDirectory } from '../model/WorkingDirectory.js';
 import { DatabaseFactory } from '../persistence/DatabaseFactory.js';
 import { IDatabaseOptions } from '../persistence/IDatabaseOptions.js';
 import { SqliteMemoryEngine } from '../persistence/SqliteMemoryEngine.js';
@@ -293,6 +294,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(EditorState).to(EditorState);
   services.register(ToolApprovalState).to(ToolApprovalState);
   services.register(CommandModeState).to(CommandModeState);
+  services.register(WorkingDirectory).to(WorkingDirectory);
   services.register(TerminalState).to(TerminalState);
   services.register(PrimaryViewState).to(PrimaryViewState);
   services.register(AppModeState).to(AppModeState);

--- a/apps/claude-sdk-cli/src/view/PrimaryView.ts
+++ b/apps/claude-sdk-cli/src/view/PrimaryView.ts
@@ -19,9 +19,10 @@ export class PrimaryView implements View {
     const rows = terminalState.rows;
 
     const { approvalRow, expandedRows: toolRows } = renderToolApproval(toolApprovalState, cols, Math.floor(rows / 2));
-    const { commandRow, previewRows } = renderCommandMode(commandModeState, session.id, cols, Math.max(1, Math.floor(rows / 3)), Math.floor(rows / 2));
+    const { commandRow, editorRows, previewRows } = renderCommandMode(commandModeState, session.id, cols, Math.max(1, Math.floor(rows / 3)), Math.floor(rows / 2));
     const expandedRows = [...toolRows, ...previewRows];
-    const statusBarHeight = 6 + expandedRows.length;
+    // editorRows (the cd path editor) sit above the command row; both add to the fixed footer height.
+    const statusBarHeight = 6 + editorRows.length + expandedRows.length;
     const contentRows = Math.max(2, rows - statusBarHeight);
 
     const allContent = renderConversation(conversationState, cols, configLoader.config.markdown);
@@ -42,6 +43,6 @@ export class PrimaryView implements View {
     // The view bar shares the command-mode row (existing footer chrome, not a
     // new row): it fills the row when no command hint is present. How the two
     // share the row when both are present is the deferred layout call.
-    return [...visibleRows, separator, modelLine, statusLine, clockLine, approvalRow, commandRow || viewBar, ...expandedRows];
+    return [...visibleRows, separator, modelLine, statusLine, clockLine, approvalRow, ...editorRows, commandRow || viewBar, ...expandedRows];
   }
 }

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -9,6 +9,7 @@ const CONTENT_INDENT = '   ';
 
 export type CommandModeRender = {
   commandRow: string;
+  editorRows: string[];
   previewRows: string[];
 };
 
@@ -27,8 +28,31 @@ export type CommandModeRender = {
 export function renderCommandMode(state: CommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number): CommandModeRender {
   return {
     commandRow: buildCommandRow(state, conversationId),
+    editorRows: buildEditorRows(state, cols),
     previewRows: buildPreviewRows(state, cols, maxTextLines, maxRows),
   };
+}
+
+/**
+ * The cd path-editor rows: the pre-filled path with a block cursor, and the
+ * failed-move message beneath it when a move has just failed. Empty unless the
+ * cd editor is open. Rendered above the command row (see PrimaryView).
+ */
+function buildEditorRows(state: CommandModeState, cols: number): string[] {
+  if (!state.commandMode || state.context !== 'cdEdit' || state.cdEditor == null) {
+    return [];
+  }
+  const line = state.cdEditor.lines[0] ?? '';
+  const cursorCol = state.cdEditor.cursorCol;
+  const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+  const grapheme = [...seg.segment(line)].find((s) => s.index === cursorCol);
+  const charUnder = grapheme?.segment ?? ' ';
+  const withCursor = `${line.slice(0, cursorCol)}${INVERSE_ON}${charUnder}${INVERSE_OFF}${line.slice(cursorCol + charUnder.length)}`;
+  const rows = wrapLine(` ${withCursor}`, cols);
+  if (state.cdError != null) {
+    rows.push(` \u2717 ${state.cdError}`);
+  }
+  return rows;
 }
 
 function buildCommandRow(state: CommandModeState, conversationId: string): string {
@@ -89,10 +113,14 @@ function buildCommandRow(state: CommandModeState, conversationId: string): strin
     b.ansi(RESET);
     if (state.context === 'model') {
       b.text('  t think  \u00b7  e effort  \u00b7  ESC back');
+    } else if (state.context === 'cd') {
+      b.text('  d directory  \u00b7  ESC back');
+    } else if (state.context === 'cdEdit') {
+      b.text('  ESC back');
     } else if (hasAttachments) {
-      b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  n new  \u00b7  ESC cancel');
+      b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  n new  \u00b7  ESC cancel');
     } else {
-      b.text('  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  n new  \u00b7  ESC cancel');
+      b.text('  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  n new  \u00b7  ESC cancel');
     }
   }
   return b.output;

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -18,6 +18,7 @@ import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
+import { WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
 import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
@@ -62,6 +63,7 @@ function makeExecutor(source: AttachmentSource) {
   services.register(StatusState).to(StatusState, () => new StatusState('test'));
   services.register(AuditStats).to(AuditStats); // resolves the already-registered IFileSystem
   services.register(IConvServe).to(IConvServe, () => ({ bind: () => {} }));
+  services.register(WorkingDirectory).to(WorkingDirectory);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   const provider = services.buildProvider();
   const executor = provider.resolve(CommandIntentExecutor);
@@ -212,6 +214,46 @@ describe('CommandIntentExecutor — model sub-mode', () => {
     await executor.execute('cycleEffort');
     const expected = 1;
     const actual = cycleCalls.effort;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CommandIntentExecutor — cd sub-mode', () => {
+  it('enterCdSubMode sets the command context to cd', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('enterCdSubMode');
+    const expected = 'cd';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('openCdEditor pre-fills the editor with the current directory', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('openCdEditor');
+    const expected = '/test';
+    const actual = commandModeState.cdEditor?.text ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('submitCd returns to the cd sub-menu on a successful move', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('openCdEditor');
+    await executor.execute('submitCd');
+    const expected = 'cd';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('submitCd keeps the editor open on a failed move', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('openCdEditor');
+    commandModeState.cdEditor?.reset();
+    for (const ch of '/nowhere') {
+      commandModeState.cdEditor?.handleKey({ type: 'char', value: ch });
+    }
+    await executor.execute('submitCd');
+    const expected = 'cdEdit';
+    const actual = commandModeState.context;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -19,6 +19,7 @@ import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
+import { WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
 import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
@@ -66,6 +67,7 @@ function makeHandler(sourceText: string | null = null) {
   services.register(StatusState).to(StatusState, () => new StatusState('test'));
   services.register(AuditStats).to(AuditStats);
   services.register(IConvServe).to(IConvServe, () => ({ bind: () => {} }));
+  services.register(WorkingDirectory).to(WorkingDirectory);
   services.register(CommandIntentExecutor).to(CommandIntentExecutor);
   services.register(CommandKeyHandler).to(CommandKeyHandler);
   const handler = services.buildProvider().resolve(CommandKeyHandler);
@@ -187,6 +189,140 @@ describe('CommandKeyHandler — model sub-mode', () => {
     handler.handleKey({ type: 'escape' });
     const expected = true;
     const actual = commandModeState.commandMode;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CommandKeyHandler — cd sub-mode', () => {
+  it('enters the cd sub-mode on c', () => {
+    const { handler, commandModeState } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'char', value: 'c' });
+    const expected = 'cd';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('opens the path editor on d inside the cd sub-mode', async () => {
+    const { handler, commandModeState } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'char', value: 'c' });
+    handler.handleKey({ type: 'char', value: 'd' });
+    await flush();
+    const expected = 'cdEdit';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('pre-fills the path editor with the current directory', async () => {
+    const { handler, commandModeState } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'char', value: 'c' });
+    handler.handleKey({ type: 'char', value: 'd' });
+    await flush();
+    const expected = '/test';
+    const actual = commandModeState.cdEditor?.text ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('pops the cd sub-menu back to root on escape', () => {
+    const { handler, commandModeState } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'char', value: 'c' });
+    handler.handleKey({ type: 'escape' });
+    const expected = 'root';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CommandKeyHandler — cd path editor', () => {
+  async function openEditor() {
+    const made = makeHandler();
+    made.handler.handleKey({ type: 'ctrl+/' });
+    made.handler.handleKey({ type: 'char', value: 'c' });
+    made.handler.handleKey({ type: 'char', value: 'd' });
+    await flush();
+    return made;
+  }
+
+  it('forwards a typed character to the editor buffer', async () => {
+    const { handler, commandModeState } = await openEditor();
+    handler.handleKey({ type: 'char', value: '/' });
+    const expected = '/test/';
+    const actual = commandModeState.cdEditor?.text ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('backs out to the cd sub-menu on escape', async () => {
+    const { handler, commandModeState } = await openEditor();
+    handler.handleKey({ type: 'escape' });
+    const expected = 'cd';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns to the cd sub-menu on a successful move', async () => {
+    const { handler, commandModeState } = await openEditor();
+    handler.handleKey({ type: 'enter' });
+    await flush();
+    const expected = 'cd';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the editor open and shows an error on a failed move', async () => {
+    const { handler, commandModeState } = await openEditor();
+    // Clear the pre-filled path and type a directory that does not exist.
+    for (let i = 0; i < '/test'.length; i++) {
+      handler.handleKey({ type: 'backspace' });
+    }
+    for (const ch of '/nowhere') {
+      handler.handleKey({ type: 'char', value: ch });
+    }
+    handler.handleKey({ type: 'enter' });
+    await flush();
+    const expected = 'cdEdit';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('surfaces the failure message under the editor', async () => {
+    const { handler, commandModeState } = await openEditor();
+    for (let i = 0; i < '/test'.length; i++) {
+      handler.handleKey({ type: 'backspace' });
+    }
+    for (const ch of '/nowhere') {
+      handler.handleKey({ type: 'char', value: ch });
+    }
+    handler.handleKey({ type: 'enter' });
+    await flush();
+    const expected = 'no such directory';
+    const actual = commandModeState.cdError;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the editor open when enter is pressed on an emptied path', async () => {
+    const { handler, commandModeState } = await openEditor();
+    for (let i = 0; i < '/test'.length; i++) {
+      handler.handleKey({ type: 'backspace' });
+    }
+    handler.handleKey({ type: 'enter' });
+    await flush();
+    const expected = 'cdEdit';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('shows the no-directory-entered message on an emptied path', async () => {
+    const { handler, commandModeState } = await openEditor();
+    for (let i = 0; i < '/test'.length; i++) {
+      handler.handleKey({ type: 'backspace' });
+    }
+    handler.handleKey({ type: 'enter' });
+    await flush();
+    const expected = 'no directory entered';
+    const actual = commandModeState.cdError;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/CommandModeState.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandModeState.spec.ts
@@ -291,3 +291,92 @@ describe('CommandModeState — context', () => {
     expect(actual).toBe(expected);
   });
 });
+
+describe('CommandModeState — cd sub-mode', () => {
+  it('enterCdSubMode sets the context to cd', () => {
+    const state = new CommandModeState();
+    state.enterCdSubMode();
+    const expected = 'cd';
+    const actual = state.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('exitCdSubMode returns the context to root', () => {
+    const state = new CommandModeState();
+    state.enterCdSubMode();
+    state.exitCdSubMode();
+    const expected = 'root';
+    const actual = state.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('openCdEditor sets the context to cdEdit', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    const expected = 'cdEdit';
+    const actual = state.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('openCdEditor pre-fills the editor with the given directory', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    const expected = '/repos/project';
+    const actual = state.cdEditor?.text ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('openCdEditor places the cursor at the end of the pre-filled path', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    const expected = '/repos/project'.length;
+    const actual = state.cdEditor?.cursorCol ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('closeCdEditor returns to the cd sub-menu', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    state.closeCdEditor();
+    const expected = 'cd';
+    const actual = state.context;
+    expect(actual).toBe(expected);
+  });
+
+  it('closeCdEditor clears the editor buffer', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    state.closeCdEditor();
+    const expected = null;
+    const actual = state.cdEditor;
+    expect(actual).toBe(expected);
+  });
+
+  it('setCdError records the failure message', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    state.setCdError('no such directory');
+    const expected = 'no such directory';
+    const actual = state.cdError;
+    expect(actual).toBe(expected);
+  });
+
+  it('handleCdEditorKey clears a shown error on the next edit', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/x');
+    state.setCdError('no such directory');
+    state.handleCdEditorKey({ type: 'char', value: '/' });
+    const expected = null;
+    const actual = state.cdError;
+    expect(actual).toBe(expected);
+  });
+
+  it('exitCommandMode clears the open cd editor', () => {
+    const state = new CommandModeState();
+    state.openCdEditor('/repos/project');
+    state.exitCommandMode();
+    const expected = null;
+    const actual = state.cdEditor;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/MemoryFileSystem.ts
+++ b/apps/claude-sdk-cli/test/MemoryFileSystem.ts
@@ -12,7 +12,7 @@ export class MemoryFileSystem extends IFileSystem {
   private readonly files = new Map<string, string>();
   private readonly env = new Map<string, string>();
   private readonly home: string;
-  private readonly cwd_: string;
+  private cwd_: string;
 
   public constructor(initial?: Record<string, string>, home = '/home/user', cwd = '/cwd') {
     super();
@@ -35,6 +35,22 @@ export class MemoryFileSystem extends IFileSystem {
 
   public cwd(): string {
     return this.cwd_;
+  }
+
+  public chdir(path: string): void {
+    if (this.files.has(path)) {
+      const err = new Error(`ENOTDIR: not a directory, chdir '${path}'`) as NodeJS.ErrnoException;
+      err.code = 'ENOTDIR';
+      throw err;
+    }
+    const prefix = path.endsWith('/') ? path : `${path}/`;
+    const known = path === this.home || path === this.cwd_ || [...this.files.keys()].some((p) => p.startsWith(prefix));
+    if (!known) {
+      const err = new Error(`ENOENT: no such file or directory, chdir '${path}'`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    this.cwd_ = path;
   }
 
   public homedir(): string {

--- a/apps/claude-sdk-cli/test/StatusState.spec.ts
+++ b/apps/claude-sdk-cli/test/StatusState.spec.ts
@@ -332,3 +332,13 @@ describe('StatusState — showConversationId', () => {
     expect(actual).toBe(expected);
   });
 });
+
+describe('StatusState — setCwdBasename', () => {
+  it('updates the working-directory label when the session moves', () => {
+    const state = new StatusState('chdir');
+    state.setCwdBasename('hello');
+    const expected = 'hello';
+    const actual = state.cwdBasename;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -34,6 +34,7 @@ import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { TerminalState } from '../src/model/TerminalState.js';
 import { ToolApprovalState } from '../src/model/ToolApprovalState.js';
 import { TurnClock } from '../src/model/TurnClock.js';
+import { WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { ConsumerChannel } from '../src/setup/ConsumerChannel.js';
 import { PrimaryView } from '../src/view/PrimaryView.js';
 import type { TerminalRenderer } from '../src/view/TerminalRenderer.js';
@@ -233,6 +234,7 @@ describe('ViewHost — escape routing through the primary chains', () => {
     services.register(StatusState).to(StatusState, () => new StatusState('test'));
     services.register(AuditStats).to(AuditStats);
     services.register(IConvServe).to(IConvServe, () => ({ bind: () => {} }));
+    services.register(WorkingDirectory).to(WorkingDirectory);
     services.register(CommandIntentExecutor).to(CommandIntentExecutor);
     services.register(ApprovalHandler).to(ApprovalHandler);
     services.register(CommandKeyHandler).to(CommandKeyHandler);

--- a/apps/claude-sdk-cli/test/WorkingDirectory.spec.ts
+++ b/apps/claude-sdk-cli/test/WorkingDirectory.spec.ts
@@ -1,0 +1,127 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { createServiceCollection } from '@shellicar/core-di-lite';
+import { describe, expect, it } from 'vitest';
+import { WorkingDirectory } from '../src/model/WorkingDirectory.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+function make(cwd = '/repos/project/chdir') {
+  const fs = new MemoryFileSystem({ '/repos/hello/file.txt': 'x', '/repos/project/afile': 'y' }, '/home/user', cwd);
+  const services = createServiceCollection();
+  services.register(IFileSystem).to(IFileSystem, () => fs);
+  services.register(WorkingDirectory).to(WorkingDirectory);
+  const workingDirectory = services.buildProvider().resolve(WorkingDirectory);
+  return { workingDirectory, fs };
+}
+
+describe('WorkingDirectory — successful move', () => {
+  it('reports success for an existing directory', () => {
+    const { workingDirectory } = make();
+    const expected = true;
+    const actual = workingDirectory.change('/repos/hello').ok;
+    expect(actual).toBe(expected);
+  });
+
+  it('moves the working directory to the target', () => {
+    const { workingDirectory, fs } = make();
+    const expected = '/repos/hello';
+    workingDirectory.change('/repos/hello');
+    const actual = fs.cwd();
+    expect(actual).toBe(expected);
+  });
+
+  it('emits the change event with the new directory', () => {
+    const { workingDirectory } = make();
+    const expected = '/repos/hello';
+    let actual: string | null = null;
+    workingDirectory.on('change', (cwd) => {
+      actual = cwd;
+    });
+    workingDirectory.change('/repos/hello');
+    expect(actual).toBe(expected);
+  });
+
+  it('resolves relative .. segments against the current directory', () => {
+    const { workingDirectory, fs } = make();
+    const expected = '/repos/hello';
+    workingDirectory.change('/repos/project/chdir/../../hello');
+    const actual = fs.cwd();
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('WorkingDirectory — failed move', () => {
+  it('reports failure when the directory does not exist', () => {
+    const { workingDirectory } = make();
+    const expected = false;
+    const actual = workingDirectory.change('/nowhere').ok;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries a no-such-directory message on ENOENT', () => {
+    const { workingDirectory } = make();
+    const expected = 'no such directory';
+    const result = workingDirectory.change('/nowhere');
+    const actual = result.ok ? null : result.message;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries a not-a-directory message when the target is a file', () => {
+    const { workingDirectory } = make();
+    const expected = 'not a directory';
+    const result = workingDirectory.change('/repos/project/afile');
+    const actual = result.ok ? null : result.message;
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves the working directory unchanged on failure', () => {
+    const { workingDirectory, fs } = make();
+    const expected = '/repos/project/chdir';
+    workingDirectory.change('/nowhere');
+    const actual = fs.cwd();
+    expect(actual).toBe(expected);
+  });
+
+  it('does not emit the change event on failure', () => {
+    const { workingDirectory } = make();
+    const expected = 0;
+    let count = 0;
+    workingDirectory.on('change', () => {
+      count += 1;
+    });
+    workingDirectory.change('/nowhere');
+    const actual = count;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('WorkingDirectory — blank input', () => {
+  it('reports failure for an empty target', () => {
+    const { workingDirectory } = make();
+    const expected = false;
+    const actual = workingDirectory.change('').ok;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries a no-directory-entered message for an empty target', () => {
+    const { workingDirectory } = make();
+    const expected = 'no directory entered';
+    const result = workingDirectory.change('');
+    const actual = result.ok ? null : result.message;
+    expect(actual).toBe(expected);
+  });
+
+  it('rejects a whitespace-only target', () => {
+    const { workingDirectory } = make();
+    const expected = false;
+    const actual = workingDirectory.change('   ').ok;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not move for an empty target', () => {
+    const { workingDirectory, fs } = make();
+    const expected = '/repos/project/chdir';
+    workingDirectory.change('');
+    const actual = fs.cwd();
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
+++ b/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
@@ -231,3 +231,59 @@ describe('renderCommandMode — conversationId', () => {
     expect(actual).toBe(expected);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cd sub-menu and path editor
+// ---------------------------------------------------------------------------
+
+function stateInCd(): CommandModeState {
+  const state = new CommandModeState();
+  state.toggleCommandMode();
+  state.enterCdSubMode();
+  return state;
+}
+
+function stateInCdEditor(cwd = '/repos/project'): CommandModeState {
+  const state = new CommandModeState();
+  state.toggleCommandMode();
+  state.openCdEditor(cwd);
+  return state;
+}
+
+describe('renderCommandMode — cd sub-menu', () => {
+  it('root command row offers the c cd entry', () => {
+    const expected = true;
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('c cd');
+    expect(actual).toBe(expected);
+  });
+
+  it('cd sub-menu command row offers the directory entry', () => {
+    const expected = true;
+    const actual = renderCommandMode(stateInCd(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('d directory');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('renderCommandMode — cd path editor', () => {
+  it('editorRows is empty when the cd editor is closed', () => {
+    const expected = 0;
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('editorRows shows the pre-filled path', () => {
+    const rows = renderCommandMode(stateInCdEditor('/repos/sentinel-dir'), '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows;
+    const expected = true;
+    const actual = rows.some((r) => r.includes('/repos/sentinel-dir'));
+    expect(actual).toBe(expected);
+  });
+
+  it('editorRows shows the failure message when a move failed', () => {
+    const state = stateInCdEditor();
+    state.setCdError('no such directory');
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows;
+    const expected = true;
+    const actual = rows.some((r) => r.includes('no such directory'));
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a chdir operation to the IFileSystem contract
 - Add a README describing the package and pointing to the main documentation
 - Add IObjectStore interface for injectable persistence
 - Add overrides option to ConfigLoader for a highest-precedence config layer

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -13,3 +13,4 @@
 {"description":"File discovery returns records carrying type, size, and symlink target instead of bare path strings","category":"changed"}
 {"description":"Add rename and platform operations to the IFileSystem contract","category":"added"}
 {"description":"Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged","category":"added"}
+{"description":"Add a chdir operation to the IFileSystem contract","category":"added"}

--- a/packages/claude-core/src/fs/interfaces.ts
+++ b/packages/claude-core/src/fs/interfaces.ts
@@ -4,6 +4,8 @@ import { walk } from './walk';
 
 export abstract class IFileSystem {
   public abstract cwd(): string;
+  /** Move the working directory. The authoritative move: everything reading `cwd()` live follows it. */
+  public abstract chdir(path: string): void;
   public abstract homedir(): string;
   public abstract exists(path: string): Promise<boolean>;
   public abstract readFile(path: string, encoding?: BufferEncoding): Promise<string>;

--- a/packages/claude-core/test/MemoryFileSystem.ts
+++ b/packages/claude-core/test/MemoryFileSystem.ts
@@ -33,6 +33,10 @@ export class MemoryFileSystem extends IFileSystem {
     throw new Error('MemoryFileSystem: cwd() not supported');
   }
 
+  public chdir(): void {
+    throw new Error('MemoryFileSystem: chdir() not supported');
+  }
+
   public exists(): Promise<boolean> {
     throw new Error('MemoryFileSystem: exists() not supported');
   }

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem
 - Add AppendFile tool: appends text to a file, creating it if missing
 - Add atomic rename and platform lookup to the Node filesystem implementation
+- Add chdir to the Node filesystem implementation, moving the process working directory
 - Add ExecV2 tool: execute commands as a recursive AST (commands joined by ;, &&, ||, &, | operators) instead of a steps array
 - Add ExecV3 structured execution tool
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -42,3 +42,4 @@
 {"description":"The TypeScript tools now read each file fresh from disk, spawning a short-lived tsserver per tool block instead of a session-long server that kept reporting its first snapshot","category":"fixed"}
 {"description":"A failed tsserver request now throws instead of returning an empty result that was indistinguishable from a clean file","category":"fixed"}
 {"description":"TsReferences and TsDefinition group their results by file path, and TsDiagnostics accepts a batch of files in one call","category":"changed"}
+{"description":"Add chdir to the Node filesystem implementation, moving the process working directory","category":"added"}

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -17,6 +17,10 @@ export class NodeFileSystem extends IFileSystem {
     return process.cwd();
   }
 
+  public chdir(path: string): void {
+    process.chdir(path);
+  }
+
   public homedir(): string {
     return osHomedir();
   }

--- a/packages/claude-sdk-tools/test/MemoryFileSystem.ts
+++ b/packages/claude-sdk-tools/test/MemoryFileSystem.ts
@@ -12,7 +12,7 @@ export class MemoryFileSystem extends IFileSystem {
   private readonly files = new Map<string, Buffer>();
   private readonly env = new Map<string, string>();
   private readonly home: string;
-  private readonly cwd_: string;
+  private cwd_: string;
 
   public constructor(initial?: Record<string, string | Buffer>, home = '/home/user', cwd = '/cwd') {
     super();
@@ -35,6 +35,10 @@ export class MemoryFileSystem extends IFileSystem {
 
   public cwd(): string {
     return this.cwd_;
+  }
+
+  public chdir(path: string): void {
+    this.cwd_ = path;
   }
 
   public homedir(): string {

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -58,6 +58,7 @@ class SymlinkMockFileSystem extends IFileSystem {
   public cwd(): string {
     return ROOT;
   }
+  public chdir(): void {}
   public homedir(): string {
     return '/home/user';
   }


### PR DESCRIPTION
## Summary

- Add a `[c]d` -> `[d]irectory` command-mode entry that moves the session to a new working directory without restarting
- Every loaded file (local config, SYSTEM.md, CLAUDE.md) re-points and reloads on the move; the status bar and permission fence follow the new cwd
- Add a `chdir` operation to the `IFileSystem` contract and its Node implementation
- Fold the CLAUDE.md and SYSTEM.md loaders onto one shared file-loading mechanism