### PR TITLE
Show token usage on every turn, split into input and output

### DIFF
--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -1,4 +1,5 @@
 import { relative } from 'node:path';
+import { RESET } from '@shellicar/claude-core/ansi';
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -10,6 +11,7 @@ import { IConvChangePublisher } from '../conv/ConvChangePublisher.js';
 import { ApprovalNotifier } from '../model/ApprovalNotifier.js';
 import { ConversationSession } from '../model/ConversationSession.js';
 import { ConversationState } from '../model/ConversationState.js';
+import { CODE_FG } from '../model/markdown/palette.js';
 import { StatusState } from '../model/StatusState.js';
 import { type PendingTool, ToolApprovalState } from '../model/ToolApprovalState.js';
 import { ToolObject } from '../model/ToolObject.js';
@@ -371,31 +373,35 @@ export class AgentMessageHandler {
         this.conversation.appendStreaming(`${msg.name} error\n\`\`\`json\n${JSON.stringify(msg.input, null, 2)}\n\`\`\`\n\n${msg.error}\n`);
         break;
       case 'message_usage': {
-        // Per-turn token-delta annotation, appended while a tools block is active.
-        // Guarded on the active block type (not the persisted map) so a pure-text
-        // turn after a tools turn does not pick up a spurious annotation.
-        const prev = this.#lastUsage;
-        if (this.conversation.activeBlock?.type === 'tools' && prev !== null) {
-          const prevCtx = prev.inputTokens + prev.cacheCreationTokens + prev.cacheReadTokens;
-          const currCtx = msg.inputTokens + msg.cacheCreationTokens + msg.cacheReadTokens;
-          const delta = currCtx - prevCtx;
+        // The API reports usage in frames across a turn: input + cache land on message_start, output at
+        // message_end. Each frame is priced on its own, so the per-turn token line splits in two — the
+        // context frame at the start, the output frame at the end — rather than one lump on the tools block.
+        const context = msg.inputTokens + msg.cacheCreationTokens + msg.cacheReadTokens;
+        if (context > 0) {
+          // Context frame. Show the growth over the previous turn's context, priced as the marginal new
+          // input/cache (the running calc). #lastUsage tracks the context frame, never the output frame.
+          const prev = this.#lastUsage;
+          const prevCtx = prev ? prev.inputTokens + prev.cacheCreationTokens + prev.cacheReadTokens : 0;
+          const delta = context - prevCtx;
           const sign = delta >= 0 ? '+' : '';
           const marginalCost = calculateCostSplit(
             {
-              inputTokens: Math.max(0, msg.inputTokens - prev.inputTokens),
-              cacheCreation5mTokens: Math.max(0, msg.cacheCreation5mTokens - prev.cacheCreation5mTokens),
-              cacheCreation1hTokens: Math.max(0, msg.cacheCreation1hTokens - prev.cacheCreation1hTokens),
-              cacheReadTokens: Math.max(0, msg.cacheReadTokens - prev.cacheReadTokens),
-              outputTokens: msg.outputTokens,
+              inputTokens: Math.max(0, msg.inputTokens - (prev?.inputTokens ?? 0)),
+              cacheCreation5mTokens: Math.max(0, msg.cacheCreation5mTokens - (prev?.cacheCreation5mTokens ?? 0)),
+              cacheCreation1hTokens: Math.max(0, msg.cacheCreation1hTokens - (prev?.cacheCreation1hTokens ?? 0)),
+              cacheReadTokens: Math.max(0, msg.cacheReadTokens - (prev?.cacheReadTokens ?? 0)),
+              outputTokens: 0,
             },
             this.#config.model,
           );
-          const costStr = `$${marginalCost.toFixed(4)}`;
-          this.#toolAnnotation += `[\u2191 ${sign}${delta.toLocaleString()} tokens \u00b7 ${costStr}]\n`;
-          this.#redrawTools();
+          this.#appendUsageLine(`[\u2191 ${sign}${delta.toLocaleString()} tokens \u00b7 $${marginalCost.toFixed(4)}]`);
+          this.#lastUsage = msg;
+        } else if (msg.outputTokens > 0) {
+          // Output frame. Show the tokens the model produced this turn and their own cost.
+          const outputCost = calculateCostSplit({ inputTokens: 0, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0, cacheReadTokens: 0, outputTokens: msg.outputTokens }, this.#config.model);
+          this.#appendUsageLine(`[\u2193 +${msg.outputTokens.toLocaleString()} tokens \u00b7 $${outputCost.toFixed(4)}]`);
         }
         this.conversation.completeActive();
-        this.#lastUsage = msg;
         this.statusState.update(msg);
         break;
       }
@@ -419,6 +425,24 @@ export class AgentMessageHandler {
           .then(() => this.convChanges.flush(this.session.id))
           .catch((err) => this.logger.error('persist after turn failed', { error: String(err) }));
         break;
+    }
+  }
+
+  // Place a per-frame usage line, painted gold. A tools/execution block owns its content through
+  // #redrawTools, so the line rides the annotation buffer there; an active meta/response block takes it
+  // inline (both already indented). With no active block — the output frame after a plain-text response,
+  // whose block is sealed — appendStreaming opens a notice block, which renders flush-left, so the line
+  // is hand-indented to line up with the other block bodies (matches CONTENT_INDENT in renderConversation).
+  #appendUsageLine(line: string): void {
+    const styled = `${CODE_FG}${line}${RESET}`;
+    const type = this.conversation.activeBlock?.type;
+    if (type === 'tools' || type === 'execution') {
+      this.#toolAnnotation += `${styled}\n`;
+      this.#redrawTools();
+    } else if (type != null) {
+      this.conversation.appendStreaming(`\n${styled}`);
+    } else {
+      this.conversation.appendStreaming(`   ${styled}`);
     }
   }
 

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -9,6 +9,7 @@ import { dependsOn } from '@shellicar/core-di-lite';
 import { IApprovalHolder, type Settlement } from '../approval/ApprovalHolder.js';
 import { IConvChangePublisher } from '../conv/ConvChangePublisher.js';
 import { ApprovalNotifier } from '../model/ApprovalNotifier.js';
+import { CONTENT_INDENT } from '../model/blockLayout.js';
 import { ConversationSession } from '../model/ConversationSession.js';
 import { ConversationState } from '../model/ConversationState.js';
 import { CODE_FG } from '../model/markdown/palette.js';
@@ -432,7 +433,7 @@ export class AgentMessageHandler {
   // #redrawTools, so the line rides the annotation buffer there; an active meta/response block takes it
   // inline (both already indented). With no active block — the output frame after a plain-text response,
   // whose block is sealed — appendStreaming opens a notice block, which renders flush-left, so the line
-  // is hand-indented to line up with the other block bodies (matches CONTENT_INDENT in renderConversation).
+  // is hand-indented with CONTENT_INDENT to line up with the other block bodies.
   #appendUsageLine(line: string): void {
     const styled = `${CODE_FG}${line}${RESET}`;
     const type = this.conversation.activeBlock?.type;
@@ -442,7 +443,7 @@ export class AgentMessageHandler {
     } else if (type != null) {
       this.conversation.appendStreaming(`\n${styled}`);
     } else {
-      this.conversation.appendStreaming(`   ${styled}`);
+      this.conversation.appendStreaming(`${CONTENT_INDENT}${styled}`);
     }
   }
 

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -394,6 +394,7 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
   const processor = provider.resolve(StreamProcessor);
   processor.on('final_message', (msg) => provider.resolve(AuditWriter).write(session.id, msg));
   processor.on('message_start', () => sdkChannel.send({ type: 'message_start' }));
+  processor.on('message_usage', (usage) => sdkChannel.send({ type: 'message_usage', ...usage }));
   processor.on('message_text', (text) => sdkChannel.send({ type: 'message_text', text }));
   processor.on('thinking_text', (text) => sdkChannel.send({ type: 'message_thinking', text }));
   processor.on('message_stop', (stopReason) => sdkChannel.send({ type: 'message_end', stopReason }));

--- a/apps/claude-sdk-cli/src/model/StatusState.ts
+++ b/apps/claude-sdk-cli/src/model/StatusState.ts
@@ -159,7 +159,13 @@ export class StatusState {
     this.#totalCacheReadTokens += msg.cacheReadTokens;
     this.#totalOutputTokens += msg.outputTokens;
     this.#totalCostUsd += msg.costUsd;
-    this.#lastContextUsed = msg.inputTokens + msg.cacheCreationTokens + msg.cacheReadTokens;
+    // Usage arrives as two frames per turn: the context frame (input + cache) and the output-only
+    // frame. Context is a point-in-time snapshot, not a running sum, so take it only from the frame
+    // that carries it — the output frame would otherwise clobber it to zero.
+    const context = msg.inputTokens + msg.cacheCreationTokens + msg.cacheReadTokens;
+    if (context > 0) {
+      this.#lastContextUsed = context;
+    }
     this.#contextWindow = msg.contextWindow;
     this.#emitter.emit('change');
   }

--- a/apps/claude-sdk-cli/src/model/blockLayout.ts
+++ b/apps/claude-sdk-cli/src/model/blockLayout.ts
@@ -4,6 +4,10 @@ import type { Focus, HistoryContentExtent } from './HistoryViewState.js';
 
 const CODE_FENCE_RE = /```(\w*)\n([\s\S]*?)```/g;
 
+/** The left margin a block's body renders at (non-notice blocks). Lives here in model/ so both view/
+ * (renderConversation) and controller/ (AgentMessageHandler's hand-indented usage line) share one value. */
+export const CONTENT_INDENT = '   ';
+
 /**
  * Decorates a code-fence body for display. Must return one line per source line:
  * decoration (syntax colour) paints inside a line and never adds or removes one.

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -4,7 +4,7 @@ import { wrapLine } from '@shellicar/claude-core/reflow';
 import { highlight, supportsLanguage } from 'cli-highlight';
 import stringWidth from 'string-width';
 import type { MarkdownConfig } from '../cli-config/types.js';
-import { blockContentLines } from '../model/blockLayout.js';
+import { blockContentLines, CONTENT_INDENT } from '../model/blockLayout.js';
 import type { Block, ConversationState } from '../model/ConversationState.js';
 import { MIN_DIVIDER_WIDTH } from '../model/dividerWidths.js';
 import { markdownContentLines } from '../model/markdown/markdownLayout.js';
@@ -31,8 +31,6 @@ const BLOCK_EMOJI: Record<string, string> = {
   compaction: '🗜 ',
   meta: 'ℹ️  ',
 };
-
-const CONTENT_INDENT = '   ';
 
 // Some fence language identifiers don't match highlight.js names.
 // Map them so we get proper syntax colouring instead of a silent fallback.

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -966,6 +966,51 @@ describe('AgentMessageHandler — message_usage delta annotation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// usage frames split across the turn (message_start context, message_end output)
+// ---------------------------------------------------------------------------
+
+// An output-only frame: no context (input/cache), just the output produced this turn. This is the
+// message_end frame; makeUsage (input > 0) stands in for the message_start context frame.
+function outputFrame(outputTokens: number) {
+  return { type: 'message_usage' as const, inputTokens: 0, cacheCreationTokens: 0, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0, cacheReadTokens: 0, outputTokens, costUsd: 0.002, contextWindow: 200_000 };
+}
+
+describe('AgentMessageHandler — usage frames split across the turn', () => {
+  it('renders the output frame as a down-arrow output line on the tools block', () => {
+    const { handler, conversationState } = makeHandler();
+    handler.handle(makeUsage(1000));
+    streamTool(handler, 'r1', 'Find');
+    handler.handle({ type: 'tool_approval_request', requestId: 'r1', name: 'Find', input: { path: '.' } });
+    handler.handle(outputFrame(250));
+    const expected = true;
+    const actual = toolsBlockContent(conversationState).includes('\u2193 +250');
+    expect(actual).toBe(expected);
+  });
+
+  it('does not put a context (up-arrow) line on the tools block for the output frame', () => {
+    // The output frame carries zero context, so the context branch — which subtracts the prior context
+    // and reads negative — must not run. Guards the negative-delta regression.
+    const { handler, conversationState } = makeHandler();
+    streamTool(handler, 'r1', 'Find');
+    handler.handle({ type: 'tool_approval_request', requestId: 'r1', name: 'Find', input: { path: '.' } });
+    handler.handle(outputFrame(250));
+    const expected = false;
+    const actual = toolsBlockContent(conversationState).includes('\u2191');
+    expect(actual).toBe(expected);
+  });
+
+  it('shows the context frame line on a plain-text turn with no tools block', () => {
+    // The complaint that started this: on a text turn there was no token line at all.
+    const { handler, conversationState } = makeHandler();
+    handler.handle(makeUsage(1000));
+    const blocks = [...conversationState.sealedBlocks, conversationState.activeBlock];
+    const expected = true;
+    const actual = blocks.some((b) => b?.content.includes('\u2191 +1,000') ?? false);
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // message_compaction with lastUsage
 // ---------------------------------------------------------------------------
 

--- a/apps/claude-sdk-cli/test/StatusState.spec.ts
+++ b/apps/claude-sdk-cli/test/StatusState.spec.ts
@@ -118,6 +118,17 @@ describe('StatusState — update overwrites lastContextUsed and contextWindow', 
     expect(actual).toBe(expected);
   });
 
+  it('keeps the context frame value when a following output-only frame carries no context', () => {
+    // Usage arrives as two frames per turn: input+cache (context) then output-only. The output frame
+    // has zero context and must not zero the snapshot the context frame set.
+    const state = makeState();
+    state.update(makeUsage(1000, { cacheRead: 500 }));
+    state.update(makeUsage(0, { output: 250 }));
+    const expected = 1500;
+    const actual = state.lastContextUsed;
+    expect(actual).toBe(expected);
+  });
+
   it('contextWindow is overwritten on second update', () => {
     const state = makeState();
     state.update(makeUsage(0, { contextWindow: 100_000 }));

--- a/apps/claude-sdk-cli/test/ThinkingRequestWiring.spec.ts
+++ b/apps/claude-sdk-cli/test/ThinkingRequestWiring.spec.ts
@@ -9,7 +9,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IRandomProvider } from '@shellicar/claude-core/providers/IRandomProvider';
 import { ISleepProvider } from '@shellicar/claude-core/providers/ISleepProvider';
-import { AccountLimitListener, Conversation, IDurableConfigProvider, IMessageStreamer, IRequestClockListener, IStreamProcessor, IToolRegistry, IWakeLock, StreamInterruptListener, StreamProcessor, type ThinkingEffort, ToolRegistry, TurnRunner, type WakeLockHandle } from '@shellicar/claude-sdk';
+import { AccountLimitListener, Conversation, type DurableConfig, IDurableConfigProvider, IMessageStreamer, IRequestClockListener, IStreamProcessor, IToolRegistry, IWakeLock, StreamInterruptListener, StreamProcessor, type ThinkingEffort, ToolRegistry, TurnRunner, type WakeLockHandle } from '@shellicar/claude-sdk';
 import { RefStore } from '@shellicar/claude-sdk-tools/RefStore';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
@@ -81,6 +81,30 @@ class NoopRequestClock extends IRequestClockListener {
   public requestSettled(_kept: boolean): void {}
 }
 
+// StreamProcessor @dependsOn(IDurableConfigProvider) to price the usage frames it emits. This wiring
+// captures the request and aborts before any stream is processed, so only construction needs it.
+class NoopDurableConfigProvider extends IDurableConfigProvider {
+  public get config(): DurableConfig {
+    return { model: 'claude-test' } as DurableConfig;
+  }
+  public update(): void {}
+  public updateIdentityBody(): void {}
+  public async resolveSystemPromptsFor(): Promise<void> {}
+  public async resolveSkillCatalogue(): Promise<void> {}
+  public needsSystemPromptResolve(): boolean {
+    return false;
+  }
+  public getEffectiveModel(): string {
+    return 'claude-test';
+  }
+  public getEffectiveThinkingEnabled(): boolean {
+    return false;
+  }
+  public getEffectiveEffort(): ThinkingEffort | undefined {
+    return undefined;
+  }
+}
+
 // TurnRunner is property-injected; build it through a container with test doubles.
 function buildTurnRunner(streamer: IMessageStreamer): TurnRunner {
   const services = createServiceCollection();
@@ -88,6 +112,7 @@ function buildTurnRunner(streamer: IMessageStreamer): TurnRunner {
   services.register(IStreamProcessor).to(StreamProcessor);
   // StreamProcessor now @dependsOn(IToolRegistry); an empty registry is a no-op normaliser here.
   services.register(IToolRegistry).to(IToolRegistry, () => new ToolRegistry([], new NoopLogger()));
+  services.register(IDurableConfigProvider).to(IDurableConfigProvider, () => new NoopDurableConfigProvider());
   services.register(ILogger).to(NoopLogger);
   services.register(AccountLimitListener).to(NoopAccountLimitListener);
   services.register(ISleepProvider).to(ISleepProvider, () => ({ sleep: async () => {} }));

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -11,7 +11,6 @@ import { Conversation } from './Conversation';
 import { buildReminderBlocks } from './claudeMdReminders';
 import { AccountLimitStoppedError, toSdkErrorDetail } from './http/errors';
 import { userIdentity } from './messageIdentity';
-import { calculateCostSplit, getContextWindow } from './pricing';
 import type { ToolUseResult } from './types';
 
 /**
@@ -153,18 +152,8 @@ export class QueryRunner extends IQueryRunner {
       // One-shot: only the first turn of a query carries the query-supplied ephemeral reminders.
       turnEphemeral = undefined;
 
-      const costUsd = calculateCostSplit(
-        {
-          inputTokens: result.usage.inputTokens,
-          cacheCreation5mTokens: result.usage.cacheCreation5mTokens,
-          cacheCreation1hTokens: result.usage.cacheCreation1hTokens,
-          cacheReadTokens: result.usage.cacheReadTokens,
-          outputTokens: result.usage.outputTokens,
-        },
-        this.durableProvider.config.model,
-      );
-      const contextWindow = getContextWindow(this.durableProvider.config.model);
-      this.publisher.send({ type: 'message_usage', ...result.usage, costUsd, contextWindow } satisfies SdkMessage);
+      // Per-turn usage is emitted by the StreamProcessor as the API's usage frames arrive
+      // (input + cache on message_start, output at message_end), not collapsed and sent here.
       this.publisher.send({ type: 'turn_content', blocks: result.blocks } satisfies SdkMessage);
 
       const toolUses = result.blocks.filter((b): b is Extract<typeof b, { type: 'tool_use' }> => b.type === 'tool_use');

--- a/packages/claude-sdk/src/private/StreamProcessor.ts
+++ b/packages/claude-sdk/src/private/StreamProcessor.ts
@@ -1,12 +1,13 @@
-import type { BetaContentBlock } from '@anthropic-ai/sdk/resources/beta.mjs';
+import type { BetaContentBlock, BetaUsage } from '@anthropic-ai/sdk/resources/beta.mjs';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { dependsOn } from '@shellicar/core-di-lite';
+import { IDurableConfigProvider } from '../public/IDurableConfigProvider';
 import { IStreamProcessor, IToolRegistry } from '../public/interfaces';
 import type { ContentBlock } from '../public/types';
 import { MessageAccumulator } from './http/accumulator';
 import type { IMessageStream } from './MessageStreamer';
-import { reconstructCacheSplit } from './pricing';
-import type { MessageStreamResult } from './types';
+import { calculateCostSplit, getContextWindow, reconstructCacheSplit } from './pricing';
+import type { MessageStreamResult, MessageUsage } from './types';
 
 const SERVER_TOOL_RESULT_NAMES = {
   web_search_tool_result: 'web_search',
@@ -37,6 +38,7 @@ const SERVER_TOOL_RESULT_NAMES = {
 export class StreamProcessor extends IStreamProcessor {
   @dependsOn(ILogger) private readonly logger!: ILogger;
   @dependsOn(IToolRegistry) private readonly registry!: IToolRegistry;
+  @dependsOn(IDurableConfigProvider) private readonly durableProvider!: IDurableConfigProvider;
 
   public async process(stream: IMessageStream): Promise<MessageStreamResult> {
     let currentToolId: string | null = null;
@@ -44,6 +46,9 @@ export class StreamProcessor extends IStreamProcessor {
     // stop_reason === 'tool_use' when tool blocks are present, so tool_batch_end is
     // emitted on that stop_reason rather than guessed.
     let hasToolBatch = false;
+    // The message_start usage share, kept so the message_end frame can be emitted as the
+    // remaining delta rather than the cumulative total (which would double-count downstream).
+    let startUsage: MessageUsage | null = null;
     const accumulator = new MessageAccumulator();
 
     for await (const event of stream) {
@@ -53,6 +58,10 @@ export class StreamProcessor extends IStreamProcessor {
           accumulator.start(event);
           this.logger.debug('message_start');
           this.emit('message_start');
+          // Input + cache tokens (and the initial output) land here; emit them as they arrive
+          // instead of collapsing them into the single end-of-turn frame.
+          startUsage = mapUsage(accumulator.message.usage);
+          this.#emitUsage(startUsage);
           break;
         case 'content_block_start': {
           accumulator.startBlock(event);
@@ -157,22 +166,56 @@ export class StreamProcessor extends IStreamProcessor {
     }
 
     const msg = accumulator.message;
+    const totalUsage = mapUsage(msg.usage);
+    // The end frame carries only what the start frame did not: the output that accrued over the turn.
+    // start + delta == total, so downstream accumulators reach the same per-turn figures.
+    this.#emitUsage(startUsage != null ? subtractUsage(totalUsage, startUsage) : totalUsage);
     this.emit('final_message', msg);
-    const split = reconstructCacheSplit(msg.usage);
     return {
       blocks: mapBlocks(msg.content),
       stopReason: msg.stop_reason,
       contextManagementOccurred: msg.context_management != null,
-      usage: {
-        inputTokens: msg.usage.input_tokens,
-        cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
-        cacheCreation5mTokens: split.fiveMinute,
-        cacheCreation1hTokens: split.oneHour,
-        cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
-        outputTokens: msg.usage.output_tokens,
-      },
+      usage: totalUsage,
     };
   }
+
+  #emitUsage(usage: MessageUsage): void {
+    const model = this.durableProvider.config.model;
+    const costUsd = calculateCostSplit(
+      {
+        inputTokens: usage.inputTokens,
+        cacheCreation5mTokens: usage.cacheCreation5mTokens,
+        cacheCreation1hTokens: usage.cacheCreation1hTokens,
+        cacheReadTokens: usage.cacheReadTokens,
+        outputTokens: usage.outputTokens,
+      },
+      model,
+    );
+    this.emit('message_usage', { ...usage, costUsd, contextWindow: getContextWindow(model) });
+  }
+}
+
+function mapUsage(usage: BetaUsage): MessageUsage {
+  const split = reconstructCacheSplit(usage);
+  return {
+    inputTokens: usage.input_tokens,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+    cacheCreation5mTokens: split.fiveMinute,
+    cacheCreation1hTokens: split.oneHour,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    outputTokens: usage.output_tokens,
+  };
+}
+
+function subtractUsage(total: MessageUsage, start: MessageUsage): MessageUsage {
+  return {
+    inputTokens: total.inputTokens - start.inputTokens,
+    cacheCreationTokens: total.cacheCreationTokens - start.cacheCreationTokens,
+    cacheCreation5mTokens: total.cacheCreation5mTokens - start.cacheCreation5mTokens,
+    cacheCreation1hTokens: total.cacheCreation1hTokens - start.cacheCreation1hTokens,
+    cacheReadTokens: total.cacheReadTokens - start.cacheReadTokens,
+    outputTokens: total.outputTokens - start.outputTokens,
+  };
 }
 
 function mapBlocks(content: ReadonlyArray<BetaContentBlock>): ContentBlock[] {

--- a/packages/claude-sdk/src/private/types.ts
+++ b/packages/claude-sdk/src/private/types.ts
@@ -1,5 +1,5 @@
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta.mjs';
-import type { ContentBlock } from '../public/types';
+import type { ContentBlock, SdkMessageUsage } from '../public/types';
 
 export type ApprovalResponse = {
   approved: boolean;
@@ -48,6 +48,10 @@ export type MessageStreamEvents = {
   exit_block: [type: string];
   tool_batch_start: [];
   tool_batch_end: [];
+  // One priced usage frame. The API reports usage cumulatively across a turn (input + cache on
+  // message_start, output at message_end); this fires once per frame carrying that frame's own share,
+  // delta-tracked so the shares sum to the turn total. Consumers keep accumulating unchanged.
+  message_usage: [usage: Omit<SdkMessageUsage, 'type'>];
   // The assembled raw message at stream end. Consumed by the CLI for the audit log.
   final_message: [msg: BetaMessage];
 };

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -321,12 +321,9 @@ describe('QueryRunner — single turn terminal exit', () => {
     expect(actual).toBe(true);
   });
 
-  it('emits message_usage on the channel', async () => {
-    const w = makeWiring([endTurnResult('hello')]);
-    await w.queryRunner.run(makeInput());
-    const actual = w.channel.messages.some((m) => m.type === 'message_usage');
-    expect(actual).toBe(true);
-  });
+  // Per-turn usage is emitted by the StreamProcessor as the API's usage frames arrive, not by the
+  // QueryRunner (see StreamProcessor.spec — usage frames). The wiring here fakes the TurnRunner, so no
+  // stream runs and no message_usage reaches this channel.
 });
 
 // ---------------------------------------------------------------------------
@@ -628,16 +625,6 @@ describe('QueryRunner — tool_result content array for binary outputs', () => {
 // ---------------------------------------------------------------------------
 
 describe('QueryRunner — turn_content', () => {
-  it('emits turn_content after message_usage', async () => {
-    const w = makeWiring([endTurnResult('hello')]);
-    await w.queryRunner.run(makeInput());
-    const msgs = w.channel.messages;
-    const usageIdx = msgs.findIndex((m) => m.type === 'message_usage');
-    const contentIdx = msgs.findIndex((m) => m.type === 'turn_content');
-    const actual = usageIdx !== -1 && contentIdx !== -1 && usageIdx < contentIdx;
-    expect(actual).toBe(true);
-  });
-
   it('emits turn_content before done', async () => {
     const w = makeWiring([endTurnResult('hello')]);
     await w.queryRunner.run(makeInput());

--- a/packages/claude-sdk/test/StreamProcessor.spec.ts
+++ b/packages/claude-sdk/test/StreamProcessor.spec.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest';
 import { ApiStreamError } from '../src/private/http/errors.js';
 import { StreamProcessor } from '../src/private/StreamProcessor.js';
 import { ToolRegistry } from '../src/private/ToolRegistry.js';
+import { IDurableConfigProvider } from '../src/public/IDurableConfigProvider.js';
 import { IToolRegistry } from '../src/public/interfaces.js';
+import type { DurableConfig, ThinkingEffort } from '../src/public/types.js';
 import { makeRawStream, makeThrowingStream, wrapWithMessageEnvelope } from './helpers.js';
 
 class NoopLogger extends ILogger {
@@ -14,6 +16,29 @@ class NoopLogger extends ILogger {
   public info(): void {}
   public warn(): void {}
   public error(): void {}
+}
+
+// StreamProcessor reads only `config.model` to price the usage frames it emits.
+class FakeConfigProvider extends IDurableConfigProvider {
+  public get config(): DurableConfig {
+    return { model: 'claude-test' } as DurableConfig;
+  }
+  public update(): void {}
+  public updateIdentityBody(): void {}
+  public async resolveSystemPromptsFor(): Promise<void> {}
+  public async resolveSkillCatalogue(): Promise<void> {}
+  public needsSystemPromptResolve(): boolean {
+    return false;
+  }
+  public getEffectiveModel(): string {
+    return 'claude-test';
+  }
+  public getEffectiveThinkingEnabled(): boolean {
+    return false;
+  }
+  public getEffectiveEffort(): ThinkingEffort | undefined {
+    return undefined;
+  }
 }
 
 // StreamProcessor injects ILogger via @dependsOn, so build it through a real
@@ -25,6 +50,7 @@ function buildStreamProcessor(): StreamProcessor {
   // StreamProcessor now @dependsOn(IToolRegistry) to normalise marked input paths. An empty registry
   // makes normaliseInputPaths a no-op (no tool resolves by name), which these stream tests don't exercise.
   services.register(IToolRegistry).to(IToolRegistry, () => new ToolRegistry([], new NoopLogger()));
+  services.register(IDurableConfigProvider).to(IDurableConfigProvider, () => new FakeConfigProvider());
   services.register(StreamProcessor).to(StreamProcessor);
   return services.buildProvider().resolve(StreamProcessor);
 }
@@ -283,5 +309,67 @@ describe('StreamProcessor — compaction', () => {
     const block = result.blocks.find((b) => b.type === 'compaction') as { type: 'compaction'; content: string } | undefined;
     const actual = block?.content;
     expect(actual).toBe('First summary');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Usage frames: the API reports usage cumulatively (input + cache on
+// message_start, output at message_end). The processor emits each frame as it
+// arrives, delta-tracked so the per-frame shares sum to the turn total.
+// ---------------------------------------------------------------------------
+
+type EmittedUsage = { inputTokens: number; cacheCreationTokens: number; cacheReadTokens: number; outputTokens: number; costUsd: number; contextWindow: number };
+
+describe('StreamProcessor — usage frames', () => {
+  async function collectUsage(): Promise<EmittedUsage[]> {
+    const processor = buildStreamProcessor();
+    const emitted: EmittedUsage[] = [];
+    processor.on('message_usage', (usage) => emitted.push(usage as EmittedUsage));
+    await processor.process(makeRawStream(textThenToolStream));
+    return emitted;
+  }
+
+  it('emits one usage frame per API usage frame (message_start and message_end)', async () => {
+    const expected = 2;
+    const actual = (await collectUsage()).length;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries the input tokens on the message_start frame', async () => {
+    const expected = 10;
+    const actual = (await collectUsage())[0].inputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries no output on the message_start frame', async () => {
+    const expected = 0;
+    const actual = (await collectUsage())[0].outputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries only the output delta on the message_end frame', async () => {
+    const expected = 9;
+    const actual = (await collectUsage())[1].outputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not repeat the input tokens on the message_end frame', async () => {
+    const expected = 0;
+    const actual = (await collectUsage())[1].inputTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('sums the per-frame input tokens to the turn total', async () => {
+    const expected = 10;
+    const frames = await collectUsage();
+    const actual = frames.reduce((sum, f) => sum + f.inputTokens, 0);
+    expect(actual).toBe(expected);
+  });
+
+  it('sums the per-frame output tokens to the turn total', async () => {
+    const expected = 9;
+    const frames = await collectUsage();
+    const actual = frames.reduce((sum, f) => sum + f.outputTokens, 0);
+    expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
## Changes

- Token usage shows on every turn, not just tool turns.
- Each turn's usage is split into input and output, priced separately.
- Token totals and context percentage stay correct.