### PR TITLE
Recover from a conversation left on a dangling tool_use

### DIFF
--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -480,12 +480,17 @@ export class AgentMessageHandler {
         return;
       }
       let approved: boolean;
+      let autoDenyReason: string | undefined;
       if (perm === PermissionAction.Approve) {
         this.logger.info('Auto approving', { name: msg.name });
         approved = true;
       } else if (perm === PermissionAction.Deny) {
         this.logger.info('Auto denying', { name: msg.name });
         approved = false;
+        // Distinct from a human rejection: no prompt was shown, so "do not reattempt" is the wrong
+        // signal. Name the cause plainly so the model can adjust (e.g. try a different tool) rather
+        // than reading it as a user who saw and refused the call.
+        autoDenyReason = `Auto-denied by permission policy (not a user decision): ${msg.name} is configured to be denied automatically.`;
       } else {
         // A human actually waits here (auto-approve/auto-deny settle without a prompt, above). Raise the
         // ask on the wire and race the local keypress against a wire answer — first valid answer wins.
@@ -503,7 +508,7 @@ export class AgentMessageHandler {
         this.tools.resolveApproval(msg.requestId, settlement.approved);
         this.notifier.cancel();
       }
-      this.channel.send({ type: 'tool_approval_response', requestId: msg.requestId, approved });
+      this.channel.send({ type: 'tool_approval_response', requestId: msg.requestId, approved, ...(autoDenyReason ? { reason: autoDenyReason } : {}) });
       this.tools.removeTool(msg.requestId);
       if (approved) {
         obj?.approve();

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -49,6 +49,10 @@ export class ConversationSession {
         return { msg, identity: _identity };
       });
     this.conversation.setHistory(rows);
+    // A prior process may have died between committing a tool_use and its tool_result (crash,
+    // signal, hung tool), leaving the record on a dangling tool_use the API refuses to continue.
+    // Self-heal on load with an honest synthetic result before anything else touches it.
+    this.conversation.healDanglingToolUse();
   }
 
   public async resume(id: string): Promise<void> {

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -706,6 +706,33 @@ describe('AgentMessageHandler — tool_approval_request', () => {
     expect(actual).toBe(expected);
   });
 
+  it('auto-denies a delete outside cwd without a reason claiming user rejection', async () => {
+    const sends: ConsumerMessage[] = [];
+    const { handler } = makeHandler({ config: { tools: [makeTool('DeleteFile', 'delete')] }, onSend: (m) => sends.push(m) });
+    // default matrix: outside.delete = 'deny' — settles without a prompt (PermissionAction.Deny).
+    const input = { path: '/outside/file.txt' };
+    streamTool(handler, 'toolu_01', 'DeleteFile', input);
+    handler.handle({ type: 'tool_approval_request', requestId: 'toolu_01', name: 'DeleteFile', input });
+    await flush();
+    const response = sends.find((m) => m.type === 'tool_approval_response');
+    const expected = false;
+    const actual = response?.type === 'tool_approval_response' && response.approved;
+    expect(actual).toBe(expected);
+  });
+
+  it('an auto-denied tool carries a reason distinct from a user rejection', async () => {
+    const sends: ConsumerMessage[] = [];
+    const { handler } = makeHandler({ config: { tools: [makeTool('DeleteFile', 'delete')] }, onSend: (m) => sends.push(m) });
+    const input = { path: '/outside/file.txt' };
+    streamTool(handler, 'toolu_01', 'DeleteFile', input);
+    handler.handle({ type: 'tool_approval_request', requestId: 'toolu_01', name: 'DeleteFile', input });
+    await flush();
+    const response = sends.find((m) => m.type === 'tool_approval_response');
+    const expected = true;
+    const actual = response?.type === 'tool_approval_response' && (response.reason?.includes('Auto-denied by permission policy') ?? false);
+    expect(actual).toBe(expected);
+  });
+
   it('records auto-approved status for a read tool', () => {
     const { handler, conversationState } = makeHandler({ config: { tools: [makeTool('Find', 'read')] } });
     streamTool(handler, 'toolu_01', 'Find');

--- a/apps/claude-sdk-cli/test/ConversationSession.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSession.spec.ts
@@ -251,7 +251,7 @@ describe('ConversationSession — saveConversation', () => {
     expect(actual).toBe(false);
   });
 
-  it('restores a conversation whose tail is an unanswered assistant tool_use', async () => {
+  it('restores a conversation whose tail is an unanswered assistant tool_use, self-healed with a synthetic result', async () => {
     const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
     const historyPath = `${HOME}/.claude/conversations/${id}.jsonl`;
     const userMsg = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
@@ -262,7 +262,42 @@ describe('ConversationSession — saveConversation', () => {
     const session = buildSession(fs, conversation);
     await session.resume(id);
 
-    const expected = 2;
+    // user + assistant tool_use + the self-healed synthetic tool_result
+    const expected = 3;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('the self-healed message answers the dangling tool_use id', async () => {
+    const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const historyPath = `${HOME}/.claude/conversations/${id}.jsonl`;
+    const userMsg = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
+    const assistantToolUse = { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_1', name: 'ReadFile', input: {} }] };
+    const seeded = `${JSON.stringify(userMsg)}\n${JSON.stringify(assistantToolUse)}\n`;
+    const fs = new MemoryFileSystem({ [historyPath]: seeded }, HOME, CWD);
+    const conversation = new Conversation();
+    const session = buildSession(fs, conversation);
+    await session.resume(id);
+
+    const content = conversation.messages.at(-1)?.content as { tool_use_id: string }[];
+    const expected = 'toolu_1';
+    const actual = content[0]?.tool_use_id;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not self-heal a conversation that already ends on a real tool_result', async () => {
+    const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const historyPath = `${HOME}/.claude/conversations/${id}.jsonl`;
+    const userMsg = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
+    const assistantToolUse = { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_1', name: 'ReadFile', input: {} }] };
+    const toolResult = { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'file contents' }] };
+    const seeded = `${JSON.stringify(userMsg)}\n${JSON.stringify(assistantToolUse)}\n${JSON.stringify(toolResult)}\n`;
+    const fs = new MemoryFileSystem({ [historyPath]: seeded }, HOME, CWD);
+    const conversation = new Conversation();
+    const session = buildSession(fs, conversation);
+    await session.resume(id);
+
+    const expected = 3;
     const actual = conversation.messages.length;
     expect(actual).toBe(expected);
   });

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -131,6 +131,36 @@ export class Conversation {
   public removeLast(): Anthropic.Beta.Messages.BetaMessageParam | undefined {
     return this.#items.pop()?.msg;
   }
+
+  /**
+   * Self-heal a tip left on a dangling tool_use: a prior process died after committing the
+   * assistant's tool_use blocks but before their tool_result (crash, kill signal, hung tool).
+   * The API rejects any request whose history ends on an unanswered tool_use, so an honest
+   * synthetic result is appended for each one — never a claim about what the tool did, only
+   * that it never got an answer. Uses `push`, so a real user message pushed right after merges
+   * into the same row rather than sitting as its own leading message.
+   * Returns `true` if a heal was applied.
+   */
+  public healDanglingToolUse(): boolean {
+    const last = this.#items.at(-1);
+    if (last?.msg.role !== 'assistant' || !Array.isArray(last.msg.content)) {
+      return false;
+    }
+    const toolUseIds = last.msg.content.filter((b) => b.type === 'tool_use').map((b) => b.id);
+    if (toolUseIds.length === 0) {
+      return false;
+    }
+    this.push({
+      role: 'user',
+      content: toolUseIds.map((id) => ({
+        type: 'tool_result' as const,
+        tool_use_id: id,
+        is_error: true,
+        content: [{ type: 'text' as const, text: 'Abandoned: the CLI was restarted or crashed before this tool completed. The outcome is unknown.' }],
+      })),
+    });
+    return true;
+  }
 }
 
 /**

--- a/packages/claude-sdk/test/Conversation.spec.ts
+++ b/packages/claude-sdk/test/Conversation.spec.ts
@@ -23,6 +23,13 @@ function texts(conversation: Conversation): (string | undefined)[] {
   return conversation.messages.map((m) => (m.content as { text: string }[])[0]?.text);
 }
 
+function toolUseMsg(...ids: string[]): Anthropic.Beta.Messages.BetaMessageParam {
+  return {
+    role: 'assistant',
+    content: ids.map((id) => ({ type: 'tool_use' as const, id, name: 'Bash', input: {} })),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // push / messages
 // ---------------------------------------------------------------------------
@@ -281,6 +288,97 @@ describe('Conversation.setHistory', () => {
 // ---------------------------------------------------------------------------
 // cloneForRequest
 // ---------------------------------------------------------------------------
+
+describe('Conversation.healDanglingToolUse', () => {
+  it('returns false when the conversation is empty', () => {
+    const c = new Conversation();
+    const expected = false;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('returns false when the tip is a user message', () => {
+    const c = new Conversation();
+    c.push(msg('user', 'hello'));
+    const expected = false;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('returns false when the tip is an assistant message with no tool_use blocks', () => {
+    const c = new Conversation();
+    c.push(msg('assistant', 'just text'));
+    const expected = false;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('returns true when the tip is an assistant message with a dangling tool_use', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    const expected = true;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('appends a user message carrying the synthetic tool_result', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.healDanglingToolUse();
+    const expected = 2;
+    const actual = c.messages.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('the synthetic tool_result targets the dangling tool_use id', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { tool_use_id: string }[];
+    const expected = 'toolu_1';
+    const actual = content[0]?.tool_use_id;
+    expect(actual).toBe(expected);
+  });
+
+  it('the synthetic tool_result is marked as an error', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { is_error: boolean }[];
+    const expected = true;
+    const actual = content[0]?.is_error;
+    expect(actual).toBe(expected);
+  });
+
+  it('heals every dangling tool_use in a multi-tool batch', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1', 'toolu_2'));
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { tool_use_id: string }[];
+    const expected = ['toolu_1', 'toolu_2'];
+    const actual = content.map((b) => b.tool_use_id);
+    expect(actual).toEqual(expected);
+  });
+
+  it('does not add a second row when a real tool_result follows the tool_use', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }] });
+    const expected = false;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('a real user message pushed after the heal merges into the same row', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.healDanglingToolUse();
+    c.push(msg('user', 'still there?'));
+    const expected = 2;
+    const actual = c.messages.length;
+    expect(actual).toBe(expected);
+  });
+});
 
 describe('Conversation.cloneForRequest', () => {
   it('returns an empty array for an empty conversation', () => {


### PR DESCRIPTION
## Summary
- A conversation that died mid tool-round (crash, kill signal, hung tool) now self-heals on load: any tool_use left without a result gets an honest synthetic error result instead of leaving the API request invalid.
- An auto-denied tool call now tells Claude it was denied by permission policy, not by a user who saw and rejected it.
