### PR TITLE
Config startup display shows only the keys it named

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- --config startup display now shows only the keys the payload actually named, not the full merged config
 - Adopt core-di-lite property injection end to end: the container resolves the whole graph eagerly, SQLite databases are created through a registered factory, and CLI startup moves into main() so the entry module's only import-time effect is invoking it
 - Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up
 - claude-cli now records each session's directory to a central store and resumes the most-recent session for the current directory, so a conversation survives a restart or a machine going away

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -130,3 +130,4 @@
 {"description":"Distinguish an auto-denied tool call from a real human rejection: the model now receives a reason naming the policy, not a signal that a user saw and refused the call","category":"changed"}
 {"description":"Speak the conversation concern's v2 tree (leafed subjects, query closure, per-frame usage) instead of v1","category":"changed"}
 {"description":"Publish the agent concern: ready/pulse/attached/detached telemetry and service/drain/chdir requests","category":"added"}
+{"description":"--config startup display now shows only the keys the payload actually named, not the full merged config","category":"changed"}

--- a/apps/claude-sdk-cli/src/cli-config/formatEffectiveConfig.ts
+++ b/apps/claude-sdk-cli/src/cli-config/formatEffectiveConfig.ts
@@ -1,11 +1,36 @@
 import type { ResolvedSdkConfig } from './types';
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
+
 /**
- * Render the effective (merged) config for the startup display, shown when
- * --config was passed so the user can see how it resolved. The model is the
- * effective model (the --model slot over the config value), passed in by the
- * caller so this stays a pure formatter.
+ * Project `override` (the raw --config payload) onto `config` (the resolved
+ * merge), keeping only the keys --config actually named. A key --config sent
+ * that the schema doesn't recognise (e.g. a typo) has no counterpart in
+ * `config` and is dropped — it caused no effect, so it shouldn't appear.
+ * Nested objects recurse so a partial override (e.g. one hook field) only
+ * surfaces that field, not the whole parent object.
  */
-export function formatEffectiveConfig(config: ResolvedSdkConfig): string {
-  return `effective config:\n${JSON.stringify(config)}`;
+export function pickOverriddenConfig(config: Record<string, unknown>, override: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, overrideValue] of Object.entries(override)) {
+    if (!(key in config)) {
+      continue;
+    }
+    const configValue = config[key];
+    result[key] = isPlainObject(overrideValue) && isPlainObject(configValue) ? pickOverriddenConfig(configValue, overrideValue) : configValue;
+  }
+  return result;
+}
+
+/**
+ * Render the config keys --config actually affected, for the startup display
+ * shown when --config was passed. Not the full merged config — only the
+ * projection of `override`'s shape onto the resolved values, so the user sees
+ * exactly what their --config payload caused. The model is the effective
+ * model (the --model slot over the config value), passed in by the caller so
+ * this stays a pure formatter.
+ */
+export function formatEffectiveConfig(config: ResolvedSdkConfig, override: Record<string, unknown>): string {
+  const effective = pickOverriddenConfig(config as unknown as Record<string, unknown>, override);
+  return `effective config:\n${JSON.stringify(effective)}`;
 }

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -521,7 +521,7 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
     });
   }
   if (configOverride !== undefined) {
-    conversationState.addBlocks([{ type: 'meta', content: formatEffectiveConfig({ ...configLoader.config, model: configFactory.getEffectiveModel() }) }]);
+    conversationState.addBlocks([{ type: 'meta', content: formatEffectiveConfig({ ...configLoader.config, model: configFactory.getEffectiveModel() }, configOverride) }]);
   }
   statusState.setModel(configFactory.getEffectiveModel(), overrides.model != null);
   statusState.setShowConversationId(configLoader.config.statusBar.showConversationId);

--- a/apps/claude-sdk-cli/test/formatEffectiveConfig.spec.ts
+++ b/apps/claude-sdk-cli/test/formatEffectiveConfig.spec.ts
@@ -1,17 +1,45 @@
 import { describe, expect, it } from 'vitest';
-import { formatEffectiveConfig } from '../src/cli-config/formatEffectiveConfig.js';
+import { formatEffectiveConfig, pickOverriddenConfig } from '../src/cli-config/formatEffectiveConfig.js';
 import type { ResolvedSdkConfig } from '../src/cli-config/types.js';
 
 describe('formatEffectiveConfig', () => {
-  it('includes the effective model in the output', () => {
+  it('includes the effective model in the output when --config named it', () => {
     const config = { model: 'claude-opus-4-6', maxTokens: 8000 } as unknown as ResolvedSdkConfig;
-    const actual = formatEffectiveConfig(config);
+    const actual = formatEffectiveConfig(config, { model: 'claude-opus-4-6' });
     expect(actual).toContain('claude-opus-4-6');
   });
 
   it('renders the config as compact JSON', () => {
     const config = { model: 'claude-opus-4-6', maxTokens: 8000 } as unknown as ResolvedSdkConfig;
-    const actual = formatEffectiveConfig(config);
+    const actual = formatEffectiveConfig(config, { maxTokens: 8000 });
     expect(actual).toContain('"maxTokens":8000');
+  });
+
+  it('omits a key --config did not name', () => {
+    const config = { model: 'claude-opus-4-6', maxTokens: 8000 } as unknown as ResolvedSdkConfig;
+    const actual = formatEffectiveConfig(config, { maxTokens: 8000 });
+    expect(actual).not.toContain('claude-opus-4-6');
+  });
+});
+
+describe('pickOverriddenConfig', () => {
+  it('keeps a top-level key that --config named', () => {
+    const actual = pickOverriddenConfig({ maxTokens: 8000 }, { maxTokens: 120000 });
+    expect(actual).toEqual({ maxTokens: 8000 });
+  });
+
+  it('drops a key --config named that the schema does not recognise', () => {
+    const actual = pickOverriddenConfig({ maxTokens: 8000 }, { x: 5 });
+    expect(actual).toEqual({});
+  });
+
+  it('drops a key the config has but --config did not name', () => {
+    const actual = pickOverriddenConfig({ maxTokens: 8000, model: 'claude-opus-4-6' }, { maxTokens: 8000 });
+    expect(actual).not.toHaveProperty('model');
+  });
+
+  it('recurses into a nested object so a partial override only surfaces the named field', () => {
+    const actual = pickOverriddenConfig({ hooks: { approvalNotify: { command: 'foo', enabled: true } } }, { hooks: { approvalNotify: { command: 'bar' } } });
+    expect(actual).toEqual({ hooks: { approvalNotify: { command: 'foo' } } });
   });
 });


### PR DESCRIPTION
## Summary

- The `--config` startup display now shows only the keys the payload actually named, instead of the full merged config
- A key the schema doesn't recognise is dropped rather than shown, since it had no effect
- A nested override (e.g. one hook field) surfaces only that field, not the whole parent object