### PR TITLE
Add a Skill tool and inject an available-skills catalogue

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add per-source CLAUDE.md loading control
 - Add the --system-identity flag: bind a system prompt to a conversation from a file, persisted and restored on resume
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions
+- Add the skillDirs config setting: an ordered, replacement-only list of skill roots the Skill tool resolves across, with later roots overriding earlier ones and an empty list resolving nothing
 - Add tools config to select execution tools; ExecV2 enabled by default, Exec (V1) off
 - Add web search and web fetch as built-in server tools
 - Allow --file to be specified multiple times; files attach in argument order
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESC while a tool is running cancels the tool instead of the query, so Claude receives the cancellation and can continue
 - Flash tool approval prompt with inverted colours when awaiting Y/N
 - Format 1M+ token counts with M suffix in the status bar
+- Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load
 - Mark model with * suffix in status bar when overridden via --model
 - Publish conversation activity as opt-in NATS tap events
 - Ref and PreviewEdit state is now persisted to disk

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -104,3 +104,5 @@
 {"description":"The --verify check now boot-checks the tsserver with a one-shot spawn instead of only looking for its path","category":"changed"}
 {"description":"A running session can now move to another working directory from command mode, without restarting the process","category":"added"}
 {"description":"The user-level CLAUDE.md and SYSTEM.md sources now default off, so nothing is silently concatenated into a session at launch; project, projectClaude and local sources are unchanged, and setting user back to true in config remains supported","category":"changed"}
+{"description":"Add the skillDirs config setting: an ordered, replacement-only list of skill roots the Skill tool resolves across, with later roots overriding earlier ones and an empty list resolving nothing","category":"added"}
+{"description":"Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load","category":"added"}

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -271,6 +271,12 @@ export const sdkConfigSchema = z
     historyReplay: historyReplaySchema.describe('History replay configuration'),
     claudeMd: claudeMdSchema.describe('CLAUDE.md loading configuration'),
     systemPrompt: systemPromptSchema.describe('System prompt (SYSTEM.md + inline) configuration'),
+    skillDirs: z
+      .array(z.string())
+      .optional()
+      .default([])
+      .catch([])
+      .describe('Ordered skill root directories the Skill tool resolves across. Replacement-only: this array is the whole set for a session, never merged with a built-in default. Later directories override earlier ones on a name collision. Empty (the default) resolves nothing.'),
     compact: compactSchema.describe('Compaction configuration'),
     advancedTools: advancedToolsSchema.describe('Advanced tool use configuration'),
     serverTools: serverToolsSchema,

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -138,6 +138,9 @@ function formatToolSummary(name: string, input: Record<string, unknown>, cwd: st
       .join(' | ');
     return steps;
   }
+  if (name === 'Skill' && typeof input.skill === 'string') {
+    return `Skill(${input.skill})`;
+  }
   const arg = displayArg(input, cwd, resolveSchema(name));
   return arg ? `${name}(${arg})` : name;
 }

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -23,6 +23,7 @@ import { Read } from '@shellicar/claude-sdk-tools/Read';
 import { createReadFileTool } from '@shellicar/claude-sdk-tools/ReadFile';
 import { createRef } from '@shellicar/claude-sdk-tools/Ref';
 import { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
+import { createSkillTool } from '@shellicar/claude-sdk-tools/Skill';
 import { Tail } from '@shellicar/claude-sdk-tools/Tail';
 import { createTsDefinition } from '@shellicar/claude-sdk-tools/TsDefinition';
 import { createTsDiagnostics } from '@shellicar/claude-sdk-tools/TsDiagnostics';
@@ -49,9 +50,11 @@ export type CreateAppToolsOptions = {
   memory: IMemoryStore;
   tsAvailable: boolean;
   logger: ILogger;
+  /** Skill roots the Skill tool resolves across, already expanded to absolute paths. Absent or empty resolves nothing. */
+  skillDirs?: string[];
 };
 
-export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, tsAvailable, logger }: CreateAppToolsOptions): AppTools {
+export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, tsAvailable, logger, skillDirs = [] }: CreateAppToolsOptions): AppTools {
   const store = new RefStore(objects);
   const ReadFile = createReadFileTool(logger);
   const { previewEdit: PreviewEdit, editFile: EditFile } = createEditFilePair(fs, objects);
@@ -83,6 +86,7 @@ export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, tsA
     tools.push({ ...createTsDiagnostics(tsServer), blockLifetime: tsServer }, { ...createTsHover(tsServer), blockLifetime: tsServer }, { ...createTsReferences(tsServer), blockLifetime: tsServer }, { ...createTsDefinition(tsServer), blockLifetime: tsServer });
   }
   tools.push(...createMemoryTools(memory));
+  tools.push(createSkillTool(fs, skillDirs, logger));
 
   // Stages run only inside a pipe, so they are not in `tools`. The permission resolver looks every pipe
   // step up by name and reads its operation and input_schema (to locate marked paths), so it needs them

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -425,6 +425,9 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
   // factory). Resolve once for this session here; runTurn re-resolves on a
   // session change. The config getter reads the resolved prompts each turn.
   await configFactory.resolveSystemPromptsFor(session.id);
+  // Scan the configured skill roots once and hold the catalogue reminder. Static for the session; it
+  // rides cachedReminders (see DurableConfigFactory.update) into the first user message and post-compact.
+  await configFactory.resolveSkillCatalogue();
   sdkChannel.subscribe(async (msg: SdkMessage) => {
     handler.handle(msg);
     // Deltas are the streaming assistant text, published bare (the spec waives the envelope `ts` for them).

--- a/apps/claude-sdk-cli/src/setup/DurableConfigFactory.ts
+++ b/apps/claude-sdk-cli/src/setup/DurableConfigFactory.ts
@@ -1,7 +1,11 @@
+import path from 'node:path';
 import type { BetaToolSearchToolBm25_20251119, BetaToolSearchToolRegex20251119 } from '@anthropic-ai/sdk/resources/beta.mjs';
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { expandPath } from '@shellicar/claude-core/fs/expandPath';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { AnthropicBeta, type BetaToolUnion, CacheTtl, type DurableConfig, IDurableConfigProvider } from '@shellicar/claude-sdk';
+import { buildSkillCatalogue } from '@shellicar/claude-sdk-tools/Skill';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { buildAtuTransform, withPathNote } from '../buildAtuTransform.js';
 import { buildServerTools } from '../buildServerTools.js';
@@ -23,9 +27,11 @@ export class DurableConfigFactory extends IDurableConfigProvider {
   @dependsOn(SystemPromptLoader) private readonly systemPromptLoader!: SystemPromptLoader;
   @dependsOn(IRuntimeOptions) private readonly runtime!: IRuntimeOptions;
   @dependsOn(ILogger) private readonly logger!: ILogger;
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   #resolvedSystemPrompts: string[] = [];
   #systemPromptSessionId: string | null = null;
   #cachedReminders: string[] | undefined;
+  #skillCatalogue: string | null = null;
   #identityBody: string | null = null;
 
   /**
@@ -50,6 +56,21 @@ export class DurableConfigFactory extends IDurableConfigProvider {
     const fileSections = cfg.enabled ? await this.systemPromptLoader.getSections(cfg.sources) : [];
     this.#resolvedSystemPrompts = composeSystemPrompts({ fileSections, configText: cfg.text, flagText: this.runtime.systemFlagText });
     this.#systemPromptSessionId = sessionId;
+  }
+
+  /**
+   * Scans the configured skill roots once and builds the catalogue reminder the next `config` read
+   * folds into `cachedReminders`. Genuine async file I/O over an already-constructed object, called at
+   * startup — the roots are fixed for the session (a live re-scan on change is a separate concern).
+   * Each root is expanded (~/$VAR, then resolved against cwd) to the same absolute form the Skill tool
+   * resolves against, so the listed names match what `load` can find.
+   */
+  public async resolveSkillCatalogue(): Promise<void> {
+    const configured = this.configLoader.config.skillDirs;
+    const dirs = configured.map((d: string) => path.resolve(this.fs.cwd(), expandPath(d, this.fs)));
+    this.logger.info('resolving skill catalogue', { cwd: this.fs.cwd(), configured, expanded: dirs });
+    this.#skillCatalogue = await buildSkillCatalogue(this.fs, dirs, this.logger);
+    this.logger.info('skill catalogue resolved', { present: this.#skillCatalogue != null, chars: this.#skillCatalogue?.length ?? 0 });
   }
 
   public needsSystemPromptResolve(sessionId: string): boolean {
@@ -82,7 +103,12 @@ export class DurableConfigFactory extends IDurableConfigProvider {
    * `config` getter derives the rest from current state on read.
    */
   public update(claudeMdContent?: string | null): void {
-    this.#cachedReminders = claudeMdContent != null ? [claudeMdContent] : undefined;
+    // Compose the cached reminder run: the skills catalogue (scanned once at startup) leads, then the
+    // per-turn CLAUDE.md content. Each entry becomes its own <system-reminder> block; a single cache
+    // breakpoint covers the whole run.
+    const reminders = [this.#skillCatalogue, claudeMdContent].filter((r): r is string => r != null && r.length > 0);
+    this.#cachedReminders = reminders.length > 0 ? reminders : undefined;
+    this.logger.debug('cachedReminders composed', { catalogue: this.#skillCatalogue != null, claudeMd: claudeMdContent != null && claudeMdContent.length > 0, blocks: this.#cachedReminders?.length ?? 0 });
   }
 
   /**

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -220,7 +220,11 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
     const memory = x.resolve(IMemoryStore);
     const runtime = x.resolve(IRuntimeOptions);
     const appLogger = x.resolve(ILogger);
-    const tools = createAppTools({ fs, tsServer, toolsConfig: loader.config.tools, objects, memory, tsAvailable: runtime.tsAvailable, logger: appLogger });
+    // Skill roots are replacement-only config: the whole set for the session, no built-in default.
+    // Expand each to a single absolute form (~/$VAR, then resolve against cwd) so the Skill tool
+    // resolves against canonical paths. An empty list resolves nothing — a valid, visibly bare state.
+    const skillDirs = loader.config.skillDirs.map((d: string) => path.resolve(fs.cwd(), expandPath(d, fs)));
+    const tools = createAppTools({ fs, tsServer, toolsConfig: loader.config.tools, objects, memory, tsAvailable: runtime.tsAvailable, logger: appLogger, skillDirs });
     return new AppToolsService(tools);
   });
   // AppToolsService is factory-built, so its cache key is the factory; alias the

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -82,6 +82,7 @@ class FakeDurableConfigProvider extends IDurableConfigProvider {
   public update(): void {}
   public updateIdentityBody(): void {}
   public async resolveSystemPromptsFor(): Promise<void> {}
+  public async resolveSkillCatalogue(): Promise<void> {}
   public needsSystemPromptResolve(): boolean {
     return false;
   }
@@ -602,6 +603,16 @@ describe('AgentMessageHandler — tool_use_input_stop', () => {
     // The input arrives parsed on the stop event; the tool flips to its resolved view.
     handler.handle({ type: 'tool_use_input_stop', id: 'toolu_01', input: { path: '/test/foo.ts' } });
     const expected = 'ReadFile(foo.ts)\n';
+    const actual = conversationState.activeBlock?.content;
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the Skill tool with its skill name argument', () => {
+    const { handler, conversationState } = makeHandler({ config: { tools: [makeTool('Skill', 'read')] } });
+    handler.handle({ type: 'tool_batch_start' });
+    handler.handle({ type: 'tool_use_start', id: 'toolu_01', name: 'Skill' });
+    handler.handle({ type: 'tool_use_input_stop', id: 'toolu_01', input: { skill: 'git' } });
+    const expected = 'Skill(git)\n';
     const actual = conversationState.activeBlock?.content;
     expect(actual).toBe(expected);
   });

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -18,6 +18,7 @@ describe('sdkConfigSchema', () => {
         historyReplay: { enabled: true, showThinking: false },
         claudeMd: { enabled: true, sources: { user: false, project: true, projectClaude: true, local: true } },
         systemPrompt: { enabled: true, sources: { user: false, project: true, projectClaude: true, local: true }, text: null },
+        skillDirs: [],
         compact: { enabled: false, inputTokens: 160_000, pauseAfterCompaction: true, customInstructions: null },
         advancedTools: { enabled: true, searchTool: null, allowProgrammaticExecution: [], codeExecutionTool: 'code_execution_20260120' },
         serverTools: {

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a load-only Skill tool that resolves a skill by name from the configured roots and returns its body with frontmatter stripped; discovery stays in the injected catalogue, not the tool
 - Add a README describing the package and pointing to the main documentation
 - Add append operation to EditFile
 - Add appendFile to IFileSystem, NodeFileSystem, and MemoryFileSystem
 - Add AppendFile tool: appends text to a file, creating it if missing
 - Add atomic rename and platform lookup to the Node filesystem implementation
+- Add buildSkillCatalogue, which lists the resolvable skills (name, plus frontmatter description when present) for injection as an always-on catalogue
 - Add chdir to the Node filesystem implementation, moving the process working directory
 - Add ExecV2 tool: execute commands as a recursive AST (commands joined by ;, &&, ||, &, | operators) instead of a steps array
 - Add ExecV3 structured execution tool

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -43,3 +43,5 @@
 {"description":"A failed tsserver request now throws instead of returning an empty result that was indistinguishable from a clean file","category":"fixed"}
 {"description":"TsReferences and TsDefinition group their results by file path, and TsDiagnostics accepts a batch of files in one call","category":"changed"}
 {"description":"Add chdir to the Node filesystem implementation, moving the process working directory","category":"added"}
+{"description":"Add a load-only Skill tool that resolves a skill by name from the configured roots and returns its body with frontmatter stripped; discovery stays in the injected catalogue, not the tool","category":"added"}
+{"description":"Add buildSkillCatalogue, which lists the resolvable skills (name, plus frontmatter description when present) for injection as an always-on catalogue","category":"added"}

--- a/packages/claude-sdk-tools/package.json
+++ b/packages/claude-sdk-tools/package.json
@@ -226,6 +226,16 @@
         "default": "./dist/cjs/Memory.cjs"
       }
     },
+    "./Skill": {
+      "import": {
+        "types": "./dist/esm/Skill.d.ts",
+        "default": "./dist/esm/Skill.js"
+      },
+      "require": {
+        "types": "./dist/cjs/Skill.d.cts",
+        "default": "./dist/cjs/Skill.cjs"
+      }
+    },
     "./RefStore": {
       "import": {
         "types": "./dist/esm/RefStore.d.ts",
@@ -313,6 +323,7 @@
     "@shellicar/exec-core": "workspace:^",
     "diff": "^8.0.4",
     "file-type": "^22.0.1",
+    "yaml": "^2.8.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/claude-sdk-tools/src/Skill/Skill.ts
+++ b/packages/claude-sdk-tools/src/Skill/Skill.ts
@@ -1,0 +1,39 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { defineTool } from '@shellicar/claude-sdk';
+import { splitFrontmatter } from './frontmatter';
+import { resolveSkills } from './resolve';
+import { SkillInputSchema, SkillOutputSchema } from './schema';
+import type { SkillOutput } from './types';
+
+/** The Skill tool: load one skill's body from the configured roots at runtime, inside the agent loop.
+ *
+ *  Load-only by design. Discovery is not the tool's job: the available-skills catalogue is injected as
+ *  context (see buildSkillCatalogue), a stable cached prefix the model reads to decide when to load. A
+ *  `list` operation would fire an extra turn and land its result outside that cacheable prefix —
+ *  strictly worse. So the CLI only resolves a name to its body and strips the frontmatter; which skills
+ *  exist, and what is always-on, is the launcher's policy. Pass a logger to trace loads. */
+export function createSkillTool(fs: IFileSystem, skillDirs: readonly string[], logger?: ILogger) {
+  return defineTool({
+    name: 'Skill',
+    operation: 'read',
+    description: "Load a skill's instructions into the conversation. Available skills are listed in the injected skills catalogue; invoke only names from that list, never guessed ones. When a skill matches the task, invoke it before responding.",
+    input_schema: SkillInputSchema,
+    output_schema: SkillOutputSchema,
+    input_examples: [{ skill: 'git' }],
+    handler: async (input) => {
+      const resolved = await resolveSkills(fs, skillDirs, logger);
+      const target = resolved.get(input.skill);
+      if (target === undefined) {
+        const available = [...resolved.keys()].sort((a, b) => a.localeCompare(b));
+        logger?.info('Skill load: not found', { skill: input.skill, available });
+        return { textContent: { found: false, skill: input.skill, available } satisfies SkillOutput };
+      }
+      // Return the body only, frontmatter stripped, with leading whitespace trimmed — the catalogue
+      // already carried the frontmatter, so the model wants the instructions, not the metadata.
+      const body = splitFrontmatter(await fs.readFile(target.file)).body.trimStart();
+      logger?.info('Skill load', { skill: input.skill, file: target.file, chars: body.length });
+      return { textContent: { found: true, skill: input.skill, body } satisfies SkillOutput };
+    },
+  });
+}

--- a/packages/claude-sdk-tools/src/Skill/catalogue.ts
+++ b/packages/claude-sdk-tools/src/Skill/catalogue.ts
@@ -1,0 +1,55 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { parse as parseYaml } from 'yaml';
+import { splitFrontmatter } from './frontmatter';
+import { resolveSkills } from './resolve';
+
+const HEADER = 'The following skills are available for use with the Skill tool:';
+
+function readDescription(frontmatter: string): string | undefined {
+  if (frontmatter.length === 0) {
+    return undefined;
+  }
+  try {
+    const parsed = parseYaml(frontmatter) as unknown;
+    if (parsed !== null && typeof parsed === 'object' && 'description' in parsed) {
+      const value = (parsed as { description?: unknown }).description;
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  } catch {
+    // Unparseable frontmatter → no description. The skill still appears by name; a broken frontmatter
+    // must never drop a loadable skill from the catalogue.
+  }
+  return undefined;
+}
+
+/** Build the injected skills catalogue from the configured roots.
+ *
+ *  Mechanism, not policy: one line per resolvable skill, `- name` or `- name: description`, keyed by
+ *  the directory name — the exact key the `Skill` tool's `load` resolves, so the list can never point
+ *  at something `load` cannot find. `description` is read from the frontmatter (optional; a skill with
+ *  none is listed by name). Returns null when nothing resolves, so the caller injects nothing. Pass a
+ *  logger to trace the scan. */
+export async function buildSkillCatalogue(fs: IFileSystem, skillDirs: readonly string[], logger?: ILogger): Promise<string | null> {
+  const resolved = await resolveSkills(fs, skillDirs, logger);
+  if (resolved.size === 0) {
+    logger?.info('skill catalogue empty: no skills resolved from the configured roots', { roots: skillDirs });
+    return null;
+  }
+  const entries = [...resolved.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const lines: string[] = [];
+  for (const entry of entries) {
+    let description: string | undefined;
+    try {
+      description = readDescription(splitFrontmatter(await fs.readFile(entry.file)).frontmatter);
+    } catch (err) {
+      logger?.debug('skill file unreadable; listing by name only', { name: entry.name, file: entry.file, error: err instanceof Error ? err.message : String(err) });
+    }
+    lines.push(description ? `- ${entry.name}: ${description}` : `- ${entry.name}`);
+  }
+  const catalogue = `${HEADER}\n\n${lines.join('\n')}`;
+  logger?.info('skill catalogue built', { skills: entries.length, chars: catalogue.length });
+  return catalogue;
+}

--- a/packages/claude-sdk-tools/src/Skill/frontmatter.ts
+++ b/packages/claude-sdk-tools/src/Skill/frontmatter.ts
@@ -1,0 +1,20 @@
+export interface SplitSkill {
+  /** The raw text between the leading `---` fences (empty when there is no frontmatter). */
+  frontmatter: string;
+  /** Everything after the frontmatter block (the whole file when there is none). */
+  body: string;
+}
+
+// A leading `---` fence, its lines, then a closing `---` fence on its own line. CRLF-tolerant.
+const FENCE = /^---\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/** Split a skill file into its raw frontmatter text and its body. The CLI reads the frontmatter only
+ *  to build the catalogue (the `description`); `load` uses the body. Parsing the frontmatter's meaning
+ *  is the caller's job — this only separates the two halves. */
+export function splitFrontmatter(content: string): SplitSkill {
+  const match = FENCE.exec(content);
+  if (match === null) {
+    return { frontmatter: '', body: content };
+  }
+  return { frontmatter: match[1], body: content.slice(match[0].length) };
+}

--- a/packages/claude-sdk-tools/src/Skill/resolve.ts
+++ b/packages/claude-sdk-tools/src/Skill/resolve.ts
@@ -1,0 +1,36 @@
+import { basename, dirname } from 'node:path';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+
+export interface ResolvedSkill {
+  /** The skill name — the directory holding the SKILL.md. */
+  name: string;
+  /** Absolute path to the resolved SKILL.md. */
+  file: string;
+}
+
+/** Resolve skill names to files across the configured roots. A skill is a `<root>/<name>/SKILL.md`.
+ *
+ *  Precedence is defined: roots are walked in order and a later root overrides an earlier one on a
+ *  name collision, so a single skill can be overlaid without forking the whole set. A configured root
+ *  that does not exist resolves nothing rather than failing — an empty or absent root list is a valid,
+ *  visibly bare state. Pass a logger to trace which roots produced which skills. */
+export async function resolveSkills(fs: IFileSystem, roots: readonly string[], logger?: ILogger): Promise<Map<string, ResolvedSkill>> {
+  const resolved = new Map<string, ResolvedSkill>();
+  for (const root of roots) {
+    let records: Awaited<ReturnType<IFileSystem['find']>>;
+    try {
+      records = await fs.find(root, { pattern: '^SKILL\\.md$', type: 'file', maxDepth: 2 });
+    } catch (err) {
+      logger?.debug('skill root not scannable, skipped', { root, error: err instanceof Error ? err.message : String(err) });
+      continue;
+    }
+    logger?.debug('skill root scanned', { root, foundSkillMd: records.length });
+    for (const record of [...records].sort((a, b) => a.path.localeCompare(b.path))) {
+      const name = basename(dirname(record.path));
+      resolved.set(name, { name, file: record.path });
+    }
+  }
+  logger?.debug('skills resolved', { roots: roots.length, skills: resolved.size, names: [...resolved.keys()] });
+  return resolved;
+}

--- a/packages/claude-sdk-tools/src/Skill/schema.ts
+++ b/packages/claude-sdk-tools/src/Skill/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const SkillInputSchema = z
+  .object({
+    skill: z.string().min(1).describe('The name of a skill from the available-skills list.'),
+  })
+  .strict();
+
+export const SkillOutputSchema = z.discriminatedUnion('found', [z.object({ found: z.literal(true), skill: z.string(), body: z.string() }), z.object({ found: z.literal(false), skill: z.string(), available: z.array(z.string()) })]);

--- a/packages/claude-sdk-tools/src/Skill/types.ts
+++ b/packages/claude-sdk-tools/src/Skill/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+import type { SkillInputSchema, SkillOutputSchema } from './schema';
+
+export type SkillInput = z.output<typeof SkillInputSchema>;
+export type SkillOutput = z.output<typeof SkillOutputSchema>;

--- a/packages/claude-sdk-tools/src/entry/Skill.ts
+++ b/packages/claude-sdk-tools/src/entry/Skill.ts
@@ -1,0 +1,9 @@
+import { buildSkillCatalogue } from '../Skill/catalogue';
+import { splitFrontmatter } from '../Skill/frontmatter';
+import { resolveSkills } from '../Skill/resolve';
+import { createSkillTool } from '../Skill/Skill';
+import { SkillInputSchema, SkillOutputSchema } from '../Skill/schema';
+import type { SkillInput, SkillOutput } from '../Skill/types';
+
+export type { SkillInput, SkillOutput };
+export { buildSkillCatalogue, createSkillTool, resolveSkills, SkillInputSchema, SkillOutputSchema, splitFrontmatter };

--- a/packages/claude-sdk-tools/test/Skill.spec.ts
+++ b/packages/claude-sdk-tools/test/Skill.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { buildSkillCatalogue } from '../src/Skill/catalogue';
+import { splitFrontmatter } from '../src/Skill/frontmatter';
+import { resolveSkills } from '../src/Skill/resolve';
+import { createSkillTool } from '../src/Skill/Skill';
+import { call } from './helpers';
+import { MemoryFileSystem } from './MemoryFileSystem';
+
+const gitSkill = ['---', 'description: Git as it works.', 'trigger: Before any git command.', '---', '', '# Git', '', 'The body.', ''].join('\n');
+const plainSkill = ['# Voice', '', 'No frontmatter here.', ''].join('\n');
+const blockScalarSkill = ['---', 'description: |', '  Testing methodology.', '  TRIGGER when writing tests.', '---', '', '# TDD', ''].join('\n');
+
+function fsWith(files: Record<string, string>): MemoryFileSystem {
+  return new MemoryFileSystem(files);
+}
+
+describe('splitFrontmatter', () => {
+  it('returns the raw frontmatter text between the fences', () => {
+    const expected = 'description: Git as it works.\ntrigger: Before any git command.';
+    const actual = splitFrontmatter(gitSkill).frontmatter;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns the content after the fence as the body (leading blank line intact; load trims it)', () => {
+    const expected = '\n# Git\n\nThe body.\n';
+    const actual = splitFrontmatter(gitSkill).body;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not treat an inline --- inside a value as the closing fence', () => {
+    const content = ['---', 'name: my-skill', 'description: the best --- skill ever', '---', '', '# Body', ''].join('\n');
+    const expected = 'name: my-skill\ndescription: the best --- skill ever';
+    const actual = splitFrontmatter(content).frontmatter;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns the body after the real closing fence despite an inline --- above it', () => {
+    const content = ['---', 'description: the best --- skill ever', '---', '', '# Body', ''].join('\n');
+    const expected = '\n# Body\n';
+    const actual = splitFrontmatter(content).body;
+    expect(actual).toBe(expected);
+  });
+
+  // A column-0 --- inside a quoted value is a YAML document-start marker, not valid string content, so
+  // this input is not valid frontmatter. We still DEFINE the split: it fences at the first column-0 ---.
+  it('splits at the first column-0 --- even one sitting inside a quoted value', () => {
+    const content = ['---', 'description: "a', '---', 'b"', '---', '', '# Body', ''].join('\n');
+    const expected = 'description: "a';
+    const actual = splitFrontmatter(content).frontmatter;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns an empty frontmatter when there is no fence', () => {
+    const expected = '';
+    const actual = splitFrontmatter(plainSkill).frontmatter;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns the whole content as body when there is no fence', () => {
+    const expected = plainSkill;
+    const actual = splitFrontmatter(plainSkill).body;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('resolveSkills', () => {
+  it('lets a later root override an earlier one on a name collision', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill, '/roots/b/git/SKILL.md': plainSkill });
+    const resolved = await resolveSkills(fs, ['/roots/a', '/roots/b']);
+    const expected = '/roots/b/git/SKILL.md';
+    const actual = resolved.get('git')?.file;
+    expect(actual).toBe(expected);
+  });
+
+  it('skips a configured root that does not exist', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill });
+    const resolved = await resolveSkills(fs, ['/roots/missing', '/roots/a']);
+    const expected = ['git'];
+    const actual = [...resolved.keys()];
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('Skill tool', () => {
+  it('loads a skill body by name, frontmatter stripped', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill });
+    const tool = createSkillTool(fs, ['/roots/a']);
+    const expected = '# Git\n\nThe body.\n';
+    const result = await call(tool, { skill: 'git' });
+    const actual = result.found ? result.body : undefined;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports not found for an unknown skill name', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill });
+    const tool = createSkillTool(fs, ['/roots/a']);
+    const expected = false;
+    const result = await call(tool, { skill: 'nope' });
+    const actual = result.found;
+    expect(actual).toBe(expected);
+  });
+
+  it('lists the available skill names when a name is unknown', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill, '/roots/a/voice/SKILL.md': plainSkill });
+    const tool = createSkillTool(fs, ['/roots/a']);
+    const expected = ['git', 'voice'];
+    const result = await call(tool, { skill: 'nope' });
+    const actual = result.found ? undefined : result.available;
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('buildSkillCatalogue', () => {
+  it('returns null when no roots are configured', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill });
+    const expected = null;
+    const actual = await buildSkillCatalogue(fs, []);
+    expect(actual).toBe(expected);
+  });
+
+  it('lists a skill with its frontmatter description', async () => {
+    const fs = fsWith({ '/roots/a/git/SKILL.md': gitSkill });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- git: Git as it works.';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  it('lists a skill with no frontmatter by name only', async () => {
+    const fs = fsWith({ '/roots/a/voice/SKILL.md': plainSkill });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- voice';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  it('preserves a multi-line block-scalar description', async () => {
+    const fs = fsWith({ '/roots/a/tdd/SKILL.md': blockScalarSkill });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- tdd: Testing methodology.\nTRIGGER when writing tests.';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps an inline --- inside a description', async () => {
+    const content = ['---', 'name: whatever', 'description: the best --- skill ever', '---', '', '# Body', ''].join('\n');
+    const fs = fsWith({ '/roots/a/my-skill/SKILL.md': content });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- my-skill: the best --- skill ever';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  it('preserves a --- inside an indented block-scalar description', async () => {
+    const content = ['---', 'description: |', '  line a', '  ---', '  line b', '---', '', '# Body', ''].join('\n');
+    const fs = fsWith({ '/roots/a/blk/SKILL.md': content });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- blk: line a\n---\nline b';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  // Invalid frontmatter (unterminated quote, caused by a column-0 --- inside the value) must not crash
+  // the catalogue: the yaml parse error is swallowed and the skill is listed by name only.
+  it('lists by name only when the frontmatter is invalid YAML', async () => {
+    const content = ['---', 'description: "a', '---', 'b"', '---', '', '# Body', ''].join('\n');
+    const fs = fsWith({ '/roots/a/weird/SKILL.md': content });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- weird';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+
+  it('sorts entries by name', async () => {
+    const fs = fsWith({ '/roots/a/voice/SKILL.md': plainSkill, '/roots/a/git/SKILL.md': gitSkill });
+    const expected = 'The following skills are available for use with the Skill tool:\n\n- git: Git as it works.\n- voice';
+    const actual = await buildSkillCatalogue(fs, ['/roots/a']);
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-sdk/src/public/IDurableConfigProvider.ts
+++ b/packages/claude-sdk/src/public/IDurableConfigProvider.ts
@@ -11,6 +11,8 @@ export abstract class IDurableConfigProvider {
   /** Sets the live system-identity body folded in as the first (base) system prompt on the next `config` read. Null clears it. */
   public abstract updateIdentityBody(body: string | null): void;
   public abstract resolveSystemPromptsFor(sessionId: string): Promise<void>;
+  /** Scans the configured skill roots once and holds the catalogue reminder folded into the next `config` read. Called at startup. */
+  public abstract resolveSkillCatalogue(): Promise<void>;
   public abstract needsSystemPromptResolve(sessionId: string): boolean;
   public abstract getEffectiveModel(): string;
   public abstract getEffectiveThinkingEnabled(): boolean;

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -128,6 +128,7 @@ class FakeDurableConfigProvider extends IDurableConfigProvider {
   public update(): void {}
   public updateIdentityBody(): void {}
   public async resolveSystemPromptsFor(): Promise<void> {}
+  public async resolveSkillCatalogue(): Promise<void> {}
   public needsSystemPromptResolve(): boolean {
     return false;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -181,6 +181,14 @@
         }
       }
     },
+    "skillDirs": {
+      "default": [],
+      "description": "Ordered skill root directories the Skill tool resolves across. Replacement-only: this array is the whole set for a session, never merged with a built-in default. Later directories override earlier ones on a name collision. Empty (the default) resolves nothing.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "compact": {
       "default": {
         "enabled": false,

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,7 @@
     },
     "type-check": {
       "dependsOn": ["^build"],
-      "inputs": ["tsconfig.check.json"],
+      "inputs": ["**/*.ts", "tsconfig.json", "tsconfig.check.json"],
       "outputs": ["**/node_modules/.cache/tsbuildinfo.json"],
       "outputLogs": "errors-only"
     },


### PR DESCRIPTION
## Summary

- Add a load-only `Skill` tool that resolves a skill by name from the configured roots and returns its body (frontmatter stripped); an unknown name comes back with the list of what is available.
- Add a `skillDirs` config setting — an ordered, replacement-only list of skill roots, later roots winning on a name collision, empty resolving nothing.
- Inject an available-skills catalogue (name, plus its frontmatter description when present) as a cached `<system-reminder>` on the first user message, scanned once at startup and re-injected after compaction, so the model discovers skills to load without a `list` round-trip.
- Render the tool call as `Skill(<name>)` in the TUI, matching how the other tools show their argument.

The catalogue rides the existing CLAUDE.md `cachedReminders` path, so it sits inside one cache breakpoint rather than adding a fifth. Discovery stays a stable cached prefix and the tool only loads; which skills exist and what is always-on remains launcher policy.
