### PR TITLE
Fix GitVersion silently failing to resolve in CI

### DIFF
--- a/.github/actions/install-gitversion/action.yml
+++ b/.github/actions/install-gitversion/action.yml
@@ -17,7 +17,12 @@ runs:
   using: composite
   steps:
     - shell: bash
+      # Installed under $HOME, owned by the runner user, not root via sudo:
+      # a sudo-owned /usr/local/bin binary failed to memory-map when the
+      # runner user later tried to execute it (error 13, EACCES).
       run: |
+        mkdir -p "$HOME/.local/bin"
         curl --fail --silent --show-error --location --retry 3 --retry-delay 5 --retry-all-errors --write-out 'gitversion download: HTTP %{http_code}\n' --output /tmp/gitversion.tar.gz "https://github.com/GitTools/GitVersion/releases/download/${{ inputs.version }}/gitversion-${{ inputs.platform }}-${{ inputs.version }}.tar.gz"
-        sudo tar xzf /tmp/gitversion.tar.gz -C /usr/local/bin gitversion
-        sudo chmod +x /usr/local/bin/gitversion
+        tar xzf /tmp/gitversion.tar.gz -C "$HOME/.local/bin" gitversion
+        chmod +x "$HOME/.local/bin/gitversion"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -33,6 +33,8 @@ jobs:
           # pinned in-config, not read from the running Node.
           node-version: '26'
       - uses: ./.github/actions/install-gitversion
+      - name: Verify GitVersion is runnable
+        run: gitversion -showvariable SemVer
 
       - name: Resolve package metadata
         id: meta

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/install-gitversion
+      - name: Verify GitVersion is runnable
+        run: gitversion -showvariable SemVer
       - run: pnpm i --frozen-lockfile
       - run: pnpm run --if-present build --only
       - run: pnpm run --if-present type-check --only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 # One entrypoint for every trigger. Jobs gate on the event:
-#   - pull_request / push to main → checks + build & package the affected
-#     packages (the CLI leg wraps its SEA binary but STOPS before publish).
+#   - pull_request / push to main / workflow_dispatch → checks + build & package
+#     the affected packages (the CLI leg wraps its SEA binary but STOPS before
+#     publish).
 #   - release / workflow_dispatch → build the tagged package once, then publish
-#     it. Publishing happens ONLY here — never on PR or main.
+#     it. workflow_dispatch's publish-package step always runs --dry-run, so a
+#     manual dispatch exercises the whole pipeline without touching npm.
 on:
   push:
     branches: [ main ]
@@ -21,12 +23,12 @@ on:
 jobs:
   # --- PR and main: correctness + affected build & package ------------------
   checks:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/checks.yml
     secrets: inherit
 
   detect:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     outputs:
       packages: ${{ steps.affected.outputs.packages }}
@@ -73,7 +75,7 @@ jobs:
 
   build:
     needs: detect
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && needs.detect.outputs.build-packages != '' && needs.detect.outputs.build-packages != '[]' }}
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.detect.outputs.build-packages != '' && needs.detect.outputs.build-packages != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +87,7 @@ jobs:
 
   wrap:
     needs: [ detect, build ]
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && needs.detect.outputs.packages != '' && contains(fromJSON(needs.detect.outputs.packages), '@shellicar/claude-sdk-cli') }}
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.detect.outputs.packages != '' && contains(fromJSON(needs.detect.outputs.packages), '@shellicar/claude-sdk-cli') }}
     permissions:
       contents: read
       id-token: write # publish-sea's platform/launcher jobs declare it; the caller must grant it even when publish is false
@@ -202,7 +204,7 @@ jobs:
 
   verify-keychain-native:
     needs: detect
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && needs.detect.outputs.packages != '' && contains(fromJSON(needs.detect.outputs.packages), '@shellicar/keychain-native') }}
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.detect.outputs.packages != '' && contains(fromJSON(needs.detect.outputs.packages), '@shellicar/keychain-native') }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,20 @@ jobs:
             # Diff the PR against its base branch tip.
             git fetch --no-tags origin "$BASE_REF"
             BASE="origin/$BASE_REF"
-          else
+          elif [ "$EVENT" = "push" ]; then
             # On a main push, origin/main IS the pushed commit, so an origin/main
             # base returns nothing. Use the push's previous commit instead.
             BASE="$BEFORE"
             if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
               BASE="HEAD^"
             fi
+          else
+            # workflow_dispatch (or anything else): there is no "before" commit,
+            # and the dispatched ref may carry several commits since it diverged
+            # from main. Diff against main's tip, not HEAD^, so the whole
+            # branch's delta is captured rather than only its last commit.
+            git fetch --no-tags origin main
+            BASE="origin/main"
           fi
           # Exclude platforms/* — they have no build task and are published only
           # through the release SEA path, so they must never enter this matrix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,18 @@ jobs:
           else
             # workflow_dispatch (or anything else): there is no "before" commit,
             # and the dispatched ref may carry several commits since it diverged
-            # from main. Diff against main's tip, not HEAD^, so the whole
-            # branch's delta is captured rather than only its last commit.
+            # from main. Diff from where this ref branched off main (the merge-base),
+            # not origin/main directly, so commits main gained afterward don't leak
+            # into the diff. If the ref IS main (merge-base == HEAD, e.g. dispatched
+            # directly on main), there's nothing to diverge from, so fall back to
+            # HEAD^ same as the push case.
             git fetch --no-tags origin main
-            BASE="origin/main"
+            MERGE_BASE=$(git merge-base origin/main HEAD)
+            if [ "$MERGE_BASE" = "$(git rev-parse HEAD)" ]; then
+              BASE="HEAD^"
+            else
+              BASE="$MERGE_BASE"
+            fi
           fi
           # Exclude platforms/* — they have no build task and are published only
           # through the release SEA path, so they must never enter this matrix.

--- a/apps/claude-sdk-cli/build.ts
+++ b/apps/claude-sdk-cli/build.ts
@@ -7,7 +7,7 @@ import { generateJsonSchema } from './src/cli-config/generateJsonSchema.js';
 const watch = process.argv.some((x) => x === '--watch');
 const minify = !watch;
 
-const plugins = [versionPlugin({ versionCalculator: 'gitversion' })];
+const plugins = [versionPlugin({ versionCalculator: 'gitversion', debug: true })];
 const inject = await Array.fromAsync(glob('./inject/*.ts'));
 
 const ctx = await esbuild.context({

--- a/apps/claude-sdk-cli/build.ts
+++ b/apps/claude-sdk-cli/build.ts
@@ -7,7 +7,7 @@ import { generateJsonSchema } from './src/cli-config/generateJsonSchema.js';
 const watch = process.argv.some((x) => x === '--watch');
 const minify = !watch;
 
-const plugins = [versionPlugin({ versionCalculator: 'gitversion', debug: true })];
+const plugins = [versionPlugin({ versionCalculator: 'gitversion' })];
 const inject = await Array.fromAsync(glob('./inject/*.ts'));
 
 const ctx = await esbuild.context({


### PR DESCRIPTION
## Summary

- Fix GitVersion silently resolving to an empty version in CI: it was extracted into `sudo`-owned `/usr/local/bin`, which the runner user then couldn't execute
- Add a runnability check right after install, so a broken install fails loud instead of silently
- Manual dispatch now runs the whole pipeline (checks/build/wrap), not just the publish jobs, and diffs affected packages from the merge-base with `main`