### PR TITLE
Mouse-wheel scrollback for the primary transcript

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render assistant responses as styled markdown in the terminal
 - Retry on internal server error
 - Retry transient API errors with exponential backoff and jitter before surfacing the error
+- Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read earlier output; the editor and status bar stay pinned
 - Section dividers show when each section started, ended, and how long it took
 - Service `say` and `cancel` on the conversation over NATS and raise and answer tool approvals over the wire, so a client can address the CLI and drive a turn remotely
 - Show conversation id in status bar, controlled by statusBar.showConversationId config (default true)

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -107,3 +107,4 @@
 {"description":"Add the skillDirs config setting: an ordered, replacement-only list of skill roots the Skill tool resolves across, with later roots overriding earlier ones and an empty list resolving nothing","category":"added"}
 {"description":"Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load","category":"added"}
 {"description":"Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up","category":"changed"}
+{"description":"Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read earlier output; the editor and status bar stay pinned","category":"added"}

--- a/apps/claude-sdk-cli/src/app/ViewHost.ts
+++ b/apps/claude-sdk-cli/src/app/ViewHost.ts
@@ -34,6 +34,7 @@ export class ViewHost implements Disposable {
     model.statusState.on('change', this.#onChange);
     model.terminalState.on('change', this.#onChange);
     model.primaryViewState.on('change', this.#onChange);
+    model.scrollState.on('change', this.#onChange);
     model.historyViewState.on('change', this.#onChange);
     appModeState.on('change', this.#onChange);
   }
@@ -47,6 +48,7 @@ export class ViewHost implements Disposable {
     this.#model.statusState.off('change', this.#onChange);
     this.#model.terminalState.off('change', this.#onChange);
     this.#model.primaryViewState.off('change', this.#onChange);
+    this.#model.scrollState.off('change', this.#onChange);
     this.#model.historyViewState.off('change', this.#onChange);
     this.#appModeState.off('change', this.#onChange);
   }

--- a/apps/claude-sdk-cli/src/controller/ScrollHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/ScrollHandler.ts
@@ -1,0 +1,34 @@
+import type { KeyAction } from '@shellicar/claude-core/input';
+import { dependsOn } from '@shellicar/core-di-lite';
+import { ScrollState } from '../model/ScrollState.js';
+import type { InputHandler } from './InputHandler.js';
+
+/**
+ * Scrolls the primary transcript. Claims the wheel (scroll_up/scroll_down, one
+ * notch at a time) and PageUp/PageDown (a viewport at a time), and passes
+ * everything else down — so it is safe anywhere in a chain, including ahead of
+ * the editor, where scroll keys must not reach the composer. Owns only
+ * ScrollState; nothing auto-snaps, so it never touches another concern.
+ */
+export class ScrollHandler implements InputHandler {
+  @dependsOn(ScrollState) private readonly scrollState!: ScrollState;
+
+  public handleKey(key: KeyAction): boolean {
+    switch (key.type) {
+      case 'scroll_up':
+        this.scrollState.lineUp();
+        return true;
+      case 'scroll_down':
+        this.scrollState.lineDown();
+        return true;
+      case 'page_up':
+        this.scrollState.pageUp();
+        return true;
+      case 'page_down':
+        this.scrollState.pageDown();
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/apps/claude-sdk-cli/src/model/ScrollState.ts
+++ b/apps/claude-sdk-cli/src/model/ScrollState.ts
@@ -1,0 +1,104 @@
+import EventEmitter from 'node:events';
+
+type ScrollStateEvents = {
+  change: [];
+};
+
+/** Lines moved per wheel notch. */
+const LINE_STEP = 3;
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+/**
+ * The primary transcript's scrollback position, measured as `offset` = lines the
+ * viewport bottom sits above the transcript bottom. 0 = pinned to the bottom
+ * (live). The user moves it with the wheel / PageUp-Down; nothing auto-snaps.
+ *
+ * Anchoring to the same content line is the load-bearing rule. The transcript's
+ * line count is computed in the view (it depends on width and markdown), so the
+ * view reports geometry back each render via measure(). Two cases: when content
+ * is appended at the same width the offset grows by the added lines so the same
+ * absolute lines stay visible (true hold); when the width changes (resize) the
+ * transcript rewraps — the line count changes but the content does not — so the
+ * offset is scaled by the rewrap ratio to anchor the viewport to the same line
+ * (a narrower window wraps more lines, so the offset must grow to hold place).
+ * measure() never emits — it runs inside a render and its result is read by that
+ * same render.
+ */
+export class ScrollState {
+  #offset = 0;
+  #lastTotal = 0;
+  #lastCols = 0;
+  #maxOffset = 0;
+  #pageSize = 1;
+  readonly #emitter = new EventEmitter<ScrollStateEvents>();
+
+  public on<K extends keyof ScrollStateEvents>(event: K, listener: (...args: ScrollStateEvents[K]) => void): void {
+    this.#emitter.on(event, listener);
+  }
+
+  public off<K extends keyof ScrollStateEvents>(event: K, listener: (...args: ScrollStateEvents[K]) => void): void {
+    this.#emitter.off(event, listener);
+  }
+
+  public get offset(): number {
+    return this.#offset;
+  }
+
+  public get isScrolled(): boolean {
+    return this.#offset > 0;
+  }
+
+  /**
+   * Reconcile the stored offset against the transcript geometry for this frame.
+   * Called by the view during render; silent (never emits). `total` is the full
+   * transcript line count, `visible` the rows available to it, `cols` the width.
+   */
+  public measure(total: number, visible: number, cols: number): void {
+    const maxOffset = Math.max(0, total - visible);
+    if (this.#offset > 0 && this.#lastTotal > 0) {
+      if (cols === this.#lastCols) {
+        // Same width: extra lines are appended content. Grow the offset with
+        // them so the same absolute lines stay in view (true hold).
+        if (total > this.#lastTotal) {
+          this.#offset += total - this.#lastTotal;
+        }
+      } else {
+        // Width changed: the transcript rewrapped — the line count changed but
+        // the content did not. Scale the offset by the rewrap ratio so the
+        // viewport stays anchored to the same content line.
+        this.#offset = Math.round((this.#offset * total) / this.#lastTotal);
+      }
+    }
+    this.#offset = clamp(this.#offset, 0, maxOffset);
+    this.#lastTotal = total;
+    this.#lastCols = cols;
+    this.#maxOffset = maxOffset;
+    this.#pageSize = Math.max(1, visible);
+  }
+
+  public lineUp(): void {
+    this.#applyDelta(LINE_STEP);
+  }
+
+  public lineDown(): void {
+    this.#applyDelta(-LINE_STEP);
+  }
+
+  public pageUp(): void {
+    this.#applyDelta(this.#pageSize);
+  }
+
+  public pageDown(): void {
+    this.#applyDelta(-this.#pageSize);
+  }
+
+  #applyDelta(delta: number): void {
+    const next = clamp(this.#offset + delta, 0, this.#maxOffset);
+    if (next === this.#offset) {
+      return;
+    }
+    this.#offset = next;
+    this.#emitter.emit('change');
+  }
+}

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -69,6 +69,7 @@ import { EditorHandler } from '../controller/EditorHandler.js';
 import { HistoryNavHandler } from '../controller/HistoryNavHandler.js';
 import type { InputHandler } from '../controller/InputHandler.js';
 import { QuitHandler } from '../controller/QuitHandler.js';
+import { ScrollHandler } from '../controller/ScrollHandler.js';
 import { ViewSelectHandler } from '../controller/ViewSelectHandler.js';
 import { ConvChangePublisher, IConvChangePublisher } from '../conv/ConvChangePublisher.js';
 import { ConvServe, IConvServe } from '../conv/ConvServe.js';
@@ -100,6 +101,7 @@ import { NodeWakeLockSpawner } from '../model/NodeWakeLockSpawner.js';
 import { PermissionsNoticeGate } from '../model/PermissionsNoticeGate.js';
 import { PlatformWakeLock } from '../model/PlatformWakeLock.js';
 import { PrimaryViewState } from '../model/PrimaryViewState.js';
+import { ScrollState } from '../model/ScrollState.js';
 import { StatusState } from '../model/StatusState.js';
 import { StreamInterruptNotice } from '../model/StreamInterruptNotice.js';
 import { SystemIdentity } from '../model/SystemIdentity.js';
@@ -301,6 +303,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(WorkingDirectory).to(WorkingDirectory);
   services.register(TerminalState).to(TerminalState);
   services.register(PrimaryViewState).to(PrimaryViewState);
+  services.register(ScrollState).to(ScrollState);
   services.register(AppModeState).to(AppModeState);
   services.register(HistoryViewState).to(HistoryViewState);
 
@@ -325,6 +328,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(CancelHandler).to(CancelHandler);
   services.register(EditorHandler).to(EditorHandler);
   services.register(ViewSelectHandler).to(ViewSelectHandler);
+  services.register(ScrollHandler).to(ScrollHandler);
   services.register(HistoryNavHandler).to(HistoryNavHandler);
   services.register(AgentMessageHandler).to(AgentMessageHandler);
 
@@ -333,8 +337,8 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(HistoryView).to(HistoryView);
   services.register(TerminalRenderer).to(TerminalRenderer, (x) => new TerminalRenderer(x.resolve(Screen), x.resolve(TerminalState)));
   services.register(PrimaryPresentation).to(PrimaryPresentation, (x) => {
-    const editorChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ApprovalHandler), x.resolve(CommandKeyHandler), x.resolve(EditorHandler)];
-    const streamingChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ApprovalHandler), x.resolve(CancelHandler)];
+    const editorChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ScrollHandler), x.resolve(ApprovalHandler), x.resolve(CommandKeyHandler), x.resolve(EditorHandler)];
+    const streamingChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ScrollHandler), x.resolve(ApprovalHandler), x.resolve(CancelHandler)];
     return new PrimaryPresentation(x.resolve(PrimaryView), x.resolve(PrimaryViewState), editorChain, streamingChain);
   });
   services.register(HistoryPresentation).to(HistoryPresentation, (x) => {
@@ -351,6 +355,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
       turnClock: x.resolve(ITurnClock),
       terminalState: x.resolve(TerminalState),
       primaryViewState: x.resolve(PrimaryViewState),
+      scrollState: x.resolve(ScrollState),
       historyViewState: x.resolve(HistoryViewState),
       appModeState: x.resolve(AppModeState),
       session: x.resolve(ConversationSession),

--- a/apps/claude-sdk-cli/src/view/PrimaryView.ts
+++ b/apps/claude-sdk-cli/src/view/PrimaryView.ts
@@ -1,3 +1,4 @@
+import type { ScrollState } from '../model/ScrollState.js';
 import { renderCommandMode } from './renderCommandMode.js';
 import { blockTimestamps, buildDivider, renderConversation } from './renderConversation.js';
 import { renderEditor } from './renderEditor.js';
@@ -7,14 +8,42 @@ import { renderViewBar } from './renderViewBar.js';
 import type { View, ViewModel } from './View.js';
 
 /**
+ * Window the transcript into the scroll region for this frame. Reconciles the
+ * scroll offset against the current geometry (measure), then slices. At offset 0
+ * the tail is shown (pinned to the bottom, the default). When scrolled, the
+ * bottom row of the window becomes the indicator divider — it reports how many
+ * lines sit below and how to get back, and only appears while offset > 0.
+ */
+function windowTranscript(transcript: readonly string[], scrollRows: number, cols: number, scrollState: ScrollState): string[] {
+  const total = transcript.length;
+  scrollState.measure(total, scrollRows, cols);
+
+  if (total <= scrollRows) {
+    return [...new Array<string>(scrollRows - total).fill(''), ...transcript];
+  }
+
+  const offset = scrollState.offset;
+  const bottom = total - offset; // exclusive; offset <= total - scrollRows, so top >= 0
+  const window = transcript.slice(bottom - scrollRows, bottom);
+  if (offset > 0) {
+    window[window.length - 1] = buildDivider(`\u25bc ${offset} below \u00b7 scroll down to resume`, cols);
+  }
+  return window;
+}
+
+/**
  * The conversation render surface: streaming display, editor region (in editor
  * phase), tool-approval rows, command-mode rows. The render half of
  * PrimaryPresentation. A future history view is another View under another
  * presentation; adding it does not touch this file.
+ *
+ * Only the transcript scrolls. The editor region and the whole status bar are
+ * pinned below it, so a scroll-back for copy/paste leaves the composer live and
+ * the chrome fixed.
  */
 export class PrimaryView implements View {
   public render(model: ViewModel): string[] {
-    const { conversationState, editorState, toolApprovalState, commandModeState, statusState, turnClock, terminalState, primaryViewState, appModeState, session, configLoader } = model;
+    const { conversationState, editorState, toolApprovalState, commandModeState, statusState, turnClock, terminalState, primaryViewState, scrollState, appModeState, session, configLoader } = model;
     const cols = terminalState.cols;
     const rows = terminalState.rows;
 
@@ -23,17 +52,19 @@ export class PrimaryView implements View {
     const expandedRows = [...toolRows, ...previewRows];
     // editorRows (the cd path editor) sit above the command row; both add to the fixed footer height.
     const statusBarHeight = 6 + editorRows.length + expandedRows.length;
-    const contentRows = Math.max(2, rows - statusBarHeight);
 
-    const allContent = renderConversation(conversationState, cols, configLoader.config.markdown);
+    // The prompt editor region is pinned above the status bar, not scrolled, so
+    // the transcript can be scrolled back while the composer stays put and live.
+    const editorRegion: string[] = [];
     if (primaryViewState.phase === 'editor') {
-      allContent.push(buildDivider('prompt', cols, blockTimestamps(conversationState.promptStartedAt ?? undefined, undefined)));
-      allContent.push('');
-      allContent.push(...renderEditor(editorState, cols));
+      editorRegion.push(buildDivider('prompt', cols, blockTimestamps(conversationState.promptStartedAt ?? undefined, undefined)));
+      editorRegion.push('');
+      editorRegion.push(...renderEditor(editorState, cols));
     }
 
-    const overflow = allContent.length - contentRows;
-    const visibleRows = overflow > 0 ? allContent.slice(overflow) : [...new Array<string>(contentRows - allContent.length).fill(''), ...allContent];
+    const transcript = renderConversation(conversationState, cols, configLoader.config.markdown);
+    const scrollRows = Math.max(2, rows - statusBarHeight - editorRegion.length);
+    const visibleRows = windowTranscript(transcript, scrollRows, cols, scrollState);
 
     const separator = buildDivider(null, cols);
     const modelLine = renderModel(statusState, cols, session.id);
@@ -43,6 +74,6 @@ export class PrimaryView implements View {
     // The view bar shares the command-mode row (existing footer chrome, not a
     // new row): it fills the row when no command hint is present. How the two
     // share the row when both are present is the deferred layout call.
-    return [...visibleRows, separator, modelLine, statusLine, clockLine, approvalRow, ...editorRows, commandRow || viewBar, ...expandedRows];
+    return [...visibleRows, ...editorRegion, separator, modelLine, statusLine, clockLine, approvalRow, ...editorRows, commandRow || viewBar, ...expandedRows];
   }
 }

--- a/apps/claude-sdk-cli/src/view/TerminalRenderer.ts
+++ b/apps/claude-sdk-cli/src/view/TerminalRenderer.ts
@@ -1,4 +1,4 @@
-import { disableAutowrap, enableAutowrap, hideCursor, showCursor, syncEnd, syncStart } from '@shellicar/claude-core/ansi';
+import { disableAutowrap, disableMouse, enableAutowrap, enableMouse, hideCursor, showCursor, syncEnd, syncStart } from '@shellicar/claude-core/ansi';
 import type { Screen } from '@shellicar/claude-core/screen';
 import type { TerminalState } from '../model/TerminalState.js';
 import { buildGrid, diffToWrites, type Grid } from './ScreenBuffer.js';
@@ -38,6 +38,7 @@ export class TerminalRenderer implements Disposable {
 
   public enter(): void {
     this.#screen.enterAltBuffer();
+    this.#screen.write(enableMouse);
     // Fresh buffer: nothing on screen yet, so the next paint must draw in full.
     this.#previous = null;
   }
@@ -45,7 +46,7 @@ export class TerminalRenderer implements Disposable {
   public exit(): void {
     this.#cleanupResize();
     clearTimeout(this.#resizeTimer);
-    this.#screen.write(showCursor);
+    this.#screen.write(disableMouse + showCursor);
     this.#screen.exitAltBuffer();
   }
 

--- a/apps/claude-sdk-cli/src/view/View.ts
+++ b/apps/claude-sdk-cli/src/view/View.ts
@@ -8,6 +8,7 @@ import type { EditorState } from '../model/EditorState.js';
 import type { HistoryViewState } from '../model/HistoryViewState.js';
 import type { ITurnClock } from '../model/ITurnClock.js';
 import type { PrimaryViewState } from '../model/PrimaryViewState.js';
+import type { ScrollState } from '../model/ScrollState.js';
 import type { StatusState } from '../model/StatusState.js';
 import type { TerminalState } from '../model/TerminalState.js';
 import type { ToolApprovalState } from '../model/ToolApprovalState.js';
@@ -34,6 +35,7 @@ export type ViewModel = {
   turnClock: ITurnClock;
   terminalState: TerminalState;
   primaryViewState: PrimaryViewState;
+  scrollState: ScrollState;
   historyViewState: HistoryViewState;
   appModeState: AppModeState;
   session: ConversationSession;

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -9,6 +9,7 @@ import { EditorState } from '../src/model/EditorState.js';
 import { HistoryViewState } from '../src/model/HistoryViewState.js';
 import { ITurnClock } from '../src/model/ITurnClock.js';
 import { PrimaryViewState } from '../src/model/PrimaryViewState.js';
+import { ScrollState } from '../src/model/ScrollState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { TerminalState } from '../src/model/TerminalState.js';
 import { ToolApprovalState } from '../src/model/ToolApprovalState.js';
@@ -54,6 +55,7 @@ function makeModel(firstContent = 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8'): ViewModel {
     turnClock: makeTurnClock(),
     terminalState,
     primaryViewState: new PrimaryViewState(),
+    scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     appModeState: new AppModeState(),
     session: { id: 'sess', turnCount: 0 } as unknown as ConversationSession,

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -9,6 +9,7 @@ import { EditorState } from '../src/model/EditorState.js';
 import { HistoryViewState } from '../src/model/HistoryViewState.js';
 import { ITurnClock } from '../src/model/ITurnClock.js';
 import { PrimaryViewState } from '../src/model/PrimaryViewState.js';
+import { ScrollState } from '../src/model/ScrollState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { TerminalState } from '../src/model/TerminalState.js';
 import { ToolApprovalState } from '../src/model/ToolApprovalState.js';
@@ -42,6 +43,7 @@ function makeModel(): ViewModel {
     turnClock: makeTurnClock(),
     terminalState,
     primaryViewState: new PrimaryViewState(),
+    scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     appModeState: new AppModeState(),
     session: { id: 'sess-123', turnCount: 0 } as unknown as ConversationSession,
@@ -90,6 +92,48 @@ describe('PrimaryView — status', () => {
     const rows = new PrimaryView().render(model);
     const expected = true;
     const actual = rows.join('\n').includes('sess-123');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('PrimaryView — scroll', () => {
+  function tallStreamingModel(): ViewModel {
+    const model = makeModel();
+    model.primaryViewState.setPhase('streaming');
+    model.conversationState.addBlocks(Array.from({ length: 40 }, (_, i) => ({ type: 'response' as const, content: `line ${i}` })));
+    return model;
+  }
+
+  it('pins to the bottom with no indicator by default', () => {
+    const model = tallStreamingModel();
+    const rows = new PrimaryView().render(model);
+    const expected = false;
+    const actual = rows.join('\n').includes('scroll down to resume');
+    expect(actual).toBe(expected);
+  });
+
+  it('shows the indicator once scrolled back', () => {
+    const model = tallStreamingModel();
+    const view = new PrimaryView();
+    view.render(model); // measure geometry
+    model.scrollState.lineUp();
+    const rows = view.render(model);
+    const expected = true;
+    const actual = rows.join('\n').includes('scroll down to resume');
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the editor region below the transcript when scrolled', () => {
+    const model = makeModel();
+    model.conversationState.addBlocks(Array.from({ length: 40 }, (_, i) => ({ type: 'response' as const, content: `line ${i}` })));
+    const view = new PrimaryView();
+    view.render(model);
+    model.scrollState.lineUp();
+    const rows = view.render(model);
+    const indicatorRow = rows.findIndex((row) => row.includes('scroll down to resume'));
+    const promptRow = rows.findIndex((row) => row.includes('prompt'));
+    const expected = true;
+    const actual = indicatorRow >= 0 && promptRow > indicatorRow;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/ScrollHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/ScrollHandler.spec.ts
@@ -1,0 +1,56 @@
+import { createServiceCollection } from '@shellicar/core-di-lite';
+import { describe, expect, it } from 'vitest';
+import { ScrollHandler } from '../src/controller/ScrollHandler.js';
+import { ScrollState } from '../src/model/ScrollState.js';
+
+function setup() {
+  const scrollState = new ScrollState();
+  scrollState.measure(100, 10, 80); // give the transcript room to scroll
+  const services = createServiceCollection();
+  services.register(ScrollState).to(ScrollState, () => scrollState);
+  services.register(ScrollHandler).to(ScrollHandler);
+  const handler = services.buildProvider().resolve(ScrollHandler);
+  return { handler, scrollState };
+}
+
+describe('ScrollHandler', () => {
+  it('scrolls back one notch on scroll_up', () => {
+    const { handler, scrollState } = setup();
+    handler.handleKey({ type: 'scroll_up' });
+    const expected = 3;
+    const actual = scrollState.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('claims a scroll_up key', () => {
+    const { handler } = setup();
+    const expected = true;
+    const actual = handler.handleKey({ type: 'scroll_up' });
+    expect(actual).toBe(expected);
+  });
+
+  it('scrolls forward on scroll_down', () => {
+    const { handler, scrollState } = setup();
+    handler.handleKey({ type: 'scroll_up' });
+    handler.handleKey({ type: 'scroll_up' });
+    handler.handleKey({ type: 'scroll_down' });
+    const expected = 3;
+    const actual = scrollState.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('pages back by the viewport height on page_up', () => {
+    const { handler, scrollState } = setup();
+    handler.handleKey({ type: 'page_up' });
+    const expected = 10;
+    const actual = scrollState.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('passes an ordinary character down', () => {
+    const { handler } = setup();
+    const expected = false;
+    const actual = handler.handleKey({ type: 'char', value: 'a' });
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ScrollState.spec.ts
+++ b/apps/claude-sdk-cli/test/ScrollState.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { ScrollState } from '../src/model/ScrollState.js';
+
+describe('ScrollState — defaults', () => {
+  it('starts pinned to the bottom', () => {
+    const expected = 0;
+    const actual = new ScrollState().offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports not scrolled at the bottom', () => {
+    const expected = false;
+    const actual = new ScrollState().isScrolled;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ScrollState — line movement', () => {
+  it('moves back three lines per wheel notch', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.lineUp();
+    const expected = 3;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('cannot scroll past the top of the transcript', () => {
+    const state = new ScrollState();
+    state.measure(12, 10, 80); // maxOffset = 2
+    state.lineUp();
+    const expected = 2;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('floors at the bottom when scrolling forward', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.lineDown();
+    const expected = 0;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('pages back by the visible height', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.pageUp();
+    const expected = 10;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ScrollState — hold vs reflow', () => {
+  it('holds absolute position when content is appended at the same width', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.lineUp(); // offset 3
+    state.measure(105, 10, 80); // 5 lines appended
+    const expected = 8;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('scales the offset to anchor the same line when a narrower width rewraps more lines', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.pageUp();
+    state.pageUp(); // offset 20
+    state.measure(200, 10, 40); // reflow: half the width, twice the lines
+    const expected = 40; // 20 * 200 / 100
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+
+  it('clamps when a resize would anchor above the first line', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.pageUp();
+    state.pageUp();
+    state.pageUp(); // offset 30
+    state.measure(15, 10, 80); // transcript shrank; maxOffset = 5
+    const expected = 5;
+    const actual = state.offset;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ScrollState — emissions', () => {
+  it('emits change on a user scroll', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    let count = 0;
+    state.on('change', () => count++);
+    state.lineUp();
+    const expected = 1;
+    const actual = count;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not emit when a scroll is a no-op at the bottom', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    let count = 0;
+    state.on('change', () => count++);
+    state.lineDown();
+    const expected = 0;
+    const actual = count;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not emit during measure', () => {
+    const state = new ScrollState();
+    state.measure(100, 10, 80);
+    state.lineUp();
+    let count = 0;
+    state.on('change', () => count++);
+    state.measure(120, 10, 80); // append while scrolled
+    const expected = 0;
+    const actual = count;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -29,6 +29,7 @@ import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ITurnClock } from '../src/model/ITurnClock.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
 import { PrimaryViewState } from '../src/model/PrimaryViewState.js';
+import { ScrollState } from '../src/model/ScrollState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { TerminalState } from '../src/model/TerminalState.js';
@@ -85,6 +86,7 @@ function makeModel(): ViewModel {
     turnClock: makeTurnClock(),
     terminalState,
     primaryViewState: new PrimaryViewState(),
+    scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     appModeState: new AppModeState(),
     session: { id: 'sess' } as unknown as ConversationSession,

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add rename and platform operations to the IFileSystem contract
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions
 - Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged
+- Parse mouse-wheel events from stdin into scroll_up/scroll_down key actions; add enableMouse/disableMouse escape sequences
 - Support binary file reads through encoding parameter on IFileSystem.readFile
 
 ### Changed

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -14,3 +14,4 @@
 {"description":"Add rename and platform operations to the IFileSystem contract","category":"added"}
 {"description":"Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged","category":"added"}
 {"description":"Add a chdir operation to the IFileSystem contract","category":"added"}
+{"description":"Parse mouse-wheel events from stdin into scroll_up/scroll_down key actions; add enableMouse/disableMouse escape sequences","category":"added"}

--- a/packages/claude-core/src/ansi.ts
+++ b/packages/claude-core/src/ansi.ts
@@ -31,5 +31,11 @@ export const YELLOW = '\x1B[33m';
 export const CYAN = '\x1B[36m';
 export const BOLD_WHITE = '\x1B[1;97m';
 
+// Mouse tracking. 1000 = button-event tracking (reports the wheel as buttons
+// 64/65); 1006 = SGR extended coordinates. Enabled while the alt buffer is
+// active so the wheel scrolls the transcript instead of the terminal scrollback.
+export const enableMouse = `${ESC}?1000h${ESC}?1006h`;
+export const disableMouse = `${ESC}?1000l${ESC}?1006l`;
+
 // Misc
 export const BEL = '\x07';

--- a/packages/claude-core/src/input.ts
+++ b/packages/claude-core/src/input.ts
@@ -13,6 +13,7 @@
 
 import { appendFileSync } from 'node:fs';
 import readline from 'node:readline';
+import { PassThrough } from 'node:stream';
 
 export type KeyAction =
   | { type: 'char'; value: string }
@@ -44,6 +45,8 @@ export type KeyAction =
   | { type: 'f2' }
   | { type: 'shift+up' }
   | { type: 'shift+down' }
+  | { type: 'scroll_up' }
+  | { type: 'scroll_down' }
   | { type: 'unknown'; raw: string };
 
 export interface NodeKey {
@@ -239,12 +242,120 @@ export function translateKey(ch: string | undefined, key: NodeKey | undefined): 
   return null;
 }
 
+const MOUSE_PREFIX = Buffer.from([0x1b, 0x5b, 0x3c]); // ESC [ <
+const EMPTY = Buffer.alloc(0);
+
+type MouseParse = { length: number; action: KeyAction | null } | 'incomplete';
+
 /**
- * Set up readline keypress events on stdin and call the handler for each translated KeyAction.
- * Returns a cleanup function to remove the listener.
+ * Parse one SGR mouse sequence (ESC [ < button ; x ; y M|m) starting at `start`,
+ * where buf[start..start+3] is already known to be the `ESC [ <` prefix. Returns
+ * 'incomplete' when the buffer ends mid-sequence (hold for the next chunk), else
+ * the byte length consumed and the KeyAction it maps to (null = swallow). Wheel
+ * up/down are button 64/65 with an 'M' (press) final byte; wheel has no release.
+ */
+function parseMouseAt(buf: Buffer, start: number): MouseParse {
+  let k = start + 3;
+  const digits = (): number | null => {
+    let v = -1;
+    while (k < buf.length && buf[k] >= 0x30 && buf[k] <= 0x39) {
+      v = (v < 0 ? 0 : v) * 10 + (buf[k] - 0x30);
+      k++;
+    }
+    return v < 0 ? null : v;
+  };
+  const button = digits();
+  if (button === null) {
+    return k >= buf.length ? 'incomplete' : { length: 3, action: null };
+  }
+  if (k >= buf.length) {
+    return 'incomplete';
+  }
+  if (buf[k] !== 0x3b) {
+    return { length: k - start, action: null };
+  }
+  k++;
+  if (digits() === null) {
+    return k >= buf.length ? 'incomplete' : { length: k - start, action: null };
+  }
+  if (k >= buf.length) {
+    return 'incomplete';
+  }
+  if (buf[k] !== 0x3b) {
+    return { length: k - start, action: null };
+  }
+  k++;
+  if (digits() === null) {
+    return k >= buf.length ? 'incomplete' : { length: k - start, action: null };
+  }
+  if (k >= buf.length) {
+    return 'incomplete';
+  }
+  const final = buf[k];
+  if (final !== 0x4d && final !== 0x6d) {
+    return { length: k - start + 1, action: null };
+  }
+  k++;
+  const action: KeyAction | null = final === 0x4d && button === 64 ? { type: 'scroll_up' } : final === 0x4d && button === 65 ? { type: 'scroll_down' } : null;
+  return { length: k - start, action };
+}
+
+/**
+ * Pull complete SGR mouse sequences out of a raw stdin buffer. readline shreds
+ * mouse sequences into per-character keypress events, so they must be removed
+ * before readline sees them. Wheel-up (button 64) and wheel-down (65) become
+ * scroll actions; every other mouse event (clicks, drags, releases) is swallowed
+ * so its bytes never leak as stray keypresses. Non-mouse bytes pass through
+ * untouched. A sequence split across a chunk boundary is returned as `remainder`
+ * to prepend to the next chunk. Only an unambiguous `ESC [ <` prefix is held
+ * back; a bare trailing ESC (a real Escape key) passes straight through.
+ */
+export function extractMouseSequences(input: Buffer): { actions: KeyAction[]; passthrough: Buffer; remainder: Buffer } {
+  const actions: KeyAction[] = [];
+  const pass: Buffer[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const j = input.indexOf(MOUSE_PREFIX, i);
+    if (j === -1) {
+      pass.push(input.subarray(i));
+      break;
+    }
+    if (j > i) {
+      pass.push(input.subarray(i, j));
+    }
+    const parsed = parseMouseAt(input, j);
+    if (parsed === 'incomplete') {
+      return { actions, passthrough: pass.length ? Buffer.concat(pass) : EMPTY, remainder: input.subarray(j) };
+    }
+    if (parsed.action) {
+      actions.push(parsed.action);
+    }
+    i = j + parsed.length;
+  }
+  return { actions, passthrough: pass.length ? Buffer.concat(pass) : EMPTY, remainder: EMPTY };
+}
+
+/**
+ * Set up input handling on stdin and call the handler for each translated
+ * KeyAction. Raw stdin is filtered for mouse sequences first (see
+ * extractMouseSequences), then the non-mouse bytes flow through a PassThrough
+ * into readline's keypress parser exactly as before. Returns a cleanup function.
  */
 export function setupKeypressHandler(handler: (key: KeyAction) => void): () => void {
-  readline.emitKeypressEvents(process.stdin);
+  const passthrough = new PassThrough();
+  readline.emitKeypressEvents(passthrough);
+
+  let leftover: Buffer = EMPTY;
+  const onData = (chunk: Buffer): void => {
+    const { actions, passthrough: pass, remainder } = extractMouseSequences(leftover.length ? Buffer.concat([leftover, chunk]) : chunk);
+    leftover = remainder;
+    for (const action of actions) {
+      handler(action);
+    }
+    if (pass.length) {
+      passthrough.write(pass);
+    }
+  };
 
   const onKeypress = (ch: string | undefined, key: NodeKey | undefined): void => {
     const action = translateKey(ch, key);
@@ -253,9 +364,12 @@ export function setupKeypressHandler(handler: (key: KeyAction) => void): () => v
     }
   };
 
-  process.stdin.on('keypress', onKeypress);
+  passthrough.on('keypress', onKeypress);
+  process.stdin.on('data', onData);
 
   return () => {
-    process.stdin.removeListener('keypress', onKeypress);
+    process.stdin.removeListener('data', onData);
+    passthrough.removeListener('keypress', onKeypress);
+    passthrough.destroy();
   };
 }

--- a/packages/claude-core/test/extractMouseSequences.spec.ts
+++ b/packages/claude-core/test/extractMouseSequences.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { extractMouseSequences, type KeyAction } from '../src/input';
+
+const buf = (s: string): Buffer => Buffer.from(s, 'latin1');
+const wheelUp = '\x1b[<64;10;5M';
+const wheelDown = '\x1b[<65;10;5M';
+
+describe('extractMouseSequences — wheel', () => {
+  it('maps button 64 press to scroll_up', () => {
+    const expected: KeyAction[] = [{ type: 'scroll_up' }];
+    const actual = extractMouseSequences(buf(wheelUp)).actions;
+    expect(actual).toEqual(expected);
+  });
+
+  it('maps button 65 press to scroll_down', () => {
+    const expected: KeyAction[] = [{ type: 'scroll_down' }];
+    const actual = extractMouseSequences(buf(wheelDown)).actions;
+    expect(actual).toEqual(expected);
+  });
+
+  it('emits one action per wheel event in a burst', () => {
+    const expected = 3;
+    const actual = extractMouseSequences(buf(wheelUp + wheelUp + wheelDown)).actions.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('removes the wheel bytes from the passthrough', () => {
+    const expected = '';
+    const actual = extractMouseSequences(buf(wheelUp)).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('extractMouseSequences — non-wheel mouse', () => {
+  it('swallows a left-button press (button 0) with no action', () => {
+    const expected = 0;
+    const actual = extractMouseSequences(buf('\x1b[<0;3;4M')).actions.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('swallows a button release (m) and passes nothing through', () => {
+    const expected = '';
+    const actual = extractMouseSequences(buf('\x1b[<0;3;4m')).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('extractMouseSequences — passthrough', () => {
+  it('passes ordinary text straight through', () => {
+    const expected = 'hello';
+    const actual = extractMouseSequences(buf('hello')).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+
+  it('passes a bare Escape (cancel key) straight through', () => {
+    const expected = '\x1b';
+    const actual = extractMouseSequences(buf('\x1b')).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+
+  it('passes an arrow-key CSI sequence through untouched', () => {
+    const expected = '\x1b[A';
+    const actual = extractMouseSequences(buf('\x1b[A')).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps text surrounding a wheel event in the passthrough', () => {
+    const expected = 'ab';
+    const actual = extractMouseSequences(buf(`a${wheelUp}b`)).passthrough.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+
+  it('preserves multi-byte UTF-8 bytes in the passthrough', () => {
+    const emoji = Buffer.from('😀', 'utf8');
+    const expected = emoji.toString('hex');
+    const actual = extractMouseSequences(emoji).passthrough.toString('hex');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('extractMouseSequences — split across chunk boundaries', () => {
+  it('holds an incomplete sequence as remainder', () => {
+    const expected = '\x1b[<64;10';
+    const actual = extractMouseSequences(buf('\x1b[<64;10')).remainder.toString('latin1');
+    expect(actual).toBe(expected);
+  });
+
+  it('emits no action for the incomplete first half', () => {
+    const expected = 0;
+    const actual = extractMouseSequences(buf('\x1b[<64;10')).actions.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('completes the action once the remainder is prepended to the next chunk', () => {
+    const first = extractMouseSequences(buf('\x1b[<64;10'));
+    const joined = Buffer.concat([first.remainder, buf(';5M')]);
+    const expected: KeyAction[] = [{ type: 'scroll_up' }];
+    const actual = extractMouseSequences(joined).actions;
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read output that has scrolled off screen; only the transcript moves while the editor and status bar stay pinned and live, so you can read a previous response while composing.
- A divider marks how far you are scrolled, and scrolling to the bottom resumes following. Nothing auto-snaps: incoming output and typing both hold your position.
- Wheel events are parsed from raw stdin ahead of readline (which shreds SGR mouse sequences into per-character keypresses), emitting scroll actions and swallowing clicks and drags; a bare Escape passes straight through so cancel is untouched.
- Position holds as new output streams in at the same width, and re-anchors to the same line across a resize by scaling with the rewrap.
