### PR TITLE
Harden audit-file reads against non-assistant lines

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -122,10 +122,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show the API error detail on a failed request instead of only the HTTP status
 - Show the permissions notice only when displayed permissions change, not on every config edit
 - Show the prompt block's start time when the prompt is entered, matching every other block
+- Skip non-assistant audit lines when deriving the status-line token and cost figures
 - Status line token stats reflect the current conversation, derived per conversation id, instead of accumulating over the process lifetime
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice
-- The status-line token and cost figures no longer break when the audit file contains non-assistant lines: only assistant turns carrying usage are counted, so a user or other role line is skipped rather than throwing
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion
 - Write session marker and history at turn start so they survive mid-response crashes
 

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -125,6 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Status line token stats reflect the current conversation, derived per conversation id, instead of accumulating over the process lifetime
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice
+- The status-line token and cost figures no longer break when the audit file contains non-assistant lines: only assistant turns carrying usage are counted, so a user or other role line is skipped rather than throwing
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion
 - Write session marker and history at turn start so they survive mid-response crashes
 

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -108,3 +108,4 @@
 {"description":"Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load","category":"added"}
 {"description":"Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up","category":"changed"}
 {"description":"Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read earlier output; the editor and status bar stay pinned","category":"added"}
+{"description":"The status-line token and cost figures no longer break when the audit file contains non-assistant lines: only assistant turns carrying usage are counted, so a user or other role line is skipped rather than throwing","category":"fixed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -108,4 +108,4 @@
 {"description":"Inject the available-skills catalogue as a cached system-reminder on the first user message, scanned from skillDirs at startup and re-injected after compaction, so the model can discover skills to load","category":"added"}
 {"description":"Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up","category":"changed"}
 {"description":"Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read earlier output; the editor and status bar stay pinned","category":"added"}
-{"description":"The status-line token and cost figures no longer break when the audit file contains non-assistant lines: only assistant turns carrying usage are counted, so a user or other role line is skipped rather than throwing","category":"fixed"}
+{"description":"Skip non-assistant audit lines when deriving the status-line token and cost figures","category":"fixed"}

--- a/apps/claude-sdk-cli/src/AuditStats.ts
+++ b/apps/claude-sdk-cli/src/AuditStats.ts
@@ -12,6 +12,21 @@ type AuditLine = BetaMessage & {
   cacheCreation?: { fiveMinute: number; oneHour: number };
 };
 
+/**
+ * A usable audit line: an assistant turn carrying `usage`. The audit also holds
+ * non-assistant lines (user-role messages, added by a separate feature) that
+ * have no usage/cost, so the token/cost derivation keeps only these. Role is an
+ * allowlist (a missing role is a legacy assistant line) and `usage` must be
+ * present, so a bad line is skipped rather than throwing a TypeError mid-total.
+ */
+const isUsableLine = (line: unknown): line is AuditLine => {
+  if (typeof line !== 'object' || line === null) {
+    return false;
+  }
+  const role = (line as { role?: string }).role ?? 'assistant';
+  return role === 'assistant' && 'usage' in line;
+};
+
 const EMPTY: StatusTotals = {
   inputTokens: 0,
   cacheCreationTokens: 0,
@@ -49,7 +64,8 @@ export class AuditStats {
     const lines = raw
       .split('\n')
       .filter((l) => l.length > 0)
-      .map((l) => JSON.parse(l) as AuditLine);
+      .map((l) => JSON.parse(l))
+      .filter(isUsableLine);
     if (lines.length === 0) {
       return { ...EMPTY };
     }

--- a/apps/claude-sdk-cli/test/AuditStats.spec.ts
+++ b/apps/claude-sdk-cli/test/AuditStats.spec.ts
@@ -123,4 +123,36 @@ describe('AuditStats — derive', () => {
     const actual = (await stats.derive('c1', CacheTtl.FiveMinutes)).costUsd;
     expect(actual).toBe(expected);
   });
+
+  it('skips a user-role line when summing inputTokens', async () => {
+    const userLine = JSON.stringify({ role: 'user', content: 'hello' });
+    const stats = buildAuditStats(fsWithAudit('c1', [auditLine({ input: 100 }), userLine, auditLine({ input: 40 })]));
+    const expected = 140;
+    const actual = (await stats.derive('c1', CacheTtl.OneHour)).inputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('skips a line with no usage field rather than throwing', async () => {
+    const malformed = JSON.stringify({ model: 'claude-fable-5' });
+    const stats = buildAuditStats(fsWithAudit('c1', [auditLine({ input: 100 }), malformed]));
+    const expected = 100;
+    const actual = (await stats.derive('c1', CacheTtl.OneHour)).inputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('skips a non-assistant, non-user role line (allowlist, not blocklist)', async () => {
+    const systemLine = JSON.stringify({ role: 'system', content: 'hi' });
+    const stats = buildAuditStats(fsWithAudit('c1', [auditLine({ input: 100 }), systemLine]));
+    const expected = 100;
+    const actual = (await stats.derive('c1', CacheTtl.OneHour)).inputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('returns zero when every line is a user-role line', async () => {
+    const userLine = JSON.stringify({ role: 'user', content: 'hello' });
+    const stats = buildAuditStats(fsWithAudit('c1', [userLine, userLine]));
+    const expected = 0;
+    const actual = (await stats.derive('c1', CacheTtl.OneHour)).inputTokens;
+    expect(actual).toBe(expected);
+  });
 });


### PR DESCRIPTION
The status line derives its token and cost figures by reading the session's audit file (`AuditStats.derive`, the only reader of `~/.claude/audit`). A separate feature will start writing user-role lines into that file. Those lines carry no `usage`, so the derivation threw a TypeError the moment it met one and the whole status line broke.

Parsed lines now pass through an `isUsableLine` type guard before being summed: an allowlist on role (a missing role is treated as a legacy assistant line, so it still counts) plus a `usage` shape check. The guard narrows to `AuditLine`, which also removes the `JSON.parse(...) as AuditLine` cast that was asserting a shape the data doesn't always have.

Changelogged as a user-visible fix even though this is the app rather than a consumed library.