### PR TITLE
Expose TypeScript diagnostics, hover, references, and definitions to any MCP client

### DIFF
--- a/packages/mcp-typescript/CHANGELOG.md
+++ b/packages/mcp-typescript/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- TsDiagnostics, TsHover, TsReferences, and TsDefinition tools MCP server, backed by @shellicar/claude-sdk-tools' tsserver bridge

--- a/packages/mcp-typescript/CHANGELOG.md
+++ b/packages/mcp-typescript/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- TsDiagnostics, TsHover, TsReferences, and TsDefinition tools MCP server, backed by @shellicar/claude-sdk-tools' tsserver bridge
+- Initial release: MCP server exposing TsDiagnostics, TsHover, TsReferences, and TsDefinition, backed by @shellicar/claude-sdk-tools' tsserver bridge

--- a/packages/mcp-typescript/LICENSE
+++ b/packages/mcp-typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Hellicar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-typescript/README.md
+++ b/packages/mcp-typescript/README.md
@@ -1,0 +1,46 @@
+# @shellicar/mcp-typescript
+
+> MCP server exposing TypeScript language intelligence (diagnostics, hover, references, definitions) via a real `tsserver`.
+
+[![npm package](https://img.shields.io/npm/v/@shellicar/mcp-typescript.svg)](https://npmjs.com/package/@shellicar/mcp-typescript)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+
+## Features
+
+- 🩺 **Type errors without a build** - Get syntactic and semantic diagnostics for one or more files in a single call, no `tsc` run required.
+- 🔍 **Symbol info at a position** - Get the type signature, kind, and JSDoc for whatever's at a given line/character.
+- 🔗 **Find every usage** - Get every reference to a symbol across the project from one position, grouped by file.
+- 🎯 **Jump to definition** - Resolve a symbol at a position to where it's actually defined, including overloads and declaration merging.
+- 🔌 **stdio transport** - Drop it into any MCP client that speaks stdio.
+
+## Installation & Quick Start
+
+```sh
+npm i -g @shellicar/mcp-typescript
+```
+
+```sh
+pnpm add -g @shellicar/mcp-typescript
+```
+
+It runs as a stdio MCP server under the `mcp-typescript` command. Point your MCP client at it:
+
+```json
+{
+  "mcpServers": {
+    "typescript": {
+      "command": "mcp-typescript"
+    }
+  }
+}
+```
+
+## Motivation
+
+Without this, an agent answers "where is this defined" or "what's wrong with this file" by grepping and reading source across the repo and its `node_modules`, several exploratory tool calls per question, and still just guessing at what a real type checker would tell it directly. This wraps an actual `tsserver` process behind four tools, so the agent gets a precise answer in one call instead of reconstructing it from text search.
+
+Other MCP wrappers around `tsserver` I tried left the process running indefinitely, accumulating as zombies across sessions. This one scopes a fresh `tsserver` to each tool call and tears it down again once that call finishes, so nothing outlives the request that needed it.
+
+## Credits & Inspiration
+
+- [Model Context Protocol](https://modelcontextprotocol.io)

--- a/packages/mcp-typescript/changes.jsonl
+++ b/packages/mcp-typescript/changes.jsonl
@@ -1,1 +1,1 @@
-{"description":"TsDiagnostics, TsHover, TsReferences, and TsDefinition tools MCP server, backed by @shellicar/claude-sdk-tools' tsserver bridge","category":"added"}
+{"description":"Initial release: MCP server exposing TsDiagnostics, TsHover, TsReferences, and TsDefinition, backed by @shellicar/claude-sdk-tools' tsserver bridge","category":"added"}

--- a/packages/mcp-typescript/changes.jsonl
+++ b/packages/mcp-typescript/changes.jsonl
@@ -1,0 +1,1 @@
+{"description":"TsDiagnostics, TsHover, TsReferences, and TsDefinition tools MCP server, backed by @shellicar/claude-sdk-tools' tsserver bridge","category":"added"}

--- a/packages/mcp-typescript/package.json
+++ b/packages/mcp-typescript/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@shellicar/mcp-typescript",
+  "version": "1.0.0-beta.17",
+  "private": false,
+  "description": "MCP server wrapping the TypeScript tools (TsDiagnostics, TsHover, TsReferences, TsDefinition) from @shellicar/claude-sdk-tools",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "watch": "tsup --watch",
+    "type-check": "tsc -p tsconfig.check.json",
+    "test": "vitest run"
+  },
+  "author": "Stephen Hellicar",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shellicar/claude-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shellicar/claude-cli/issues"
+  },
+  "homepage": "https://github.com/shellicar/claude-cli#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "mcp-typescript": "./dist/esm/cli.js"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "contributors": [
+    "BananaBot9000 <bananabot9000@bananabot.dev>",
+    "Claude (Anthropic) <noreply@anthropic.com>"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "typescript": "^5.9.3"
+  },
+  "devDependencies": {
+    "@shellicar/build-clean": "^1.3.6",
+    "@shellicar/build-version": "^1.3.10",
+    "@shellicar/claude-core": "workspace:^",
+    "@shellicar/claude-sdk-tools": "workspace:^",
+    "@shellicar/core-di-lite": "^1.0.2",
+    "@shellicar/typescript-config": "workspace:^",
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^25.9.5",
+    "esbuild": "^0.28.0",
+    "tsup": "^8.5.1",
+    "tsx": "^4.22.5",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
+  }
+}

--- a/packages/mcp-typescript/src/entry/cli.ts
+++ b/packages/mcp-typescript/src/entry/cli.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createTypeScriptServer } from './index.js';
+
+async function main() {
+  const { server, tsService } = createTypeScriptServer();
+  const transport = new StdioServerTransport();
+
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    // Backstop for the abnormal paths a per-call blockEnded() can't reach:
+    // the process is signalled or the client drops the stdio pipe mid-call,
+    // which would otherwise leave a tsserver child orphaned.
+    await tsService.blockEnded();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  transport.onclose = () => {
+    void shutdown();
+  };
+
+  await server.connect(transport);
+}
+
+main().catch(console.error);

--- a/packages/mcp-typescript/src/entry/cli.ts
+++ b/packages/mcp-typescript/src/entry/cli.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createTypeScriptServer } from './index.js';
 
 async function main() {
-  const { server, tsService } = createTypeScriptServer();
+  const { server, active } = createTypeScriptServer();
   const transport = new StdioServerTransport();
 
   let shuttingDown = false;
@@ -14,8 +14,10 @@ async function main() {
     shuttingDown = true;
     // Backstop for the abnormal paths a per-call blockEnded() can't reach:
     // the process is signalled or the client drops the stdio pipe mid-call,
-    // which would otherwise leave a tsserver child orphaned.
-    await tsService.blockEnded();
+    // which would otherwise leave a tsserver child orphaned. Each in-flight
+    // call owns its own tsService instance, so every one still active gets
+    // its own teardown rather than assuming a single shared instance.
+    await Promise.allSettled([...active].map((ts) => ts.blockEnded()));
     process.exit(0);
   };
 

--- a/packages/mcp-typescript/src/entry/index.ts
+++ b/packages/mcp-typescript/src/entry/index.ts
@@ -1,0 +1,113 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { NodeFileSystem } from '@shellicar/claude-sdk-tools/fs';
+import { createTsDefinition } from '@shellicar/claude-sdk-tools/TsDefinition';
+import { createTsDiagnostics } from '@shellicar/claude-sdk-tools/TsDiagnostics';
+import { createTsHover } from '@shellicar/claude-sdk-tools/TsHover';
+import { createTsReferences } from '@shellicar/claude-sdk-tools/TsReferences';
+import { DEFAULT_TSSERVER_TIMEOUT_MS, ITsServerClient, ITsServerOptions, ITypeScriptService, resolveTsServerPath, TsServerBridge, TsServerClient } from '@shellicar/claude-sdk-tools/TsService';
+import { createServiceCollection } from '@shellicar/core-di-lite';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// biome-ignore-start lint/suspicious/noExplicitAny: mirrors the zod shape registerTool's inputSchema/handler accept across every tool
+type AnyToolDefinition = {
+  name: string;
+  description: string;
+  input_schema: any;
+  handler: (input: any) => Promise<{ textContent: unknown }>;
+};
+// biome-ignore-end lint/suspicious/noExplicitAny: mirrors the zod shape registerTool's inputSchema/handler accept across every tool
+
+/** Writes to stderr only: stdio transport owns stdout for the JSON-RPC framing, so ILogger output must never touch it. */
+class StderrLogger extends ILogger {
+  #write(level: string, message: string, meta: unknown[]): void {
+    process.stderr.write(`[mcp-typescript] [${level}] ${message}${meta.length ? ` ${JSON.stringify(meta)}` : ''}\n`);
+  }
+  public trace(message: string, ...meta: unknown[]): void {
+    this.#write('trace', message, meta);
+  }
+  public debug(message: string, ...meta: unknown[]): void {
+    this.#write('debug', message, meta);
+  }
+  public info(message: string, ...meta: unknown[]): void {
+    this.#write('info', message, meta);
+  }
+  public warn(message: string, ...meta: unknown[]): void {
+    this.#write('warn', message, meta);
+  }
+  public error(message: string, ...meta: unknown[]): void {
+    this.#write('error', message, meta);
+  }
+}
+
+/**
+ * Wires the same DI graph `apps/claude-sdk-cli` builds for its TS tools
+ * (options -> filesystem/logger -> ITsServerClient -> TsServerBridge), minus
+ * the CLI-only pieces (config, sessions, audit) this server has no use for.
+ */
+function buildTypeScriptService(): ITypeScriptService {
+  const services = createServiceCollection();
+  services.register(ITsServerOptions).to(ITsServerOptions, () => ({ tsserverPath: resolveTsServerPath(), timeoutMs: DEFAULT_TSSERVER_TIMEOUT_MS }));
+  services.register(IFileSystem).to(NodeFileSystem);
+  services.register(ILogger).to(StderrLogger);
+  services.register(ITsServerClient).to(TsServerClient);
+  services.register(ITypeScriptService).to(TsServerBridge);
+  return services.buildProvider().resolve(ITypeScriptService);
+}
+
+/**
+ * Registers one TS tool, treating each MCP tool call as its own block: the
+ * bridge starts the tsserver lazily on first use inside the call and this
+ * wrapper always ends the block afterwards, win or lose. MCP has no call
+ * grouping the way the CLI's turn loop does, so a per-call block is the
+ * closest honest match to the CLI's per-block freshness guarantee (a fresh
+ * spawn per block means diagnostics are never stale against a file edited
+ * between calls) without inventing a batching concept the protocol lacks.
+ */
+function registerTool(server: McpServer, tsService: ITypeScriptService, def: AnyToolDefinition): void {
+  server.registerTool(
+    def.name,
+    {
+      description: def.description,
+      inputSchema: def.input_schema,
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: registerTool is generic across four differently-shaped tool inputs
+    async (input: any) => {
+      try {
+        const { textContent: result } = await def.handler(input);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          // MCP requires structuredContent to be a record when present; TsHover
+          // legitimately returns null (no symbol at that position), so it is
+          // omitted rather than sent as a non-record value.
+          ...(result != null && typeof result === 'object' ? { structuredContent: result as Record<string, unknown> } : {}),
+        };
+      } finally {
+        await tsService.blockEnded();
+      }
+    },
+  );
+}
+
+export type TypeScriptServer = {
+  server: McpServer;
+  tsService: ITypeScriptService;
+};
+
+/**
+ * Create a configured McpServer with the TS tools registered, backed by
+ * @shellicar/claude-sdk-tools. tsService is returned alongside the server so
+ * the entry point can stop it on shutdown as a backstop for the per-call
+ * lifecycle each registered tool already drives (see registerTool).
+ */
+export function createTypeScriptServer(): TypeScriptServer {
+  const server = new McpServer({ name: 'mcp-typescript', version: '1.0.0' });
+  const tsService = buildTypeScriptService();
+
+  registerTool(server, tsService, createTsDiagnostics(tsService));
+  registerTool(server, tsService, createTsHover(tsService));
+  registerTool(server, tsService, createTsReferences(tsService));
+  registerTool(server, tsService, createTsDefinition(tsService));
+
+  return { server, tsService };
+}

--- a/packages/mcp-typescript/src/entry/index.ts
+++ b/packages/mcp-typescript/src/entry/index.ts
@@ -6,7 +6,7 @@ import { createTsDefinition } from '@shellicar/claude-sdk-tools/TsDefinition';
 import { createTsDiagnostics } from '@shellicar/claude-sdk-tools/TsDiagnostics';
 import { createTsHover } from '@shellicar/claude-sdk-tools/TsHover';
 import { createTsReferences } from '@shellicar/claude-sdk-tools/TsReferences';
-import { DEFAULT_TSSERVER_TIMEOUT_MS, ITsServerClient, ITsServerOptions, ITypeScriptService, resolveTsServerPath, TsServerBridge, TsServerClient } from '@shellicar/claude-sdk-tools/TsService';
+import { ITsServerClient, ITsServerOptions, ITypeScriptService, resolveTsServerPath, TsServerBridge, TsServerClient } from '@shellicar/claude-sdk-tools/TsService';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 
 // biome-ignore-start lint/suspicious/noExplicitAny: mirrors the zod shape registerTool's inputSchema/handler accept across every tool
@@ -41,13 +41,24 @@ class StderrLogger extends ILogger {
 }
 
 /**
+ * The CLI's `DEFAULT_TSSERVER_TIMEOUT_MS` (3000ms) is tuned for its own
+ * lifecycle, where one `tsserver` is started once per block and reused for
+ * every TS tool call inside it. Here every single call spawns its own fresh
+ * `tsserver` (see `registerTool`), so a cold spawn is on the critical path far
+ * more often; a busier host (CI, or a dev machine already under load) can
+ * push that past 3s. A more forgiving ceiling costs nothing in the common
+ * case and avoids spurious timeouts in the uncommon one.
+ */
+const TSSERVER_TIMEOUT_MS = 10_000;
+
+/**
  * Wires the same DI graph `apps/claude-sdk-cli` builds for its TS tools
  * (options -> filesystem/logger -> ITsServerClient -> TsServerBridge), minus
  * the CLI-only pieces (config, sessions, audit) this server has no use for.
  */
 function buildTypeScriptService(): ITypeScriptService {
   const services = createServiceCollection();
-  services.register(ITsServerOptions).to(ITsServerOptions, () => ({ tsserverPath: resolveTsServerPath(), timeoutMs: DEFAULT_TSSERVER_TIMEOUT_MS }));
+  services.register(ITsServerOptions).to(ITsServerOptions, () => ({ tsserverPath: resolveTsServerPath(), timeoutMs: TSSERVER_TIMEOUT_MS }));
   services.register(IFileSystem).to(NodeFileSystem);
   services.register(ILogger).to(StderrLogger);
   services.register(ITsServerClient).to(TsServerClient);
@@ -81,6 +92,8 @@ function registerTool(server: McpServer, active: Set<ITypeScriptService>, factor
     },
     // biome-ignore lint/suspicious/noExplicitAny: registerTool is generic across four differently-shaped tool inputs
     async (input: any) => {
+      const start = Date.now();
+      process.stderr.write(`[mcp-typescript] [timing] ${meta.name} start ${start} (${active.size} already in flight)\n`);
       const tsService = buildTypeScriptService();
       active.add(tsService);
       try {
@@ -95,6 +108,7 @@ function registerTool(server: McpServer, active: Set<ITypeScriptService>, factor
       } finally {
         active.delete(tsService);
         await tsService.blockEnded();
+        process.stderr.write(`[mcp-typescript] [timing] ${meta.name} end ${Date.now()} (${Date.now() - start}ms)\n`);
       }
     },
   );

--- a/packages/mcp-typescript/src/entry/index.ts
+++ b/packages/mcp-typescript/src/entry/index.ts
@@ -55,26 +55,36 @@ function buildTypeScriptService(): ITypeScriptService {
   return services.buildProvider().resolve(ITypeScriptService);
 }
 
+type ToolFactory = (ts: ITypeScriptService) => AnyToolDefinition;
+
 /**
- * Registers one TS tool, treating each MCP tool call as its own block: the
- * bridge starts the tsserver lazily on first use inside the call and this
- * wrapper always ends the block afterwards, win or lose. MCP has no call
- * grouping the way the CLI's turn loop does, so a per-call block is the
- * closest honest match to the CLI's per-block freshness guarantee (a fresh
- * spawn per block means diagnostics are never stale against a file edited
- * between calls) without inventing a batching concept the protocol lacks.
+ * Registers one TS tool. stdio MCP permits a client to pipeline overlapping
+ * `tools/call` requests, unlike the CLI's single-threaded turn loop, so a
+ * `tsService` shared across calls would let one call's teardown kill the
+ * `tsserver` process out from under another call still using it. Building a
+ * fresh `ITypeScriptService` (and so a fresh `tsserver` child process) inside
+ * every call sidesteps that: there is nothing shared to race over, and each
+ * call's `finally` tears down only its own instance.
+ *
+ * `factory(...)` is called once up front purely to read the static
+ * name/description/input_schema for registration; that throwaway instance is
+ * never started (`ITypeScriptService` only spawns `tsserver` lazily, on the
+ * first actual tool call it handles), so it costs nothing.
  */
-function registerTool(server: McpServer, tsService: ITypeScriptService, def: AnyToolDefinition): void {
+function registerTool(server: McpServer, active: Set<ITypeScriptService>, factory: ToolFactory): void {
+  const meta = factory(buildTypeScriptService());
   server.registerTool(
-    def.name,
+    meta.name,
     {
-      description: def.description,
-      inputSchema: def.input_schema,
+      description: meta.description,
+      inputSchema: meta.input_schema,
     },
     // biome-ignore lint/suspicious/noExplicitAny: registerTool is generic across four differently-shaped tool inputs
     async (input: any) => {
+      const tsService = buildTypeScriptService();
+      active.add(tsService);
       try {
-        const { textContent: result } = await def.handler(input);
+        const { textContent: result } = await factory(tsService).handler(input);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
           // MCP requires structuredContent to be a record when present; TsHover
@@ -83,6 +93,7 @@ function registerTool(server: McpServer, tsService: ITypeScriptService, def: Any
           ...(result != null && typeof result === 'object' ? { structuredContent: result as Record<string, unknown> } : {}),
         };
       } finally {
+        active.delete(tsService);
         await tsService.blockEnded();
       }
     },
@@ -91,23 +102,25 @@ function registerTool(server: McpServer, tsService: ITypeScriptService, def: Any
 
 export type TypeScriptServer = {
   server: McpServer;
-  tsService: ITypeScriptService;
+  /** The `tsService` instances currently in flight, one per overlapping call.
+   * Exposed so the entry point can tear each of them down on shutdown as a
+   * backstop for calls interrupted mid-flight; every call already tears down
+   * its own instance in its `finally` on the ordinary completion path. */
+  active: ReadonlySet<ITypeScriptService>;
 };
 
 /**
  * Create a configured McpServer with the TS tools registered, backed by
- * @shellicar/claude-sdk-tools. tsService is returned alongside the server so
- * the entry point can stop it on shutdown as a backstop for the per-call
- * lifecycle each registered tool already drives (see registerTool).
+ * @shellicar/claude-sdk-tools.
  */
 export function createTypeScriptServer(): TypeScriptServer {
   const server = new McpServer({ name: 'mcp-typescript', version: '1.0.0' });
-  const tsService = buildTypeScriptService();
+  const active = new Set<ITypeScriptService>();
 
-  registerTool(server, tsService, createTsDiagnostics(tsService));
-  registerTool(server, tsService, createTsHover(tsService));
-  registerTool(server, tsService, createTsReferences(tsService));
-  registerTool(server, tsService, createTsDefinition(tsService));
+  registerTool(server, active, createTsDiagnostics);
+  registerTool(server, active, createTsHover);
+  registerTool(server, active, createTsReferences);
+  registerTool(server, active, createTsDefinition);
 
-  return { server, tsService };
+  return { server, active };
 }

--- a/packages/mcp-typescript/src/entry/index.ts
+++ b/packages/mcp-typescript/src/entry/index.ts
@@ -1,3 +1,4 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { NodeFileSystem } from '@shellicar/claude-sdk-tools/fs';
@@ -7,7 +8,6 @@ import { createTsHover } from '@shellicar/claude-sdk-tools/TsHover';
 import { createTsReferences } from '@shellicar/claude-sdk-tools/TsReferences';
 import { DEFAULT_TSSERVER_TIMEOUT_MS, ITsServerClient, ITsServerOptions, ITypeScriptService, resolveTsServerPath, TsServerBridge, TsServerClient } from '@shellicar/claude-sdk-tools/TsService';
 import { createServiceCollection } from '@shellicar/core-di-lite';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 // biome-ignore-start lint/suspicious/noExplicitAny: mirrors the zod shape registerTool's inputSchema/handler accept across every tool
 type AnyToolDefinition = {

--- a/packages/mcp-typescript/test/cli.spec.ts
+++ b/packages/mcp-typescript/test/cli.spec.ts
@@ -1,0 +1,39 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cliEntry = path.join(packageRoot, 'src/entry/cli.ts');
+
+describe('CLI', () => {
+  let client: Client;
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  beforeAll(async () => {
+    const transport = new StdioClientTransport({
+      command: 'tsx',
+      args: [cliEntry],
+      stderr: 'pipe',
+    });
+    client = new Client({ name: 'test', version: '1.0.0' });
+    await client.connect(transport);
+    return client;
+  });
+
+  it('lists the TS tools', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('TsDiagnostics');
+  });
+
+  it('TsDiagnostics tool has a description', async () => {
+    const { tools } = await client.listTools();
+    const diagnostics = tools.find((t) => t.name === 'TsDiagnostics');
+    expect(diagnostics?.description).toBeTruthy();
+  });
+});

--- a/packages/mcp-typescript/test/integration.spec.ts
+++ b/packages/mcp-typescript/test/integration.spec.ts
@@ -51,4 +51,14 @@ describe('integration', () => {
 
     expect(result.isError).toBeFalsy();
   });
+
+  it('two overlapping calls both succeed, neither torn down by the other', async () => {
+    const c = await setup();
+    const args = { name: 'TsHover' as const, arguments: { file: selfFile, line: 1, character: 8 } };
+
+    const [first, second] = await Promise.all([c.callTool(args), c.callTool(args)]);
+
+    expect(first.isError).toBeFalsy();
+    expect(second.isError).toBeFalsy();
+  });
 });

--- a/packages/mcp-typescript/test/integration.spec.ts
+++ b/packages/mcp-typescript/test/integration.spec.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createTypeScriptServer } from '../src/entry/index.js';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const selfFile = path.join(packageRoot, 'src/entry/index.ts');
+
+describe('integration', () => {
+  let client: Client;
+
+  afterEach(async () => {
+    await client?.close();
+  });
+
+  async function setup() {
+    const { server } = createTypeScriptServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test', version: '1.0.0' });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  it('lists all four TS tools', async () => {
+    const c = await setup();
+    const { tools } = await c.listTools();
+    const names = tools.map((t) => t.name);
+
+    expect(names.sort()).toEqual(['TsDefinition', 'TsDiagnostics', 'TsHover', 'TsReferences']);
+  });
+
+  it('TsDiagnostics reports no errors for a clean file', async () => {
+    const c = await setup();
+    const result = await c.callTool({
+      name: 'TsDiagnostics',
+      arguments: { files: [{ file: selfFile }] },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('TsHover reports the hovered symbol', async () => {
+    const c = await setup();
+    const result = await c.callTool({
+      name: 'TsHover',
+      arguments: { file: selfFile, line: 1, character: 8 },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+});

--- a/packages/mcp-typescript/tsconfig.check.json
+++ b/packages/mcp-typescript/tsconfig.check.json
@@ -1,0 +1,1 @@
+../../tsconfig.check.json

--- a/packages/mcp-typescript/tsconfig.json
+++ b/packages/mcp-typescript/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shellicar/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/mcp-typescript/tsup.config.ts
+++ b/packages/mcp-typescript/tsup.config.ts
@@ -1,0 +1,41 @@
+import versionPlugin from '@shellicar/build-version/esbuild';
+import { defineConfig, type Options } from 'tsup';
+
+const esbuildPlugins = [versionPlugin({ versionCalculator: 'gitversion' })];
+
+const commonOptions = (config: Options) =>
+  ({
+    bundle: true,
+    clean: true,
+    dts: true,
+    esbuildPlugins,
+    esbuildOptions: (options) => {
+      options.chunkNames = 'chunks/[name]-[hash]';
+      options.entryNames = '[name]';
+    },
+    keepNames: true,
+    minify: false,
+    removeNodeProtocol: false,
+    platform: 'node',
+    sourcemap: true,
+    splitting: true,
+    target: 'node24',
+    treeshake: true,
+    watch: config.watch,
+    tsconfig: 'tsconfig.json',
+  }) satisfies Options;
+
+export default defineConfig((config) => [
+  {
+    ...commonOptions(config),
+    format: 'esm',
+    outDir: 'dist/esm',
+    entry: ['src/entry/*.ts'],
+  },
+  {
+    ...commonOptions(config),
+    format: 'cjs',
+    outDir: 'dist/cjs',
+    entry: ['src/entry/index.ts'],
+  },
+]);

--- a/packages/mcp-typescript/vitest.config.ts
+++ b/packages/mcp-typescript/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+  },
+});

--- a/packages/mcp-typescript/vitest.config.ts
+++ b/packages/mcp-typescript/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/**/*.spec.ts'],
+    maxWorkers: 1,
   },
 });

--- a/packages/mcp-typescript/vitest.config.ts
+++ b/packages/mcp-typescript/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     include: ['test/**/*.spec.ts'],
     maxWorkers: 1,
+    // vitest's own 5000ms default is shorter than a cold tsserver spawn can
+    // take on a loaded CI runner (this job builds 14 packages before tests
+    // even start); this is the ceiling actually killing the test, separate
+    // from TSSERVER_TIMEOUT_MS in src/entry/index.ts, which only bounds a
+    // single request to an already-running tsserver.
+    testTimeout: 20_000,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,52 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
 
+  packages/mcp-typescript:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+    devDependencies:
+      '@shellicar/build-clean':
+        specifier: ^1.3.6
+        version: 1.3.6(esbuild@0.28.1)(rolldown@1.0.3)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+      '@shellicar/build-version':
+        specifier: ^1.3.10
+        version: 1.3.10(esbuild@0.28.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+      '@shellicar/claude-core':
+        specifier: workspace:^
+        version: link:../claude-core
+      '@shellicar/claude-sdk-tools':
+        specifier: workspace:^
+        version: link:../claude-sdk-tools
+      '@shellicar/core-di-lite':
+        specifier: ^1.0.2
+        version: 1.0.2
+      '@shellicar/typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      '@tsconfig/node24':
+        specifier: ^24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: ^25.9.5
+        version: 25.9.5
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+
   packages/typescript-config:
     devDependencies:
       '@tsconfig/node24':


### PR DESCRIPTION
## Summary

- Any MCP client can now get type errors, symbol info, references, and go-to-definition without a manual `tsc` run
- Installable on its own, independent of the CLI
- Spawns `tsserver` fresh per tool call and tears it down again after, so nothing lingers as an orphaned process between calls