### PR TITLE
Model selector in command mode

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `thinking` config (enabled, effort) for extended thinking
 - Add a --claudeMd flag to contribute a string to the assembled CLAUDE.md content at launch
 - Add a history view to navigate and inspect past blocks in the active session
+- Add a model selector to command mode (Ctrl+/ m m): free-text model entry that always sends, with a blue highlight when the typed id matches a known model. Shares one override slot with the --model flag; empty submit clears back to the config model
 - Add approval notification hook: run a command when tool approval is pending
 - Add command-mode model sub-mode (`m`): `t` toggles thinking, `e` cycles effort, surfaced in the status line
 - Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -110,3 +110,4 @@
 {"description":"Scroll the conversation transcript back with the mouse wheel or PageUp/PageDown to read earlier output; the editor and status bar stay pinned","category":"added"}
 {"description":"Skip non-assistant audit lines when deriving the status-line token and cost figures","category":"fixed"}
 {"description":"Inject a skill-catalogue delta: re-scan the skill roots each query and prepend a system-reminder naming the skills whose SKILL.md content changed, silent on the first scan of a session and after a resume","category":"added"}
+{"description":"Add a model selector to command mode (Ctrl+/ m m): free-text model entry that always sends, with a blue highlight when the typed id matches a known model. Shares one override slot with the --model flag; empty submit clears back to the config model","category":"added"}

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -3,7 +3,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
-import { CacheTtl } from '@shellicar/claude-sdk';
+import { CacheTtl, IModelCatalog } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { AuditStats } from '../AuditStats.js';
 import { detectMediaType } from '../clipboard.js';
@@ -17,7 +17,7 @@ import { ModelSettings } from '../model/ModelSettings.js';
 import { StatusState } from '../model/StatusState.js';
 import { WorkingDirectory } from '../model/WorkingDirectory.js';
 
-export type CommandIntent = 'pasteText' | 'pasteFile' | 'pasteImage' | 'removeAttachment' | 'togglePreview' | 'newSession' | 'selectPrev' | 'selectNext' | 'enterModelSubMode' | 'cycleThinking' | 'cycleEffort' | 'enterCdSubMode' | 'openCdEditor' | 'submitCd';
+export type CommandIntent = 'pasteText' | 'pasteFile' | 'pasteImage' | 'removeAttachment' | 'togglePreview' | 'newSession' | 'selectPrev' | 'selectNext' | 'enterModelSubMode' | 'cycleThinking' | 'cycleEffort' | 'openModelEditor' | 'submitModel' | 'enterCdSubMode' | 'openCdEditor' | 'submitCd';
 
 /** Deliberate-path test for the missing-file chip (was AppLayout.isLikelyPath). */
 function isLikelyPath(s: string): boolean {
@@ -51,6 +51,7 @@ export class CommandIntentExecutor {
   @dependsOn(IConvServe) private readonly convServe!: IConvServe;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(WorkingDirectory) private readonly workingDirectory!: WorkingDirectory;
+  @dependsOn(IModelCatalog) private readonly modelCatalog!: IModelCatalog;
 
   public async execute(intent: CommandIntent): Promise<void> {
     try {
@@ -97,6 +98,13 @@ export class CommandIntentExecutor {
         case 'cycleEffort':
           this.modelSettings.cycleEffort();
           return;
+        case 'openModelEditor':
+          this.commandModeState.openModelEditor(this.statusState.model);
+          await this.#loadModelCatalogue();
+          return;
+        case 'submitModel':
+          this.#submitModel();
+          return;
         case 'enterCdSubMode':
           this.commandModeState.enterCdSubMode();
           return;
@@ -128,6 +136,33 @@ export class CommandIntentExecutor {
     } else {
       this.commandModeState.setCdError(result.message);
     }
+  }
+
+  /**
+   * Set or clear the model override from the editor buffer. Empty clears it
+   * (back to the config model); any other text sets it verbatim. Always
+   * succeeds — the typed model is never validated against the catalogue, so an
+   * arbitrary or just-released model always sends. Closes the editor back to
+   * the model sub-mode.
+   */
+  #submitModel(): void {
+    const editor = this.commandModeState.modelEditor;
+    if (editor == null) {
+      return;
+    }
+    const text = editor.text.trim();
+    this.modelSettings.setModel(text.length > 0 ? text : null);
+    this.commandModeState.closeModelEditor();
+  }
+
+  /**
+   * Lazy-load the model catalogue and hand the ids to the command-mode state so
+   * the editor can blue-highlight a known model. Advisory only: an empty list
+   * (offline/error) leaves the editor fully usable with no highlight.
+   */
+  async #loadModelCatalogue(): Promise<void> {
+    const models = await this.modelCatalog.list();
+    this.commandModeState.setKnownModels(new Set(models.map((m) => m.id)));
   }
 
   async #pasteText(): Promise<void> {

--- a/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
@@ -21,10 +21,11 @@ export const PRIMARY_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new 
  * operations join it later. */
 export const CD_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new Map([['d', 'openCdEditor']]);
 
-/** Model sub-mode command set: t/e cycle the per-session thinking and effort. */
+/** Model sub-mode command set: t/e cycle thinking and effort; m opens the model-name editor. */
 export const MODEL_COMMAND_BINDINGS: ReadonlyMap<string, CommandIntent> = new Map([
   ['t', 'cycleThinking'],
   ['e', 'cycleEffort'],
+  ['m', 'openModelEditor'],
 ]);
 
 /** The binding set in force for each command-mode context. */
@@ -61,6 +62,9 @@ export class CommandKeyHandler implements InputHandler {
     }
     if (this.commandModeState.context === 'cdEdit') {
       return this.#handleCdEditorKey(key);
+    }
+    if (this.commandModeState.context === 'modelEdit') {
+      return this.#handleModelEditorKey(key);
     }
     if (key.type === 'escape') {
       if (this.commandModeState.context === 'cd') {
@@ -111,6 +115,28 @@ export class CommandKeyHandler implements InputHandler {
       return true;
     }
     this.commandModeState.handleCdEditorKey(key);
+    return true;
+  }
+
+  /**
+   * Modal model-name editor keys, mirroring the cd editor. Enter submits the
+   * typed model (always succeeds — free text is never gated); Escape backs out
+   * to the model sub-mode. Up/down are swallowed; every other key edits the
+   * buffer.
+   */
+  #handleModelEditorKey(key: KeyAction): boolean {
+    if (key.type === 'escape') {
+      this.commandModeState.closeModelEditor();
+      return true;
+    }
+    if (key.type === 'enter') {
+      void this.executor.execute('submitModel');
+      return true;
+    }
+    if (key.type === 'up' || key.type === 'down') {
+      return true;
+    }
+    this.commandModeState.handleModelEditorKey(key);
     return true;
   }
 }

--- a/apps/claude-sdk-cli/src/model/CommandModeState.ts
+++ b/apps/claude-sdk-cli/src/model/CommandModeState.ts
@@ -18,7 +18,7 @@ type CommandModeStateEvents = {
  * No async I/O, no rendering. The clipboard reads and file-stat calls that happen
  * when the user presses t or f stay in AppLayout — they are I/O, not state.
  */
-export type CommandContext = 'root' | 'model' | 'cd' | 'cdEdit';
+export type CommandContext = 'root' | 'model' | 'modelEdit' | 'cd' | 'cdEdit';
 
 export class CommandModeState {
   #commandMode = false;
@@ -26,6 +26,8 @@ export class CommandModeState {
   #context: CommandContext = 'root';
   #cdEditor: EditorState | null = null;
   #cdError: string | null = null;
+  #modelEditor: EditorState | null = null;
+  #knownModels: ReadonlySet<string> = new Set();
   #attachments = new AttachmentStore();
   readonly #emitter = new EventEmitter<CommandModeStateEvents>();
 
@@ -57,6 +59,50 @@ export class CommandModeState {
   /** The last failed-move message, shown under the editor until the next edit. */
   public get cdError(): string | null {
     return this.#cdError;
+  }
+
+  /** The pre-filled model-name editor, present only while the model editor is open. */
+  public get modelEditor(): EditorState | null {
+    return this.#modelEditor;
+  }
+
+  /** The sendable model ids known to the account (from the catalogue). Advisory:
+   * used only to blue-highlight a typed id that matches. Empty until loaded. */
+  public get knownModels(): ReadonlySet<string> {
+    return this.#knownModels;
+  }
+
+  /** Replace the known-model id set; drives the blue match. Emits change so an
+   * open editor re-renders once the catalogue lands. */
+  public setKnownModels(ids: ReadonlySet<string>): void {
+    this.#knownModels = ids;
+    this.#emitter.emit('change');
+  }
+
+  /** Open the model-name editor pre-filled with the effective model (model → modelEdit). */
+  public openModelEditor(current: string): void {
+    this.#context = 'modelEdit';
+    this.#modelEditor = new EditorState({ lines: [current], cursorLine: 0, cursorCol: current.length });
+    this.#emitter.emit('change');
+  }
+
+  /** Close the model-name editor and return to the model sub-mode (modelEdit → model). */
+  public closeModelEditor(): void {
+    this.#context = 'model';
+    this.#modelEditor = null;
+    this.#emitter.emit('change');
+  }
+
+  /** Forward an editing key to the open model editor. */
+  public handleModelEditorKey(key: KeyAction): boolean {
+    if (this.#modelEditor == null) {
+      return false;
+    }
+    const consumed = this.#modelEditor.handleKey(key);
+    if (consumed) {
+      this.#emitter.emit('change');
+    }
+    return consumed;
   }
 
   public get hasAttachments(): boolean {
@@ -153,6 +199,7 @@ export class CommandModeState {
     this.#context = 'root';
     this.#cdEditor = null;
     this.#cdError = null;
+    this.#modelEditor = null;
   }
 
   /** Reset all command mode state — used when streaming completes. */

--- a/apps/claude-sdk-cli/src/model/ModelSettings.ts
+++ b/apps/claude-sdk-cli/src/model/ModelSettings.ts
@@ -8,4 +8,7 @@
 export abstract class ModelSettings {
   public abstract cycleThinking(): void;
   public abstract cycleEffort(): void;
+  /** Set or clear the per-session model override. `null` clears it, falling back
+   * to the config model. Shares one slot with the `--model` startup flag. */
+  public abstract setModel(id: string | null): void;
 }

--- a/apps/claude-sdk-cli/src/setup/ModelOverrides.ts
+++ b/apps/claude-sdk-cli/src/setup/ModelOverrides.ts
@@ -1,3 +1,4 @@
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import type { ThinkingEffort } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { ModelSettings } from '../model/ModelSettings.js';
@@ -10,11 +11,25 @@ const EFFORT_CYCLE: (ThinkingEffort | null)[] = [null, 'low', 'medium', 'high', 
 export class ModelOverrides extends ModelSettings {
   @dependsOn(IRuntimeOptions) private readonly runtime!: IRuntimeOptions;
   @dependsOn(StatusState) private readonly statusState!: StatusState;
+  @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<any>;
   #thinking: 'on' | 'off' | null = null;
   #effort: ThinkingEffort | null = null;
+  #model: string | null = null;
+  // Distinguishes "never set at runtime" (fall back to the --model flag) from
+  // "cleared at runtime" (fall back to the config model). One override slot,
+  // seeded by --model; command mode reads, sets, and clears the same slot.
+  #modelTouched = false;
 
   public get model(): string | null {
-    return this.runtime.modelOverride;
+    return this.#modelTouched ? this.#model : this.runtime.modelOverride;
+  }
+
+  public setModel(id: string | null): void {
+    this.#model = id;
+    this.#modelTouched = true;
+    const override = this.model;
+    const effective = override ?? this.configLoader.config.model;
+    this.statusState.setModel(effective, override != null);
   }
 
   public get thinking(): 'on' | 'off' | null {

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -29,6 +29,7 @@ import {
   Conversation,
   IDurableConfigProvider,
   IMessageStreamer,
+  IModelCatalog,
   IQueryRunner,
   IRequestClockListener,
   ISdkMessagePublisher,
@@ -39,6 +40,7 @@ import {
   IToolsClockListener,
   ITurnRunner,
   IWakeLock,
+  ModelCatalog,
   QueryRunner,
   StreamInterruptListener,
   StreamProcessor,
@@ -258,6 +260,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   });
   services.register(AnthropicAuth).to(AnthropicAuth, () => new AnthropicAuth({ redirect: 'local' }));
   services.register(IMessageStreamer).to(IMessageStreamer, (x) => new AnthropicClient(x.resolve(AnthropicAuth), x.resolve(ILogger)));
+  services.register(IModelCatalog).to(IModelCatalog, (x) => new ModelCatalog(x.resolve(AnthropicAuth), x.resolve(ILogger)));
   services.register(ApprovalCoordinator).to(ApprovalCoordinator);
   services.register(AccountLimitNotice).to(AccountLimitNotice);
   services.register(AccountLimitListener).to(AccountLimitNotice);

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -1,8 +1,9 @@
 import { basename } from 'node:path';
-import { DIM, INVERSE_OFF, INVERSE_ON, RESET } from '@shellicar/claude-core/ansi';
+import { BLUE, DIM, INVERSE_OFF, INVERSE_ON, RESET } from '@shellicar/claude-core/ansi';
 import { wrapLine } from '@shellicar/claude-core/reflow';
 import { StatusLineBuilder } from '@shellicar/claude-core/status-line';
 import type { CommandModeState } from '../model/CommandModeState.js';
+import type { EditorState } from '../model/EditorState.js';
 
 // Same indent used by renderConversation for block content lines.
 const CONTENT_INDENT = '   ';
@@ -34,25 +35,42 @@ export function renderCommandMode(state: CommandModeState, conversationId: strin
 }
 
 /**
- * The cd path-editor rows: the pre-filled path with a block cursor, and the
- * failed-move message beneath it when a move has just failed. Empty unless the
- * cd editor is open. Rendered above the command row (see PrimaryView).
+ * The modal editor rows for the cd path editor and the model-name editor: the
+ * pre-filled value with a block cursor. The cd editor adds a failed-move message
+ * beneath it when a move has just failed; the model editor tints the line blue
+ * when the typed id exactly matches a known model (advisory only). Empty unless
+ * one of the two editors is open. Rendered above the command row (see PrimaryView).
  */
 function buildEditorRows(state: CommandModeState, cols: number): string[] {
-  if (!state.commandMode || state.context !== 'cdEdit' || state.cdEditor == null) {
+  if (!state.commandMode) {
     return [];
   }
-  const line = state.cdEditor.lines[0] ?? '';
-  const cursorCol = state.cdEditor.cursorCol;
+  if (state.context === 'cdEdit' && state.cdEditor != null) {
+    const rows = buildCursorRows(state.cdEditor, cols, false);
+    if (state.cdError != null) {
+      rows.push(` \u2717 ${state.cdError}`);
+    }
+    return rows;
+  }
+  if (state.context === 'modelEdit' && state.modelEditor != null) {
+    const known = state.knownModels.has((state.modelEditor.lines[0] ?? '').trim());
+    return buildCursorRows(state.modelEditor, cols, known);
+  }
+  return [];
+}
+
+/** Render a single-line editor value with a block cursor, optionally tinted blue
+ * (the model-match helper). The blue wraps the whole line; the cursor's inverse
+ * survives inside it. */
+function buildCursorRows(editor: EditorState, cols: number, blue: boolean): string[] {
+  const line = editor.lines[0] ?? '';
+  const cursorCol = editor.cursorCol;
   const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
   const grapheme = [...seg.segment(line)].find((s) => s.index === cursorCol);
   const charUnder = grapheme?.segment ?? ' ';
   const withCursor = `${line.slice(0, cursorCol)}${INVERSE_ON}${charUnder}${INVERSE_OFF}${line.slice(cursorCol + charUnder.length)}`;
-  const rows = wrapLine(` ${withCursor}`, cols);
-  if (state.cdError != null) {
-    rows.push(` \u2717 ${state.cdError}`);
-  }
-  return rows;
+  const painted = blue ? `${BLUE}${withCursor}${RESET}` : withCursor;
+  return wrapLine(` ${painted}`, cols);
 }
 
 function buildCommandRow(state: CommandModeState, conversationId: string): string {
@@ -112,7 +130,9 @@ function buildCommandRow(state: CommandModeState, conversationId: string): strin
     }
     b.ansi(RESET);
     if (state.context === 'model') {
-      b.text('  t think  \u00b7  e effort  \u00b7  ESC back');
+      b.text('  t think  \u00b7  e effort  \u00b7  m model  \u00b7  ESC back');
+    } else if (state.context === 'modelEdit') {
+      b.text('  ESC back');
     } else if (state.context === 'cd') {
       b.text('  d directory  \u00b7  ESC back');
     } else if (state.context === 'cdEdit') {

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -4,7 +4,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
-import { Conversation } from '@shellicar/claude-sdk';
+import { Conversation, IModelCatalog, type ModelInfo } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import { AuditStats } from '../src/AuditStats.js';
@@ -38,6 +38,7 @@ function makeExecutor(source: AttachmentSource) {
   const fs = new MemoryFileSystem({}, '/home/user', '/test');
   const conversation = new Conversation();
   const cycleCalls = { thinking: 0, effort: 0 };
+  const modelCalls: { model: (string | null)[] } = { model: [] };
   const modelSettings: ModelSettings = {
     cycleThinking: () => {
       cycleCalls.thinking += 1;
@@ -45,7 +46,12 @@ function makeExecutor(source: AttachmentSource) {
     cycleEffort: () => {
       cycleCalls.effort += 1;
     },
+    setModel: (id) => {
+      modelCalls.model.push(id);
+    },
   };
+  const catalogueModels: ModelInfo[] = [{ id: 'claude-opus-4-8', displayName: 'Claude Opus 4.8' }];
+  const modelCatalog: IModelCatalog = { list: () => Promise.resolve(catalogueModels) };
   const services = createServiceCollection();
   services.register(CommandModeState).to(CommandModeState, () => commandModeState);
   services.register(Clock).to(Clock, () => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC));
@@ -58,6 +64,7 @@ function makeExecutor(source: AttachmentSource) {
   services.register(ISystemIdentity).to(SystemIdentity);
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
+  services.register(IModelCatalog).to(IModelCatalog, () => modelCatalog);
   services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
   services.register(ILogger).to(ILogger, () => noopLogger);
   services.register(StatusState).to(StatusState, () => new StatusState('test'));
@@ -70,7 +77,7 @@ function makeExecutor(source: AttachmentSource) {
   const conversationState = provider.resolve(ConversationState);
   const session = provider.resolve(ConversationSession);
   const statusState = provider.resolve(StatusState);
-  return { executor, commandModeState, conversationState, session, cycleCalls, statusState };
+  return { executor, commandModeState, conversationState, session, cycleCalls, modelCalls, statusState };
 }
 
 const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -253,6 +260,59 @@ describe('CommandIntentExecutor — cd sub-mode', () => {
     }
     await executor.execute('submitCd');
     const expected = 'cdEdit';
+    const actual = commandModeState.context;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CommandIntentExecutor — model editor', () => {
+  it('openModelEditor pre-fills the editor with the effective model', async () => {
+    const { executor, commandModeState, statusState } = makeExecutor(new FakeAttachmentSource());
+    statusState.setModel('claude-hello-world');
+    await executor.execute('openModelEditor');
+    const expected = 'claude-hello-world';
+    const actual = commandModeState.modelEditor?.text ?? null;
+    expect(actual).toBe(expected);
+  });
+
+  it('openModelEditor loads the catalogue ids for the blue match', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('openModelEditor');
+    const expected = true;
+    const actual = commandModeState.knownModels.has('claude-opus-4-8');
+    expect(actual).toBe(expected);
+  });
+
+  it('submitModel sets the override to the typed model', async () => {
+    const { executor, commandModeState, modelCalls, statusState } = makeExecutor(new FakeAttachmentSource());
+    statusState.setModel('claude-opus-4-8');
+    await executor.execute('openModelEditor');
+    commandModeState.modelEditor?.reset();
+    for (const ch of 'claude-sonnet-5') {
+      commandModeState.modelEditor?.handleKey({ type: 'char', value: ch });
+    }
+    await executor.execute('submitModel');
+    const expected = ['claude-sonnet-5'];
+    const actual = modelCalls.model;
+    expect(actual).toEqual(expected);
+  });
+
+  it('submitModel clears the override when the editor is empty', async () => {
+    const { executor, commandModeState, modelCalls, statusState } = makeExecutor(new FakeAttachmentSource());
+    statusState.setModel('claude-opus-4-8');
+    await executor.execute('openModelEditor');
+    commandModeState.modelEditor?.reset();
+    await executor.execute('submitModel');
+    const expected = [null];
+    const actual = modelCalls.model;
+    expect(actual).toEqual(expected);
+  });
+
+  it('submitModel returns to the model sub-mode', async () => {
+    const { executor, commandModeState } = makeExecutor(new FakeAttachmentSource());
+    await executor.execute('openModelEditor');
+    await executor.execute('submitModel');
+    const expected = 'model';
     const actual = commandModeState.context;
     expect(actual).toBe(expected);
   });

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -4,7 +4,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
-import { Conversation } from '@shellicar/claude-sdk';
+import { Conversation, IModelCatalog } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import { AuditStats } from '../src/AuditStats.js';
@@ -49,7 +49,9 @@ function makeHandler(sourceText: string | null = null) {
     cycleEffort: () => {
       cycleCalls.effort += 1;
     },
+    setModel: () => {},
   };
+  const modelCatalog: IModelCatalog = { list: () => Promise.resolve([]) };
   const services = createServiceCollection();
   services.register(CommandModeState).to(CommandModeState, () => commandModeState);
   services.register(Clock).to(Clock, () => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC));
@@ -62,6 +64,7 @@ function makeHandler(sourceText: string | null = null) {
   services.register(ISystemIdentity).to(SystemIdentity);
   services.register(AttachmentSource).to(AttachmentSource, () => source);
   services.register(ModelSettings).to(ModelSettings, () => modelSettings);
+  services.register(IModelCatalog).to(IModelCatalog, () => modelCatalog);
   services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
   services.register(ILogger).to(ILogger, () => noopLogger);
   services.register(StatusState).to(StatusState, () => new StatusState('test'));

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -3,7 +3,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
-import { type ConsumerMessage, Conversation } from '@shellicar/claude-sdk';
+import { type ConsumerMessage, Conversation, IModelCatalog } from '@shellicar/claude-sdk';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
 import { AuditStats } from '../src/AuditStats.js';
@@ -229,7 +229,8 @@ describe('ViewHost — escape routing through the primary chains', () => {
     services.register(IObjectStore).to(IObjectStore, () => new MemoryObjectStore());
     services.register(ISystemIdentity).to(SystemIdentity);
     services.register(AttachmentSource).to(AttachmentSource, () => new FakeAttachmentSource());
-    services.register(ModelSettings).to(ModelSettings, () => ({ cycleThinking: () => {}, cycleEffort: () => {} }));
+    services.register(ModelSettings).to(ModelSettings, () => ({ cycleThinking: () => {}, cycleEffort: () => {}, setModel: () => {} }));
+    services.register(IModelCatalog).to(IModelCatalog, () => ({ list: () => Promise.resolve([]) }));
     services.register(SipsBridge).to(SipsBridge, () => passthroughSips);
     services.register(ILogger).to(ILogger, () => noopLogger);
     services.register(ConsumerChannel).to(ConsumerChannel, () => new RecordingConsumerChannel(cancelLog));

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a BLUE foreground ANSI colour constant
 - Add a chdir operation to the IFileSystem contract
 - Add a README describing the package and pointing to the main documentation
 - Add IObjectStore interface for injectable persistence

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -15,3 +15,4 @@
 {"description":"Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged","category":"added"}
 {"description":"Add a chdir operation to the IFileSystem contract","category":"added"}
 {"description":"Parse mouse-wheel events from stdin into scroll_up/scroll_down key actions; add enableMouse/disableMouse escape sequences","category":"added"}
+{"description":"Add a BLUE foreground ANSI colour constant","category":"added"}

--- a/packages/claude-core/src/ansi.ts
+++ b/packages/claude-core/src/ansi.ts
@@ -25,6 +25,7 @@ export const INVERSE_ON = '\x1B[7m';
 export const INVERSE_OFF = '\x1B[27m';
 
 // Colors (foreground)
+export const BLUE = '\x1B[94m';
 export const RED = '\x1B[31m';
 export const GREEN = '\x1B[32m';
 export const YELLOW = '\x1B[33m';

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a per-block tool lifecycle: a tool can declare a blockLifetime that is torn down when the tool-execution block of a turn ends
 - Add Claude Sonnet 5 calibration and fall back to a family's most recent known config for unrecognised model versions
 - Add finalMessage event emitter surface to AnthropicClient
+- Add IModelCatalog/ModelCatalog: a lazy, memoised service that fetches the account's model list from Anthropic's /v1/models endpoint over the existing OAuth transport
 - Add output_schema to ToolDefinition for typed handler outputs
 - Add support for Claude Fable 5
 - Add support for Claude Opus 4.8

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -45,3 +45,4 @@
 {"description":"Stamp `messageId`, `turnId`, and `queryId` into each conversation record as nested fields, carried through the jsonl save and load round-trip","category":"added"}
 {"description":"Add a per-block tool lifecycle: a tool can declare a blockLifetime that is torn down when the tool-execution block of a turn ends","category":"added"}
 {"description":"Model per-message reminders with a SystemReminder type (text, persisted, position): PerQueryInput.reminders and TurnInput.ephemeralReminders replace the systemReminder string, so a persisted reminder is stored in history and leads the user message (cached) while an ephemeral one rides the request clone each turn and trails it (uncached)","category":"changed"}
+{"description":"Add IModelCatalog/ModelCatalog: a lazy, memoised service that fetches the account's model list from Anthropic's /v1/models endpoint over the existing OAuth transport","category":"added"}

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -6,6 +6,7 @@ import type { IPublisher, ISubscriber } from './private/ControlChannel';
 import { ControlChannel } from './private/ControlChannel';
 import { Conversation } from './private/Conversation';
 import { IMessageStreamer } from './private/MessageStreamer';
+import { IModelCatalog, ModelCatalog } from './private/ModelCatalog';
 import { calculateCost, calculateCostSplit, getContextWindow, reconstructCacheSplit } from './private/pricing';
 import { QueryRunner } from './private/QueryRunner';
 import { toWireTool } from './private/RequestBuilder';
@@ -63,6 +64,7 @@ export type { BetaMessage, BetaMessageParam } from '@anthropic-ai/sdk/resources/
 export type { BetaToolUnion } from '@anthropic-ai/sdk/resources/beta.mjs';
 export type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 export type { HistoryItem, MessageIdentity, Sender } from './private/Conversation';
+export type { ModelInfo } from './private/ModelCatalog';
 export type { SchemaResolver } from './public/pathSchema';
 export type {
   AnthropicBetaFlags,
@@ -120,6 +122,7 @@ export {
   getContextWindow,
   IDurableConfigProvider,
   IMessageStreamer,
+  IModelCatalog,
   IQueryRunner,
   IRequestClockListener,
   IS_PATH,
@@ -131,6 +134,7 @@ export {
   IToolsClockListener,
   ITurnRunner,
   IWakeLock,
+  ModelCatalog,
   normalisePaths,
   pathSchema,
   QueryRunner,

--- a/packages/claude-sdk/src/private/ModelCatalog.ts
+++ b/packages/claude-sdk/src/private/ModelCatalog.ts
@@ -1,0 +1,100 @@
+import versionJson from '@shellicar/build-version/version';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import type { AnthropicAuth } from './Client/Auth/AnthropicAuth';
+import { customFetch } from './http/customFetch';
+
+const MODELS_URL = 'https://api.anthropic.com/v1/models?limit=1000';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+/** One model as the catalogue exposes it: the sendable id and its human label. */
+export type ModelInfo = {
+  readonly id: string;
+  readonly displayName: string;
+};
+
+/**
+ * The set of models the account can address, as reported by Anthropic's
+ * `/v1/models` endpoint. General infrastructure, not model-select-private: any
+ * feature that needs the live model list (model override, support/settings
+ * views) reads it here rather than hardcoding ids.
+ */
+export abstract class IModelCatalog {
+  public abstract list(): Promise<readonly ModelInfo[]>;
+}
+
+/**
+ * Fetches the model list over the same OAuth-bearer transport the message
+ * client uses (the `/v1/models` endpoint accepts the claudeAiOauth token we
+ * already hold — no API key). Lazy and memoised: the first `list` fetches and
+ * caches for the process lifetime; a failed fetch returns an empty list and is
+ * NOT cached, so a later call retries. Concurrent first calls share one
+ * in-flight request.
+ *
+ * A caller must treat the list as advisory, never a gate: an empty result
+ * (offline, error, or a just-released model missing from the list) means "can't
+ * confirm", not "invalid". The list exists to catch typos, not to restrict.
+ */
+export class ModelCatalog extends IModelCatalog {
+  readonly #auth: AnthropicAuth;
+  readonly #logger: ILogger;
+  readonly #fetch: typeof fetch;
+  readonly #defaultHeaders: Record<string, string> = {
+    'user-agent': `@shellicar/claude-sdk/${versionJson.version}`,
+  };
+  #cache: readonly ModelInfo[] | null = null;
+  #inFlight: Promise<readonly ModelInfo[]> | null = null;
+
+  public constructor(auth: AnthropicAuth, logger: ILogger) {
+    super();
+    this.#auth = auth;
+    this.#logger = logger;
+    this.#fetch = customFetch(logger) as typeof fetch;
+  }
+
+  public async list(): Promise<readonly ModelInfo[]> {
+    if (this.#cache !== null) {
+      return this.#cache;
+    }
+    this.#inFlight ??= this.#load();
+    return this.#inFlight;
+  }
+
+  async #load(): Promise<readonly ModelInfo[]> {
+    try {
+      const models = await this.#fetchModels();
+      this.#cache = models;
+      return models;
+    } catch (err) {
+      // Advisory data: a failed fetch degrades to "no confirmation", never an
+      // error the caller must handle. Not cached, so the next call retries.
+      this.#logger.warn('model catalogue fetch failed', err);
+      return [];
+    } finally {
+      this.#inFlight = null;
+    }
+  }
+
+  async #fetchModels(): Promise<readonly ModelInfo[]> {
+    const { claudeAiOauth } = await this.#auth.getCredentials();
+    const response = await this.#fetch(MODELS_URL, {
+      method: 'GET',
+      headers: {
+        'anthropic-version': ANTHROPIC_VERSION,
+        authorization: `Bearer ${claudeAiOauth.accessToken}`,
+        ...this.#defaultHeaders,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`models request failed: ${response.status} ${response.statusText}`);
+    }
+    const json = (await response.json()) as { data?: ReadonlyArray<{ id?: unknown; display_name?: unknown }> };
+    const data = json.data ?? [];
+    const models: ModelInfo[] = [];
+    for (const entry of data) {
+      if (typeof entry.id === 'string') {
+        models.push({ id: entry.id, displayName: typeof entry.display_name === 'string' ? entry.display_name : entry.id });
+      }
+    }
+    return models;
+  }
+}

--- a/packages/claude-sdk/test/ModelCatalog.spec.ts
+++ b/packages/claude-sdk/test/ModelCatalog.spec.ts
@@ -1,0 +1,95 @@
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AnthropicAuth } from '../src/private/Client/Auth/AnthropicAuth.js';
+import { ModelCatalog } from '../src/private/ModelCatalog.js';
+
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+/** A fake auth that yields a static bearer token, standing in for the OAuth flow. */
+const fakeAuth = { getCredentials: () => Promise.resolve({ claudeAiOauth: { accessToken: 'tok' } }) } as unknown as AnthropicAuth;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function stubFetch(...responses: Response[]): ReturnType<typeof vi.fn> {
+  const fn = vi.fn<typeof fetch>();
+  for (const r of responses) {
+    fn.mockResolvedValueOnce(r);
+  }
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ModelCatalog — list', () => {
+  it('maps the endpoint data to id and displayName', async () => {
+    stubFetch(jsonResponse({ data: [{ id: 'claude-opus-4-8', display_name: 'Claude Opus 4.8' }] }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    const actual = await catalogue.list();
+    const expected = [{ id: 'claude-opus-4-8', displayName: 'Claude Opus 4.8' }];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('falls back to the id when display_name is absent', async () => {
+    stubFetch(jsonResponse({ data: [{ id: 'claude-x' }] }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    const actual = (await catalogue.list())[0]?.displayName;
+    const expected = 'claude-x';
+
+    expect(actual).toBe(expected);
+  });
+
+  it('skips entries without a string id', async () => {
+    stubFetch(jsonResponse({ data: [{ id: 42 }, { id: 'claude-y' }] }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    const actual = (await catalogue.list()).map((m) => m.id);
+    const expected = ['claude-y'];
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('ModelCatalog — memoisation', () => {
+  it('fetches once across repeated calls on success', async () => {
+    const fn = stubFetch(jsonResponse({ data: [{ id: 'claude-opus-4-8' }] }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    await catalogue.list();
+    await catalogue.list();
+    const expected = 1;
+    const actual = fn.mock.calls.length;
+
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ModelCatalog — failure', () => {
+  it('returns an empty list on a non-ok response', async () => {
+    stubFetch(new Response('nope', { status: 500 }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    const actual = await catalogue.list();
+    const expected: unknown[] = [];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('does not cache a failure, so a later call retries and succeeds', async () => {
+    stubFetch(new Response('nope', { status: 500 }), jsonResponse({ data: [{ id: 'claude-opus-4-8' }] }));
+    const catalogue = new ModelCatalog(fakeAuth, noopLogger);
+
+    await catalogue.list();
+    const actual = (await catalogue.list()).map((m) => m.id);
+    const expected = ['claude-opus-4-8'];
+
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a model selector to command mode: `Ctrl+/ m m` opens a free-text model editor pre-filled with the effective model, mirroring the cd path editor.
- Free text always submits and sends — a blue highlight is purely advisory, lighting up only when the typed id exactly matches a known model, and never gates submission.
- The command-mode override shares one slot with the `--model` startup flag; an empty submit clears it back to the config model, whether a human or the flag set the value.
- Add `IModelCatalog`/`ModelCatalog` to the SDK: a lazy, memoised fetch of the account's models from Anthropic's `/v1/models` over the existing OAuth transport, degrading to an empty (advisory-only) list on failure. Built as reusable infrastructure for future token/support-settings work.
- The per-session override is in-memory only, gone on restart, like `--model`.