### PR TITLE
GitHub_PullRequest_AutoMerge requires a merge strategy

### DIFF
--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary files are blocked from text reads when the format is recognised; unrecognised formats are still treated as text
 - ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph
 - Find tool follows symlinks with cycle detection
+- GitHub_PullRequest_AutoMerge takes a required strategy (merge, squash, rebase) when enabling, so it can queue a specific merge method instead of only accepting the repo default
 - Normalise tilde and environment variable paths in EditFile
 - Package now publishes CJS alongside ESM with working sourcemaps
 - ReadFile rejects images whose base64 payload exceeds the Anthropic API 5 MB per-image cap

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -62,3 +62,4 @@
 {"description":"runGhEscalated also strips SSH_AUTH_SOCK, matching the reader path's strip list","category":"changed"}
 {"description":"Add a permissions regression test asserting an escalate operation always resolves to Ask, even when every other operation is configured to auto-approve","category":"added"}
 {"description":"ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph","category":"fixed"}
+{"description":"GitHub_PullRequest_AutoMerge takes a required strategy (merge, squash, rebase) when enabling, so it can queue a specific merge method instead of only accepting the repo default","category":"fixed"}

--- a/packages/claude-sdk-tools/src/GitHub/schema.ts
+++ b/packages/claude-sdk-tools/src/GitHub/schema.ts
@@ -51,9 +51,17 @@ export const GhPrCommentInputSchema = z
 export const GhPrAutoMergeInputSchema = z
   .object({
     number: z.number().int().positive().describe('The pull request number'),
-    enable: z.boolean().describe('true enables auto-merge (--auto), false disables it (--disable-auto). This tool never performs an immediate merge — no merge-strategy flag is ever emitted.'),
+    enable: z.boolean().describe('true enables auto-merge (--auto), false disables it (--disable-auto). This tool never performs an immediate merge.'),
+    strategy: z
+      .enum(['merge', 'squash', 'rebase'])
+      .optional()
+      .describe('Merge strategy flag (--merge, --squash, --rebase) to pass alongside --auto. Required when enable is true; ignored when disabling.'),
   })
-  .strict();
+  .strict()
+  .refine((input) => !input.enable || input.strategy != null, {
+    message: 'strategy is required when enable is true',
+    path: ['strategy'],
+  });
 
 export const GhPrReviewInputSchema = z
   .object({

--- a/packages/claude-sdk-tools/src/GitHub/schema.ts
+++ b/packages/claude-sdk-tools/src/GitHub/schema.ts
@@ -52,10 +52,7 @@ export const GhPrAutoMergeInputSchema = z
   .object({
     number: z.number().int().positive().describe('The pull request number'),
     enable: z.boolean().describe('true enables auto-merge (--auto), false disables it (--disable-auto). This tool never performs an immediate merge.'),
-    strategy: z
-      .enum(['merge', 'squash', 'rebase'])
-      .optional()
-      .describe('Merge strategy flag (--merge, --squash, --rebase) to pass alongside --auto. Required when enable is true; ignored when disabling.'),
+    strategy: z.enum(['merge', 'squash', 'rebase']).optional().describe('Merge strategy flag (--merge, --squash, --rebase) to pass alongside --auto. Required when enable is true; ignored when disabling.'),
   })
   .strict()
   .refine((input) => !input.enable || input.strategy != null, {

--- a/packages/claude-sdk-tools/src/GitHub/tools.ts
+++ b/packages/claude-sdk-tools/src/GitHub/tools.ts
@@ -107,11 +107,16 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
   const AutoMerge = createGhPrTool(
     {
       name: 'GitHub_PullRequest_AutoMerge',
-      description: 'Enable or disable auto-merge on a pull request. Never performs an immediate merge — only --auto or --disable-auto is ever emitted, no merge-strategy flag.',
+      description: 'Enable or disable auto-merge on a pull request. Never performs an immediate merge — only queues one via --auto plus a merge-strategy flag, or clears it via --disable-auto.',
       input_schema: GhPrAutoMergeInputSchema,
-      input_examples: [{ number: 42, enable: true }],
+      input_examples: [{ number: 42, enable: true, strategy: 'squash' }],
       subcommand: 'merge',
-      buildArgs: (input) => [String(input.number), input.enable ? '--auto' : '--disable-auto'],
+      buildArgs: (input) => {
+        if (!input.enable) {
+          return [String(input.number), '--disable-auto'];
+        }
+        return [String(input.number), '--auto', `--${input.strategy}`];
+      },
     },
     deps,
   );


### PR DESCRIPTION
## Summary
- Enabling auto-merge now requires picking a merge strategy (merge, squash, or rebase), passed as its own flag alongside `--auto`
- Disabling auto-merge is unchanged (`--disable-auto` only)