### PR TITLE
Bound the primary-view block dividers to a minimum width

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adopt core-di-lite property injection end to end: the container resolves the whole graph eagerly, SQLite databases are created through a registered factory, and CLI startup moves into main() so the entry module's only import-time effect is invoking it
+- Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up
 - claude-cli now records each session's directory to a central store and resumes the most-recent session for the current directory, so a conversation survives a restart or a machine going away
 - Config system tracks which file each value came from
 - Hook input delivered via stdin instead of command arguments

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -106,3 +106,4 @@
 {"description":"The user-level CLAUDE.md and SYSTEM.md sources now default off, so nothing is silently concatenated into a session at launch; project, projectClaude and local sources are unchanged, and setting user back to true in config remains supported","category":"changed"}
 {"description":"Add the skillDirs config setting: an ordered, replacement-only list of skill roots the Skill tool resolves across, with later roots overriding earlier ones and an empty list resolving nothing","category":"added"}
 {"description":"Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load","category":"added"}
+{"description":"Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up","category":"changed"}

--- a/apps/claude-sdk-cli/src/model/dividerWidths.ts
+++ b/apps/claude-sdk-cli/src/model/dividerWidths.ts
@@ -1,0 +1,16 @@
+/**
+ * The two horizontal-rule widths, kept together so their difference is obviously
+ * deliberate — not an accident of living in separate files that invites someone to
+ * "tidy" them into one constant.
+ *
+ * They are different on purpose. The markdown `---` is the model's own separator,
+ * emitted inside a response; the wider labelled rule is the app's own block and mode
+ * boundary. Keeping the app boundary wider means a `---` Claude writes mid-response
+ * never reads as a new block starting. Do not unify them.
+ */
+
+/** markdown `---` thematic break: the model's own in-response separator. */
+export const HR_WIDTH = 48;
+
+/** block header / prompt divider minimum: the app's block & mode separators. */
+export const MIN_DIVIDER_WIDTH = 60;

--- a/apps/claude-sdk-cli/src/model/markdown/markdownLayout.ts
+++ b/apps/claude-sdk-cli/src/model/markdown/markdownLayout.ts
@@ -1,7 +1,8 @@
 import { wrapLine } from '@shellicar/claude-core/reflow';
 import { marked, type Token, type Tokens } from 'marked';
 import type { CodeDecorator } from '../blockLayout.js';
-import { ACCENT, BOLD, BOLD_END, BULLET, box, CODE_FG, DIM, FG, HEADING, HR_WIDTH, ITALIC, ITALIC_END, link, R, STRIKE, STRIKE_END, SUB_BULLET } from './palette.js';
+import { HR_WIDTH } from '../dividerWidths.js';
+import { ACCENT, BOLD, BOLD_END, BULLET, box, CODE_FG, DIM, FG, HEADING, ITALIC, ITALIC_END, link, R, STRIKE, STRIKE_END, SUB_BULLET } from './palette.js';
 
 /**
  * Render an assistant `response` block as styled ANSI: parse with `marked`, walk

--- a/apps/claude-sdk-cli/src/model/markdown/palette.ts
+++ b/apps/claude-sdk-cli/src/model/markdown/palette.ts
@@ -34,7 +34,6 @@ export const HEADING = [e('38;5;39'), e('38;5;74'), e('38;5;110')];
 
 export const BULLET = '\u2022';
 export const SUB_BULLET = '\u25e6';
-export const HR_WIDTH = 48;
 
 // OSC 8 hyperlink. The terminator is ST = ESC backslash (matching the spec).
 const ST = '\x1b\\';

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -6,6 +6,7 @@ import stringWidth from 'string-width';
 import type { MarkdownConfig } from '../cli-config/types.js';
 import { blockContentLines } from '../model/blockLayout.js';
 import type { Block, ConversationState } from '../model/ConversationState.js';
+import { MIN_DIVIDER_WIDTH } from '../model/dividerWidths.js';
 import { markdownContentLines } from '../model/markdown/markdownLayout.js';
 import { formatDuration } from './formatDuration.js';
 
@@ -113,23 +114,29 @@ function renderBlockContentCached(block: Block, cols: number, markdown: boolean)
  * Build a divider line with an optional centred label.
  *
  * - `null` → plain DIM fill (used as the separator between content area and status bar)
- * - non-null → "── label ────────" (used as block headers and the prompt divider)
+ * - non-null → "── label ── time" (used as block headers and the prompt divider)
+ *
+ * Labelled dividers pad to a fixed minimum width (MIN_DIVIDER_WIDTH), not the
+ * terminal width: the unbounded, screen-width-dependent fill was the noise. A short
+ * label still reaches the baseline so headers line up; a label already past the
+ * minimum (e.g. with a long timestamp) gets no fill. The leading `──` marker stays.
  */
 export function buildDivider(displayLabel: string | null, cols: number, timestamps?: DividerTimestamps): string {
   if (!displayLabel) {
     return DIM + FILL.repeat(cols) + RESET;
   }
 
-  let prefix: string;
+  let line: string;
   if (timestamps) {
     const timeStr = timestamps.exitedAt ? `${timestamps.createdAt} \u2192 ${timestamps.exitedAt} (${timestamps.duration})` : timestamps.createdAt;
-    prefix = `${FILL}${FILL} ${displayLabel} ${FILL}${FILL} ${timeStr} `;
+    line = `${FILL}${FILL} ${displayLabel} ${FILL}${FILL} ${timeStr} `;
   } else {
-    prefix = `${FILL}${FILL} ${displayLabel} `;
+    line = `${FILL}${FILL} ${displayLabel} `;
   }
 
-  const remaining = Math.max(0, cols - stringWidth(prefix));
-  return DIM + prefix + FILL.repeat(remaining) + RESET;
+  const target = Math.min(MIN_DIVIDER_WIDTH, cols);
+  const remaining = Math.max(0, target - stringWidth(line));
+  return DIM + line + FILL.repeat(remaining) + RESET;
 }
 
 /**

--- a/apps/claude-sdk-cli/test/renderConversation.spec.ts
+++ b/apps/claude-sdk-cli/test/renderConversation.spec.ts
@@ -151,23 +151,19 @@ describe('buildDivider', () => {
     expect(actual).toBe(true);
   });
 
-  it('fills remaining space with the fill character', () => {
-    const result = stripAnsi(buildDivider('hi', 20));
-    // Should contain fill characters beyond the prefix
-    const actual = result.includes('\u2500\u2500 hi ');
-    expect(actual).toBe(true);
+  it('pads a short labelled divider to the minimum width, below the terminal width', () => {
+    const cols = 120;
+    const result = stripAnsi(buildDivider('hi', cols));
+    const expected = 60;
+    const actual = stringWidth(result);
+    expect(actual).toBe(expected);
   });
 
-  it('fills exactly cols visual columns for an emoji label (D-1)', () => {
-    // Before the fix, prefix.length used code units: \u{1F527} has length 2
-    // but also visual width 2, so this test passes either way for that emoji.
-    // \u2139\uFE0F (information source + variation selector) has .length = 2
-    // but stringWidth may return 1 or 2 depending on terminal. The divider must
-    // always fill exactly `cols` regardless.
-    const cols = 40;
-    const result = stripAnsi(buildDivider('\uD83D\uDD27 tools', cols));
-    const actual = stringWidth(result);
+  it('caps the labelled divider at the terminal width when it is below the minimum', () => {
+    const cols = 20;
+    const result = stripAnsi(buildDivider('hi', cols));
     const expected = cols;
+    const actual = stringWidth(result);
     expect(actual).toBe(expected);
   });
 });
@@ -271,11 +267,11 @@ describe('buildDivider — with timestamps', () => {
     expect(actual).toBe(true);
   });
 
-  it('fills to exactly cols visual columns when timestamps are present', () => {
+  it('pads to the minimum width, below the terminal width, when timestamps are present', () => {
     const ts: DividerTimestamps = { createdAt: '15:29:03' };
-    const cols = 60;
+    const cols = 120;
     const result = stripAnsi(buildDivider('response', cols, ts));
-    const expected = cols;
+    const expected = 60;
     const actual = stringWidth(result);
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
## Summary

- Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up.
- Keep the markdown `---` rule deliberately narrower than the block divider: the model's own in-response separator stays visually distinct from the app's block and mode boundaries, so a `---` mid-response never reads as a new block starting.
- Colocate both widths in `model/dividerWidths.ts` with a note on why they differ, so the two constants can't drift or be mistakenly unified.