### PR TITLE
Default the user CLAUDE.md and SYSTEM.md sources off

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spawn the TypeScript server on demand for each tool block and tear it down after, replacing the always-on server that ran for the whole session
 - Split model identifier into name and version for separate use
 - The --verify check now boot-checks the tsserver with a one-shot spawn instead of only looking for its path
+- The user-level CLAUDE.md and SYSTEM.md sources now default off, so nothing is silently concatenated into a session at launch; project, projectClaude and local sources are unchanged, and setting user back to true in config remains supported
 - Update runtime and build dependencies
 - Updated patch and minor dependencies
 - Updated patch dependencies

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -103,3 +103,4 @@
 {"description":"Spawn the TypeScript server on demand for each tool block and tear it down after, replacing the always-on server that ran for the whole session","category":"changed"}
 {"description":"The --verify check now boot-checks the tsserver with a one-shot spawn instead of only looking for its path","category":"changed"}
 {"description":"A running session can now move to another working directory from command mode, without restarting the process","category":"added"}
+{"description":"The user-level CLAUDE.md and SYSTEM.md sources now default off, so nothing is silently concatenated into a session at launch; project, projectClaude and local sources are unchanged, and setting user back to true in config remains supported","category":"changed"}

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -18,14 +18,14 @@ const historyReplaySchema = z
 
 const claudeMdSourcesSchema = z
   .object({
-    user: z.boolean().optional().default(true).catch(true).describe('Load ~/.claude/CLAUDE.md'),
+    user: z.boolean().optional().default(false).catch(false).describe('Load ~/.claude/CLAUDE.md'),
     project: z.boolean().optional().default(true).catch(true).describe('Load ./CLAUDE.md'),
     projectClaude: z.boolean().optional().default(true).catch(true).describe('Load ./.claude/CLAUDE.md'),
     local: z.boolean().optional().default(true).catch(true).describe('Load ./CLAUDE.local.md'),
   })
   .optional()
-  .default({ user: true, project: true, projectClaude: true, local: true })
-  .catch({ user: true, project: true, projectClaude: true, local: true });
+  .default({ user: false, project: true, projectClaude: true, local: true })
+  .catch({ user: false, project: true, projectClaude: true, local: true });
 
 const claudeMdSchema = z
   .object({
@@ -33,19 +33,19 @@ const claudeMdSchema = z
     sources: claudeMdSourcesSchema.describe('Per-source CLAUDE.md loading control'),
   })
   .optional()
-  .default({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } })
-  .catch({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } });
+  .default({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true } })
+  .catch({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true } });
 
 const systemPromptSourcesSchema = z
   .object({
-    user: z.boolean().optional().default(true).catch(true).describe('Load ~/.claude/SYSTEM.md'),
+    user: z.boolean().optional().default(false).catch(false).describe('Load ~/.claude/SYSTEM.md'),
     project: z.boolean().optional().default(true).catch(true).describe('Load ./SYSTEM.md'),
     projectClaude: z.boolean().optional().default(true).catch(true).describe('Load ./.claude/SYSTEM.md'),
     local: z.boolean().optional().default(true).catch(true).describe('Load ./SYSTEM.local.md'),
   })
   .optional()
-  .default({ user: true, project: true, projectClaude: true, local: true })
-  .catch({ user: true, project: true, projectClaude: true, local: true });
+  .default({ user: false, project: true, projectClaude: true, local: true })
+  .catch({ user: false, project: true, projectClaude: true, local: true });
 
 const systemPromptSchema = z
   .object({
@@ -54,8 +54,8 @@ const systemPromptSchema = z
     text: z.string().nullable().optional().default(null).catch(null).describe('Inline system prompt contributed by config, appended after SYSTEM.md files'),
   })
   .optional()
-  .default({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true }, text: null })
-  .catch({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true }, text: null });
+  .default({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true }, text: null })
+  .catch({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true }, text: null });
 
 const compactSchema = z
   .object({

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -16,8 +16,8 @@ describe('sdkConfigSchema', () => {
         maxTokens: 32_000,
         thinking: { enabled: true, effort: 'high' },
         historyReplay: { enabled: true, showThinking: false },
-        claudeMd: { enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } },
-        systemPrompt: { enabled: true, sources: { user: true, project: true, projectClaude: true, local: true }, text: null },
+        claudeMd: { enabled: true, sources: { user: false, project: true, projectClaude: true, local: true } },
+        systemPrompt: { enabled: true, sources: { user: false, project: true, projectClaude: true, local: true }, text: null },
         compact: { enabled: false, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null },
         advancedTools: { enabled: true, searchTool: null, allowProgrammaticExecution: [], codeExecutionTool: 'code_execution_20260120' },
         serverTools: {
@@ -97,7 +97,7 @@ describe('sdkConfigSchema', () => {
 
     it('falls back to defaults on invalid value', () => {
       const config = parse({ claudeMd: 'bad' });
-      expect(config.claudeMd).toEqual({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true } });
+      expect(config.claudeMd).toEqual({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true } });
     });
 
     it('falls back field to default on wrong type', () => {
@@ -105,9 +105,9 @@ describe('sdkConfigSchema', () => {
       expect(config.claudeMd.enabled).toBe(true);
     });
 
-    it('defaults all sources to true', () => {
+    it('defaults the user source to false and the rest to true', () => {
       const config = parse({});
-      expect(config.claudeMd.sources).toEqual({ user: true, project: true, projectClaude: true, local: true });
+      expect(config.claudeMd.sources).toEqual({ user: false, project: true, projectClaude: true, local: true });
     });
 
     it('overrides individual source', () => {
@@ -117,7 +117,7 @@ describe('sdkConfigSchema', () => {
 
     it('falls back sources field to default on wrong type', () => {
       const config = parse({ claudeMd: { sources: { user: 'no' } } });
-      expect(config.claudeMd.sources.user).toBe(true);
+      expect(config.claudeMd.sources.user).toBe(false);
     });
   });
 
@@ -127,9 +127,9 @@ describe('sdkConfigSchema', () => {
       expect(config.systemPrompt.enabled).toBe(true);
     });
 
-    it('defaults all sources to true', () => {
+    it('defaults the user source to false and the rest to true', () => {
       const config = parse({});
-      expect(config.systemPrompt.sources).toEqual({ user: true, project: true, projectClaude: true, local: true });
+      expect(config.systemPrompt.sources).toEqual({ user: false, project: true, projectClaude: true, local: true });
     });
 
     it('defaults text to null', () => {
@@ -154,7 +154,7 @@ describe('sdkConfigSchema', () => {
 
     it('falls back to defaults on an invalid section value', () => {
       const config = parse({ systemPrompt: 'bad' });
-      expect(config.systemPrompt).toEqual({ enabled: true, sources: { user: true, project: true, projectClaude: true, local: true }, text: null });
+      expect(config.systemPrompt).toEqual({ enabled: true, sources: { user: false, project: true, projectClaude: true, local: true }, text: null });
     });
 
     it('falls back enabled to default on wrong type', () => {
@@ -164,7 +164,7 @@ describe('sdkConfigSchema', () => {
 
     it('falls back a source field to default on wrong type', () => {
       const config = parse({ systemPrompt: { sources: { user: 'no' } } });
-      expect(config.systemPrompt.sources.user).toBe(true);
+      expect(config.systemPrompt.sources.user).toBe(false);
     });
 
     it('falls back text to default on wrong type', () => {

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -68,7 +68,7 @@
       "default": {
         "enabled": true,
         "sources": {
-          "user": true,
+          "user": false,
           "project": true,
           "projectClaude": true,
           "local": true
@@ -84,7 +84,7 @@
         },
         "sources": {
           "default": {
-            "user": true,
+            "user": false,
             "project": true,
             "projectClaude": true,
             "local": true
@@ -93,7 +93,7 @@
           "type": "object",
           "properties": {
             "user": {
-              "default": true,
+              "default": false,
               "description": "Load ~/.claude/CLAUDE.md",
               "type": "boolean"
             },
@@ -120,7 +120,7 @@
       "default": {
         "enabled": true,
         "sources": {
-          "user": true,
+          "user": false,
           "project": true,
           "projectClaude": true,
           "local": true
@@ -137,7 +137,7 @@
         },
         "sources": {
           "default": {
-            "user": true,
+            "user": false,
             "project": true,
             "projectClaude": true,
             "local": true
@@ -146,7 +146,7 @@
           "type": "object",
           "properties": {
             "user": {
-              "default": true,
+              "default": false,
               "description": "Load ~/.claude/SYSTEM.md",
               "type": "boolean"
             },


### PR DESCRIPTION
## Summary

- Default `claudeMd.sources.user` and `systemPrompt.sources.user` to `false`, so the user-level `~/.claude/CLAUDE.md` and `SYSTEM.md` are no longer silently merged into a session at launch
- Makes `--claudeMd` the sole context channel: a composed session gets everything through it, a bare session is genuinely empty
- Project, projectClaude and local sources unchanged; setting user back to `true` in config remains an explicit opt-in