### PR TITLE
Tell the model the working directory

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show working directory name in status bar
 - Support reading PDF and image files as native API content blocks
 - Survive a mid-turn network drop: keep the machine awake during a request, persist the conversation as each message is sent and answered, and resume an interrupted turn from an empty submit
+- Tell the model the working directory: state it up front, and report the from/to when it changes mid-session
 - Track session history per working directory for future session picker
 - Write BetaMessage per turn to ~/.claude/audit/<conversation-id>.jsonl
 

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -111,3 +111,4 @@
 {"description":"Skip non-assistant audit lines when deriving the status-line token and cost figures","category":"fixed"}
 {"description":"Inject a skill-catalogue delta: re-scan the skill roots each query and prepend a system-reminder naming the skills whose SKILL.md content changed, silent on the first scan of a session and after a resume","category":"added"}
 {"description":"Add a model selector to command mode (Ctrl+/ m m): free-text model entry that always sends, with a blue highlight when the typed id matches a known model. Shares one override slot with the --model flag; empty submit clears back to the config model","category":"added"}
+{"description":"Tell the model the working directory: state it up front, and report the from/to when it changes mid-session","category":"added"}

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -51,6 +51,7 @@ import { replayHistory } from './replayHistory.js';
 import { buildRunAgentInput, runAgent, type UserInput } from './runAgent.js';
 import { AppToolsService } from './setup/AppToolsService.js';
 import { ConsumerChannel } from './setup/ConsumerChannel.js';
+import { CwdTracker } from './setup/CwdTracker.js';
 import { buildContainer, type ContainerOptions } from './setup/container.js';
 import type { IRuntimeOptions } from './setup/IRuntimeOptions.js';
 import { ModelOverrides } from './setup/ModelOverrides.js';
@@ -421,6 +422,7 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
 
   const queryRunner = provider.resolve(QueryRunner);
   const skillTracker = provider.resolve(SkillCatalogueTracker);
+  const cwdTracker = provider.resolve(CwdTracker);
   const handler = provider.resolve(AgentMessageHandler);
   const configFactory = provider.resolve(IDurableConfigProvider);
   // System prompts are read from SYSTEM.md (async file I/O over the constructed
@@ -537,6 +539,7 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
     // Re-scan the skill catalogue for this query; a non-null delta is injected as a persisted-leading
     // reminder on the user message. First scan of the process records the baseline and returns null.
     const skillDelta = await skillTracker.scanForDelta();
+    const cwdDelta = cwdTracker.scanForDelta();
     const agentInput = buildRunAgentInput(userInput);
     await runAgent(
       queryRunner,
@@ -553,6 +556,7 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
       abortController,
       gitDelta,
       skillDelta,
+      cwdDelta,
     );
     await gitMonitor.takeSnapshot();
     turnInProgress = false;

--- a/apps/claude-sdk-cli/src/runAgent.ts
+++ b/apps/claude-sdk-cli/src/runAgent.ts
@@ -78,7 +78,7 @@ export type RunAgentStores = {
   primaryViewState: PrimaryViewState;
 };
 
-export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, stores: RunAgentStores, flushToScroll: () => void, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string, skillDelta?: string | null): Promise<void> {
+export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, stores: RunAgentStores, flushToScroll: () => void, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string, skillDelta?: string | null, cwdDelta?: string | null): Promise<void> {
   const { conversationState, toolApprovalState, commandModeState, editorState, primaryViewState } = stores;
 
   // On resume there is no new user message: don't open a prompt block.
@@ -90,11 +90,14 @@ export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, s
   primaryViewState.setPhase('streaming');
   flushToScroll();
 
-  // Assemble this query's reminders: the skill-catalogue delta (persisted, leading — frozen in history,
-  // cached) and the git delta (ephemeral, trailing — re-added per turn, uncached).
+  // The skill and cwd deltas are persisted-leading (frozen in history, cached); the git delta is
+  // ephemeral-trailing (re-added per turn, uncached).
   const reminders: SystemReminder[] = [];
   if (skillDelta) {
     reminders.push({ text: skillDelta, persisted: true, position: 'leading' });
+  }
+  if (cwdDelta) {
+    reminders.push({ text: cwdDelta, persisted: true, position: 'leading' });
   }
   if (gitDelta) {
     reminders.push({ text: gitDelta, persisted: false, position: 'trailing' });

--- a/apps/claude-sdk-cli/src/setup/CwdTracker.ts
+++ b/apps/claude-sdk-cli/src/setup/CwdTracker.ts
@@ -1,0 +1,38 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { dependsOn } from '@shellicar/core-di-lite';
+
+const CWD_HEADER = 'The current working directory is:';
+const CWD_CHANGED_HEADER = 'The working directory has changed:';
+
+/**
+ * Emits a persisted-leading `<system-reminder>` naming the cwd: the current directory on the first query,
+ * and the from/to when it moves mid-session. cwd is the frame every relative path resolves against, so it
+ * is stated up front rather than left for the model to infer.
+ */
+export class CwdTracker {
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  @dependsOn(ILogger) private readonly logger!: ILogger;
+
+  #lastCwd: string | null = null;
+
+  /** Return the cwd reminder text for this query, or null when there is nothing to announce. */
+  public scanForDelta(): string | null {
+    const live = this.fs.cwd();
+
+    if (this.#lastCwd == null) {
+      this.#lastCwd = live;
+      this.logger.info('cwd announced', { cwd: live });
+      return `${CWD_HEADER}\n\n${live}`;
+    }
+
+    if (live !== this.#lastCwd) {
+      const previous = this.#lastCwd;
+      this.#lastCwd = live;
+      this.logger.info('cwd changed', { from: previous, to: live });
+      return `${CWD_CHANGED_HEADER}\n\nfrom: ${previous}\nto: ${live}`;
+    }
+
+    return null;
+  }
+}

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -126,6 +126,7 @@ import { TerminalRenderer } from '../view/TerminalRenderer.js';
 import type { ViewModel } from '../view/View.js';
 import { AppToolsService } from './AppToolsService.js';
 import { ConsumerChannel } from './ConsumerChannel.js';
+import { CwdTracker } from './CwdTracker.js';
 import { DurableConfigFactory } from './DurableConfigFactory.js';
 import { GitMemoryEnvironmentProvider } from './GitMemoryEnvironmentProvider.js';
 import { IRuntimeOptions } from './IRuntimeOptions.js';
@@ -275,6 +276,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(Conversation).to(Conversation);
   services.register(IDurableConfigProvider).to(DurableConfigFactory);
   services.register(SkillCatalogueTracker).to(SkillCatalogueTracker);
+  services.register(CwdTracker).to(CwdTracker);
   services.register(SdkChannel).to(SdkChannel);
   services.register(ISdkMessagePublisher).to(SdkChannel);
   services.register(ConsumerChannel).to(ConsumerChannel);

--- a/apps/claude-sdk-cli/test/CwdTracker.spec.ts
+++ b/apps/claude-sdk-cli/test/CwdTracker.spec.ts
@@ -1,0 +1,53 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { createServiceCollection } from '@shellicar/core-di-lite';
+import { describe, expect, it } from 'vitest';
+import { CwdTracker } from '../src/setup/CwdTracker.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function make(cwd = '/repos/alpha') {
+  // Seed a file under each directory the tests move into so MemoryFileSystem.chdir accepts the move.
+  const fs = new MemoryFileSystem({ '/repos/alpha/a': 'x', '/repos/beta/b': 'y' }, '/home/user', cwd);
+  const services = createServiceCollection();
+  services.register(IFileSystem).to(IFileSystem, () => fs);
+  services.register(ILogger).to(ILogger, () => noopLogger);
+  services.register(CwdTracker).to(CwdTracker);
+  const tracker = services.buildProvider().resolve(CwdTracker);
+  return { tracker, fs };
+}
+
+describe('CwdTracker — first scan', () => {
+  it('announces the current cwd', () => {
+    const { tracker } = make();
+    const actual = tracker.scanForDelta();
+    expect(actual).toContain('/repos/alpha');
+  });
+
+  it('announces nothing on the next scan when the cwd has not moved', () => {
+    const { tracker } = make();
+    tracker.scanForDelta();
+    const expected = null;
+    const actual = tracker.scanForDelta();
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CwdTracker — move', () => {
+  it('announces the destination', () => {
+    const { tracker, fs } = make();
+    tracker.scanForDelta();
+    fs.chdir('/repos/beta');
+    const actual = tracker.scanForDelta();
+    expect(actual).toContain('/repos/beta');
+  });
+
+  it('states the origin the move came from', () => {
+    const { tracker, fs } = make();
+    tracker.scanForDelta();
+    fs.chdir('/repos/beta');
+    const actual = tracker.scanForDelta();
+    expect(actual).toContain('/repos/alpha');
+  });
+});


### PR DESCRIPTION
## Summary

- New `CwdTracker` emits a persisted-leading `<system-reminder>` naming the working directory, wired alongside the skill-catalogue delta in `runAgent`.
- Announces the current cwd on resume, where the skill tracker stays silent: a stale cwd is a correctness lie, since every relative path the model reasons about resolves against it.
- Announces the from/to when the cwd changes mid-session; a fresh conversation is primed silent until it moves.
- On resume we announce where we are now rather than recover the prior cwd from history, which compaction can evict.