### PR TITLE
Split a tool turn into tool-use and execution blocks

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show model version alongside model name in the status bar
 - Show tool input JSON as it streams
 - Spawn the TypeScript server on demand for each tool block and tear it down after, replacing the always-on server that ran for the whole session
+- Split a tool turn into two transcript blocks, tool use (the model's request) and execution (the run), so the execution block's timing reflects the actual run including the approval wait rather than only the tool-call generation; both the primary and history views show input on the use block and input plus output on the execution block
 - Split model identifier into name and version for separate use
 - The --verify check now boot-checks the tsserver with a one-shot spawn instead of only looking for its path
 - The user-level CLAUDE.md and SYSTEM.md sources now default off, so nothing is silently concatenated into a session at launch; project, projectClaude and local sources are unchanged, and setting user back to true in config remains supported

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -114,3 +114,4 @@
 {"description":"Tell the model the working directory: state it up front, and report the from/to when it changes mid-session","category":"added"}
 {"description":"Remove the PreviewEdit tool; EditFile now validates, writes, and returns a diff in one call","category":"removed"}
 {"description":"Fix batch tool approvals: a local Y/N keypress now settles the tool you have selected by its request id, instead of the head of an anonymous queue. Previously one keypress could approve or deny a different tool in the same batch (or two at once)","category":"fixed"}
+{"description":"Split a tool turn into two transcript blocks, tool use (the model's request) and execution (the run), so the execution block's timing reflects the actual run including the approval wait rather than only the tool-call generation; both the primary and history views show input on the use block and input plus output on the execution block","category":"changed"}

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -248,8 +248,19 @@ export class AgentMessageHandler {
         this.#toolAnnotation = '';
         break;
       case 'tool_batch_end':
-        // stop_reason === 'tool_use' has fired. The tools block stays open through
-        // the approval and execution phase; message_usage seals it.
+        // stop_reason === 'tool_use' has fired. The tool-use (generation) block is
+        // sealed by message_usage; execution is a separate block opened by tool_exec_start.
+        break;
+      case 'tool_exec_start':
+        // The assistant message and its usage are done; the batch is now running.
+        // Open the execution block so its createdAt→exitedAt spans the real run
+        // (approval waits included), distinct from the generation span the use block times.
+        this.conversation.transitionBlock('execution');
+        this.#redrawTools();
+        break;
+      case 'tool_exec_end':
+        // Every tool in the batch has settled — seal the execution block.
+        this.conversation.completeActive();
         break;
       case 'block_enter': {
         // tool_use/server_tool_use lifecycle is managed by tool_batch_start/end.
@@ -417,7 +428,12 @@ export class AgentMessageHandler {
       const obj = this.#toolObjects.get(id);
       return obj ? [obj.toEntry()] : [];
     });
-    this.conversation.setLastTools(content + this.#toolAnnotation, entries);
+    // The tool-use block (generation) carries the token annotation; the execution block
+    // carries the run only. Target whichever phase is live: the execution block once it
+    // has opened, the use block before that.
+    const target = this.conversation.activeBlock?.type === 'execution' ? 'execution' : 'tools';
+    const annotation = target === 'tools' ? this.#toolAnnotation : '';
+    this.conversation.setLastTools(target, content + annotation, entries);
   }
 
   async #toolApprovalRequest(msg: SdkToolApprovalRequest, obj: ToolObject | null): Promise<void> {

--- a/apps/claude-sdk-cli/src/model/ConversationState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationState.ts
@@ -8,7 +8,7 @@ type ConversationStateEvents = {
   change: [];
 };
 
-export type BlockType = 'prompt' | 'thinking' | 'response' | 'tools' | 'compaction' | 'meta' | 'notice';
+export type BlockType = 'prompt' | 'thinking' | 'response' | 'tools' | 'execution' | 'compaction' | 'meta' | 'notice';
 
 export type Block = {
   type: BlockType;
@@ -218,16 +218,16 @@ export class ConversationState {
    * content string is byte-identical to what setLastContent wrote, so the Primary
    * view's tools rendering is unchanged; `tools` is additive, read only by history.
    */
-  public setLastTools(content: string, tools: ToolEntry[]): void {
+  public setLastTools(type: 'tools' | 'execution', content: string, tools: ToolEntry[]): void {
     const sanitised = sanitiseLoneSurrogates(content);
-    if (this.#activeBlock?.type === 'tools') {
+    if (this.#activeBlock?.type === type) {
       this.#activeBlock.content = sanitised;
       this.#activeBlock.tools = tools;
       this.#emitter.emit('change');
       return;
     }
     for (let i = this.#sealedBlocks.length - 1; i >= 0; i--) {
-      if (this.#sealedBlocks[i]?.type === 'tools') {
+      if (this.#sealedBlocks[i]?.type === type) {
         // biome-ignore lint/style/noNonNullAssertion: checked above
         this.#sealedBlocks[i]!.content = sanitised;
         // biome-ignore lint/style/noNonNullAssertion: checked above

--- a/apps/claude-sdk-cli/src/model/HistoryViewState.ts
+++ b/apps/claude-sdk-cli/src/model/HistoryViewState.ts
@@ -26,8 +26,11 @@ const PAGE_BLOCKS = 5;
 const PAGE_LINES = 10;
 
 const clamp = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(n, hi));
-const toolCount = (block: Block | undefined): number => (block?.type === 'tools' ? (block.tools?.length ?? 0) : 0);
-const isToolsBlock = (block: Block | undefined): boolean => block?.type === 'tools' && (block.tools?.length ?? 0) > 0;
+// Both 'tools' (the use block, input only) and 'execution' (the run, input + output) carry
+// structured tool entries and navigate as tool cards in history.
+const isEntryBlock = (block: Block | undefined): boolean => block?.type === 'tools' || block?.type === 'execution';
+const toolCount = (block: Block | undefined): number => (isEntryBlock(block) ? (block?.tools?.length ?? 0) : 0);
+const isToolsBlock = (block: Block | undefined): boolean => isEntryBlock(block) && (block?.tools?.length ?? 0) > 0;
 
 /**
  * History navigation state for the box-model outline: the focus path (which

--- a/apps/claude-sdk-cli/src/model/blockLayout.ts
+++ b/apps/claude-sdk-cli/src/model/blockLayout.ts
@@ -69,7 +69,7 @@ export const HISTORY_CONTENT_INDENT = '   ';
  * the row count is identical either way, so one walker serves both.
  */
 export function historyOpenLines(block: Block, focus: Focus, cols: number, decorate: CodeDecorator): string[] {
-  if (block.type !== 'tools') {
+  if (block.type !== 'tools' && block.type !== 'execution') {
     return blockContentLines(block.content, cols, HISTORY_CONTENT_INDENT, decorate);
   }
   const entry = focus.tool === null ? undefined : block.tools?.[focus.tool];

--- a/apps/claude-sdk-cli/src/replayHistory.ts
+++ b/apps/claude-sdk-cli/src/replayHistory.ts
@@ -2,7 +2,7 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type { HistoryReplayConfig } from './cli-config/types.js';
 
 // Subset of AppLayout's BlockType — meta is never produced during replay.
-export type ReplayBlockType = 'prompt' | 'thinking' | 'response' | 'tools' | 'compaction';
+export type ReplayBlockType = 'prompt' | 'thinking' | 'response' | 'tools' | 'execution' | 'compaction';
 
 export type ReplayBlock = {
   type: ReplayBlockType;
@@ -17,11 +17,11 @@ export type ReplayBlock = {
  *
  * Mapping:
  *   user  text blocks          → prompt block
- *   user  tool_result blocks   → tools block  "↩ N results" (appended if tools block already open)
+ *   user  tool_result blocks   → execution block  "↩ N results" (appended if execution block already open)
  *   asst  compaction block     → compaction block with summary text
  *   asst  text blocks          → response block
  *   asst  thinking blocks      → thinking block (only if opts.showThinking)
- *   asst  tool_use blocks      → tools block  "→ name"  (merged into running tools block)
+ *   asst  tool_use blocks      → tools block  "→ name"  (merged into running tool-use block)
  *
  * Content array is walked in order so text before tool calls appears in a
  * response block above the tools block, matching the live session display.
@@ -29,12 +29,12 @@ export type ReplayBlock = {
 export function replayHistory(messages: Anthropic.Beta.Messages.BetaMessageParam[], opts: Pick<HistoryReplayConfig, 'showThinking'>): ReplayBlock[] {
   const blocks: ReplayBlock[] = [];
 
-  const appendToTools = (line: string): void => {
+  const appendTo = (type: 'tools' | 'execution', line: string): void => {
     const last = blocks[blocks.length - 1];
-    if (last?.type === 'tools') {
+    if (last?.type === type) {
       last.content += `\n${line}`;
     } else {
-      blocks.push({ type: 'tools', content: line });
+      blocks.push({ type, content: line });
     }
   };
 
@@ -45,7 +45,7 @@ export function replayHistory(messages: Anthropic.Beta.Messages.BetaMessageParam
       // Tool results — count only, name not available without cross-referencing tool_use ids.
       const resultCount = content.filter((b) => b.type === 'tool_result').length;
       if (resultCount > 0) {
-        appendToTools(`↩ ${resultCount} result${resultCount === 1 ? '' : 's'}`);
+        appendTo('execution', `↩ ${resultCount} result${resultCount === 1 ? '' : 's'}`);
         continue;
       }
 
@@ -74,7 +74,7 @@ export function replayHistory(messages: Anthropic.Beta.Messages.BetaMessageParam
           }
         } else if (block.type === 'tool_use') {
           const name = (block as { type: 'tool_use'; name: string }).name;
-          appendToTools(`→ ${name}`);
+          appendTo('tools', `→ ${name}`);
         } else if (block.type === 'compaction') {
           const compaction = block as { type: 'compaction'; content: string };
           blocks.push({ type: 'compaction', content: compaction.content });

--- a/apps/claude-sdk-cli/src/view/HistoryView.ts
+++ b/apps/claude-sdk-cli/src/view/HistoryView.ts
@@ -9,7 +9,8 @@ const LABEL: Record<string, string> = {
   prompt: 'prompt',
   thinking: 'thinking',
   response: 'response',
-  tools: 'tools',
+  tools: 'tool use',
+  execution: 'execution',
   compaction: 'compaction',
   meta: 'query',
   notice: 'notice',
@@ -91,7 +92,7 @@ export class HistoryView implements View {
   }
 
   #blockCard(block: Block, focused: boolean, hv: HistoryViewState, cols: number, rows: number): string[] {
-    if (block.type === 'tools') {
+    if (block.type === 'tools' || block.type === 'execution') {
       return this.#toolsCard(block, focused, hv, cols, rows);
     }
     const label = LABEL[block.type] ?? block.type;
@@ -117,12 +118,13 @@ export class HistoryView implements View {
   #toolsCard(block: Block, focused: boolean, hv: HistoryViewState, cols: number, rows: number): string[] {
     const tools = block.tools ?? [];
     const n = tools.length;
+    const label = LABEL[block.type] ?? block.type;
     const descended = focused && hv.focus.tool !== null;
 
     // Open: list the tools; the focused tool is gutter-marked, and an opened tool
     // grows to its input/output, slid by scrollOffset when taller than the screen.
     if (descended) {
-      const out: string[] = [buildDivider(`tools (${n})  (open)`, cols)];
+      const out: string[] = [buildDivider(`${label} (${n})  (open)`, cols)];
       for (let t = 0; t < tools.length; t++) {
         const entry = tools[t];
         if (!entry) {
@@ -144,9 +146,9 @@ export class HistoryView implements View {
     if (focused) {
       const inner = cols - GUTTER.length;
       const preview = this.#cap(renderBlockContent(names, inner, HISTORY_CONTENT_INDENT));
-      return [`${GUTTER}${buildDivider(`tools (${n})  (focused)`, inner)}`, ...preview.map((l) => `${GUTTER}${l}`)];
+      return [`${GUTTER}${buildDivider(`${label} (${n})  (focused)`, inner)}`, ...preview.map((l) => `${GUTTER}${l}`)];
     }
-    return [buildDivider(`tools (${n})`, cols), ...this.#cap(renderBlockContent(names, cols, HISTORY_CONTENT_INDENT))];
+    return [buildDivider(`${label} (${n})`, cols), ...this.#cap(renderBlockContent(names, cols, HISTORY_CONTENT_INDENT))];
   }
 
   /** Cap a collapsed box's content: keep the first lines, mark more with a `...` line — only when there is more. */

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -16,7 +16,8 @@ const BLOCK_PLAIN: Record<string, string> = {
   prompt: 'prompt',
   thinking: 'thinking',
   response: 'response',
-  tools: 'tools',
+  tools: 'tool use',
+  execution: 'execution',
   compaction: 'compaction',
   meta: 'query',
 };
@@ -26,6 +27,7 @@ const BLOCK_EMOJI: Record<string, string> = {
   thinking: '💭 ',
   response: '📝 ',
   tools: '🔧 ',
+  execution: '\u2699\uFE0F  ',
   compaction: '🗜 ',
   meta: 'ℹ️  ',
 };

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -346,6 +346,41 @@ describe('AgentMessageHandler — tool_batch_start', () => {
   });
 });
 
+describe('AgentMessageHandler — tool execution split', () => {
+  it('opens an execution block on tool_exec_start', () => {
+    const { handler, conversationState } = makeHandler();
+    streamTool(handler, 'toolu_01', 'ReadFile');
+    handler.handle(makeUsage(1000)); // seals the tool-use block
+    handler.handle({ type: 'tool_exec_start' });
+    const expected = 'execution';
+    const actual = conversationState.activeBlock?.type;
+    expect(actual).toBe(expected);
+  });
+
+  it('seals the execution block on tool_exec_end', () => {
+    const { handler, conversationState } = makeHandler();
+    streamTool(handler, 'toolu_01', 'ReadFile');
+    handler.handle(makeUsage(1000));
+    handler.handle({ type: 'tool_exec_start' });
+    handler.handle({ type: 'tool_exec_end' });
+    const expected = null;
+    const actual = conversationState.activeBlock;
+    expect(actual).toBe(expected);
+  });
+
+  it('produces a tool-use block and an execution block as separate sealed blocks', () => {
+    const { handler, conversationState } = makeHandler();
+    streamTool(handler, 'toolu_01', 'ReadFile');
+    handler.handle(makeUsage(1000));
+    handler.handle({ type: 'tool_exec_start' });
+    handler.handle({ type: 'tool_result', id: 'toolu_01', content: 'ok', isError: false });
+    handler.handle({ type: 'tool_exec_end' });
+    const expected = ['tools', 'execution'];
+    const actual = conversationState.sealedBlocks.filter((b) => b.type === 'tools' || b.type === 'execution').map((b) => b.type);
+    expect(actual).toEqual(expected);
+  });
+});
+
 describe('AgentMessageHandler — block_exit', () => {
   it('seals the thinking block', () => {
     const { handler, conversationState } = makeHandler();

--- a/apps/claude-sdk-cli/test/ConversationState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationState.spec.ts
@@ -577,7 +577,7 @@ describe('ConversationState — setLastTools', () => {
   it('writes content and entries to the active tools block', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
-    state.setLastTools('rendered', [{ name: 'ReadFile', kind: 'client', input: { path: 'a' }, output: 'x', phase: 'done' }]);
+    state.setLastTools('tools', 'rendered', [{ name: 'ReadFile', kind: 'client', input: { path: 'a' }, output: 'x', phase: 'done' }]);
     const expected = 'rendered';
     const actual = state.activeBlock?.content;
     expect(actual).toBe(expected);
@@ -586,7 +586,7 @@ describe('ConversationState — setLastTools', () => {
   it('stores the entries on the active tools block', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
-    state.setLastTools('rendered', [{ name: 'ReadFile', kind: 'client', input: { path: 'a' }, output: 'x', phase: 'done' }]);
+    state.setLastTools('tools', 'rendered', [{ name: 'ReadFile', kind: 'client', input: { path: 'a' }, output: 'x', phase: 'done' }]);
     const expected = 1;
     const actual = state.activeBlock?.tools?.length;
     expect(actual).toBe(expected);
@@ -598,7 +598,7 @@ describe('ConversationState — setLastTools', () => {
     state.appendToActive('tool content');
     state.transitionBlock('response'); // seals the tools block at index 0
     state.appendToActive('reply');
-    state.setLastTools('updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
+    state.setLastTools('tools', 'updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
     const expected = 'updated';
     const actual = state.sealedBlocks[0]?.content;
     expect(actual).toBe(expected);
@@ -609,7 +609,7 @@ describe('ConversationState — setLastTools', () => {
     state.transitionBlock('tools');
     state.appendToActive('tool content');
     state.transitionBlock('response');
-    state.setLastTools('updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
+    state.setLastTools('tools', 'updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
     const expected = 'Exec';
     const actual = state.sealedBlocks[0]?.tools?.[0]?.name;
     expect(actual).toBe(expected);

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -233,3 +233,42 @@ describe('HistoryView — frames against the illustrations', () => {
     expect(actual).toBe(expected);
   });
 });
+
+// The tool-use/execution split: the execution block carries the input+output
+// entries, so history must navigate it as a tool card (regression — it was
+// rendered as a plain block, hiding both input and output).
+describe('HistoryView — execution block', () => {
+  function modelWithExecution(): ViewModel {
+    const model = makeModel();
+    model.conversationState.clear();
+    model.conversationState.addBlocks([
+      { type: 'prompt', content: 'do it' },
+      {
+        type: 'execution',
+        content: 'exec lines',
+        tools: [{ name: 'DeleteFile', kind: 'client', input: { path: 'x.txt' }, output: 'deleted', phase: 'approved' }],
+      },
+    ]);
+    model.historyViewState.enterAtLatest(model.conversationState.sealedBlocks.length);
+    return model;
+  }
+
+  it('descends an execution block as a tool card', () => {
+    const model = modelWithExecution();
+    const bs = model.conversationState.sealedBlocks;
+    model.historyViewState.apply('open', bs); // descend to tool 0
+    const expected = '> DeleteFile';
+    const actual = new HistoryView().render(model);
+    expect(actual).toContain(expected);
+  });
+
+  it('shows the execution tool output when the tool is opened', () => {
+    const model = modelWithExecution();
+    const bs = model.conversationState.sealedBlocks;
+    model.historyViewState.apply('open', bs); // descend to tool 0
+    model.historyViewState.apply('open', bs); // open tool 0
+    const expected = `${CONTENT_INDENT}  deleted`;
+    const actual = new HistoryView().render(model);
+    expect(actual).toContain(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/StreamInterruptNotice.spec.ts
+++ b/apps/claude-sdk-cli/test/StreamInterruptNotice.spec.ts
@@ -54,7 +54,7 @@ describe('StreamInterruptNotice', () => {
     const { notice, conversation } = build();
     conversation.transitionBlock('tools');
     const tools: ToolEntry[] = [{ name: 'ReadFile', kind: 'client', input: { path: '/foo' }, output: null, phase: 'streaming' }];
-    conversation.setLastTools('ReadFile', tools);
+    conversation.setLastTools('tools', 'ReadFile', tools);
 
     notice.reconnecting();
 

--- a/apps/claude-sdk-cli/test/renderConversation.spec.ts
+++ b/apps/claude-sdk-cli/test/renderConversation.spec.ts
@@ -71,7 +71,7 @@ describe('renderConversation — continuation suppression', () => {
       { type: 'tools', content: 'tool B' },
     ]);
     const lines = renderConversation(state, 80).map(stripAnsi);
-    const dividerCount = lines.filter((l) => l.includes('tools')).length;
+    const dividerCount = lines.filter((l) => l.includes('tool use')).length;
     // Only the first block gets a divider; the second is a continuation
     const expected = 1;
     const actual = dividerCount;
@@ -110,7 +110,7 @@ describe('renderConversation — active block', () => {
     state.transitionBlock('tools');
     state.appendToActive('tool B');
     const lines = renderConversation(state, 80).map(stripAnsi);
-    const dividerCount = lines.filter((l) => l.includes('tools')).length;
+    const dividerCount = lines.filter((l) => l.includes('tool use')).length;
     // Only the sealed block gets a divider; active continuation does not
     const expected = 1;
     const actual = dividerCount;

--- a/apps/claude-sdk-cli/test/replayHistory.spec.ts
+++ b/apps/claude-sdk-cli/test/replayHistory.spec.ts
@@ -53,9 +53,9 @@ describe('replayHistory — user messages', () => {
     expect(actual).toBe(expected);
   });
 
-  it('tool results produce a tools block', () => {
+  it('tool results produce an execution block', () => {
     const msg: Msg = { role: 'user', content: [toolResult('tu_1'), toolResult('tu_2')] };
-    const expected = 'tools';
+    const expected = 'execution';
     const actual = replayHistory([msg], noThinking)[0]?.type;
     expect(actual).toBe(expected);
   });
@@ -172,25 +172,25 @@ describe('replayHistory — ordering and merging', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('tool_result appends to preceding tools block from tool_use', () => {
+  it('tool_use and tool_result produce separate use and execution blocks', () => {
     const asstMsg: Msg = { role: 'assistant', content: [toolUse('ReadFile')] };
     const userMsg: Msg = { role: 'user', content: [toolResult('tu_ReadFile')] };
-    const expected = 1;
-    const actual = replayHistory([asstMsg, userMsg], noThinking).length;
-    expect(actual).toBe(expected);
+    const expected = ['tools', 'execution'];
+    const actual = replayHistory([asstMsg, userMsg], noThinking).map((b) => b.type);
+    expect(actual).toEqual(expected);
   });
 
-  it('tool_result content appended after tool_use in same block', () => {
+  it('the execution block carries the result line', () => {
     const asstMsg: Msg = { role: 'assistant', content: [toolUse('ReadFile')] };
     const userMsg: Msg = { role: 'user', content: [toolResult('tu_ReadFile')] };
-    const expected = '→ ReadFile\n↩ 1 result';
-    const actual = replayHistory([asstMsg, userMsg], noThinking)[0]?.content;
+    const expected = '↩ 1 result';
+    const actual = replayHistory([asstMsg, userMsg], noThinking)[1]?.content;
     expect(actual).toBe(expected);
   });
 
   it('full turn sequence produces correct block order', () => {
     const messages: Msg[] = [user('what files are here?'), { role: 'assistant', content: [{ type: 'text', text: 'Let me check.' }, toolUse('Find')] }, { role: 'user', content: [toolResult('tu_Find')] }, assistant('Here are the files.')];
-    const expected = ['prompt', 'response', 'tools', 'response'];
+    const expected = ['prompt', 'response', 'tools', 'execution', 'response'];
     const actual = replayHistory(messages, noThinking).map((b) => b.type);
     expect(actual).toEqual(expected);
   });

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deliver tool attachments as native content blocks inside tool results
 - Emit canonical per-turn content on the control channel after each turn
 - Emit enter_block and exit_block events from content_block_start and content_block_stop
+- Emit tool_exec_start and tool_exec_end around tool execution, bracketing the run phase (approval waits included) so a consumer can frame and time it separately from tool-call generation
 - ESC while a tool is running cancels the tool and delivers a cancellation result to Claude; ESC otherwise ends the query
 - Export `IMessageStreamer` from the public barrel
 - Inject a live per-turn date/time stamp into every request

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -46,3 +46,4 @@
 {"description":"Add a per-block tool lifecycle: a tool can declare a blockLifetime that is torn down when the tool-execution block of a turn ends","category":"added"}
 {"description":"Model per-message reminders with a SystemReminder type (text, persisted, position): PerQueryInput.reminders and TurnInput.ephemeralReminders replace the systemReminder string, so a persisted reminder is stored in history and leads the user message (cached) while an ephemeral one rides the request clone each turn and trails it (uncached)","category":"changed"}
 {"description":"Add IModelCatalog/ModelCatalog: a lazy, memoised service that fetches the account's model list from Anthropic's /v1/models endpoint over the existing OAuth transport","category":"added"}
+{"description":"Emit tool_exec_start and tool_exec_end around tool execution, bracketing the run phase (approval waits included) so a consumer can frame and time it separately from tool-call generation","category":"added"}

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -212,6 +212,7 @@ export class QueryRunner extends IQueryRunner {
    */
   async #handleTools(toolUses: ToolUseResult[], transformToolResult: TransformToolResult | undefined) {
     this.toolsClock.toolsStarted();
+    this.publisher.send({ type: 'tool_exec_start' } satisfies SdkMessage);
     try {
       return await this.#runTools(toolUses, transformToolResult);
     } finally {
@@ -220,6 +221,7 @@ export class QueryRunner extends IQueryRunner {
       // batch where nothing ran. A no-op when no tool declared a block lifetime.
       await this.blockNotifier.blockEnded();
       this.toolsClock.toolsStopped();
+      this.publisher.send({ type: 'tool_exec_end' } satisfies SdkMessage);
     }
   }
 

--- a/packages/claude-sdk/src/public/types.ts
+++ b/packages/claude-sdk/src/public/types.ts
@@ -222,6 +222,12 @@ export type SdkBlockEnter = { type: 'block_enter'; blockType: string };
 export type SdkBlockExit = { type: 'block_exit'; blockType: string };
 export type SdkToolBatchStart = { type: 'tool_batch_start' };
 export type SdkToolBatchEnd = { type: 'tool_batch_end' };
+/** Brackets tool execution. Emitted around the tool-time clock in the query runner:
+ * tool_exec_start when the batch begins running (after the assistant message and its
+ * usage are done), tool_exec_end when every tool has settled. The span covers approval
+ * waits and batches where nothing runs. */
+export type SdkToolExecStart = { type: 'tool_exec_start' };
+export type SdkToolExecEnd = { type: 'tool_exec_end' };
 /** The structured pieces of an API failure the CLI formats for display. Present when the
  * error is a transport error carrying a parsed body; absent for errors that have only a
  * message (e.g. an internal give-up). `message` is the human-readable detail from the
@@ -238,6 +244,8 @@ export type SdkMessage =
   | SdkBlockExit
   | SdkToolBatchStart
   | SdkToolBatchEnd
+  | SdkToolExecStart
+  | SdkToolExecEnd
   | SdkMessageStart
   | SdkMessageText
   | SdkMessageThinking

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -889,3 +889,41 @@ describe('QueryRunner — tools-clock bracket', () => {
     expect(actual).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tool-execution event bracket (tool_exec_start / tool_exec_end). These drive
+// the CLI's separate execution block, so they must be emitted around the actual
+// run — start before the tool_result, end after it.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — tool-execution event bracket', () => {
+  it('publishes tool_exec_start then tool_exec_end on a tool-use turn', async () => {
+    const tool = makeTool('echo', async (input) => `got: ${input.value}`);
+    const w = makeWiring([toolUseResult('tu_1', 'echo', { value: 'hi' }), endTurnResult('done')], [tool]);
+    await w.queryRunner.run(makeInput({ messages: ['go'] }));
+    const expected = ['tool_exec_start', 'tool_exec_end'];
+    const actual = w.channel.messages.filter((m) => m.type === 'tool_exec_start' || m.type === 'tool_exec_end').map((m) => m.type);
+    expect(actual).toEqual(expected);
+  });
+
+  it('brackets the tool_result: exec_start before it, exec_end after it', async () => {
+    const tool = makeTool('echo', async (input) => `got: ${input.value}`);
+    const w = makeWiring([toolUseResult('tu_1', 'echo', { value: 'hi' }), endTurnResult('done')], [tool]);
+    await w.queryRunner.run(makeInput({ messages: ['go'] }));
+    const types = w.channel.messages.map((m) => m.type);
+    const startIdx = types.indexOf('tool_exec_start');
+    const resultIdx = types.indexOf('tool_result');
+    const endIdx = types.indexOf('tool_exec_end');
+    const expected = true;
+    const actual = startIdx < resultIdx && resultIdx < endIdx;
+    expect(actual).toBe(expected);
+  });
+
+  it('emits no tool-execution events on a terminal turn with no tools', async () => {
+    const w = makeWiring([endTurnResult('hello')]);
+    await w.queryRunner.run(makeInput({ messages: ['hi'] }));
+    const expected = 0;
+    const actual = w.channel.messages.filter((m) => m.type === 'tool_exec_start' || m.type === 'tool_exec_end').length;
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Tool turns now render as two blocks instead of one: **tool use** (the model's request) and **execution** (the run). The old single block sealed the moment the model finished asking, so the execution phase and the approval wait fell outside any block's timing; the execution block now covers the real run.
- The SDK emits `tool_exec_start` / `tool_exec_end` around tool execution (bracketing the approval wait and no-op batches), so a consumer can frame and time the run separately from tool-call generation.
- Both the primary and history views project the split: input on the use block, input plus output on the execution block. History navigates the execution block as a tool card.
- Fixes a batch tool-approval bug where a single Y or N settled every tool in the batch at once; a manual answer now settles only the tool it was given for.
- Tests: SDK emit-order bracket, the block split and its history rendering, and an approval regression asserting one answer settles one tool.

The token/cost attribution rework (input on the query block, output on the last block) is intentionally left as separate work, since it touches the status line.