### PR TITLE
Allow command mode to be entered, exited, and submitted from any turn phase

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adopt core-di-lite property injection end to end: the container resolves the whole graph eagerly, SQLite databases are created through a registered factory, and CLI startup moves into main() so the entry module's only import-time effect is invoking it
 - Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up
 - claude-cli now records each session's directory to a central store and resumes the most-recent session for the current directory, so a conversation survives a restart or a machine going away
+- Command mode can now be entered, navigated, and exited while a query is streaming, not only in the editor phase
 - Config system tracks which file each value came from
 - Distinguish an auto-denied tool call from a real human rejection: the model now receives a reason naming the policy, not a signal that a user saw and refused the call
 - Hook input delivered via stdin instead of command arguments
@@ -117,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `typescript` as a production dependency so consumers do not need it installed separately
 - Apply biome formatting fixes
+- Attachments added while a query is streaming are no longer cleared once that query finishes
 - Count tool approval wait time as tool time in the status-line clock
 - Default `compact.enabled` to `false`
 - Delete the whole grapheme cluster on backspace and forward delete, so an emoji like ❤️ is removed in one keypress instead of leaving a stray character behind
@@ -148,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Status line token stats reflect the current conversation, derived per conversation id, instead of accumulating over the process lifetime
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice
+- Submitting with ctrl+enter now works while command mode is open, instead of requiring it to be closed first
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion
 - Write session marker and history at turn start so they survive mid-response crashes
 

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -132,3 +132,6 @@
 {"description":"Publish the agent concern: ready/pulse/attached/detached telemetry and service/drain/chdir requests","category":"added"}
 {"description":"--config startup display now shows only the keys the payload actually named, not the full merged config","category":"changed"}
 {"description":"Show the --resume flag for the current conversation on clean exit","category":"added"}
+{"description":"Command mode can now be entered, navigated, and exited while a query is streaming, not only in the editor phase","category":"changed"}
+{"description":"Submitting with ctrl+enter now works while command mode is open, instead of requiring it to be closed first","category":"fixed"}
+{"description":"Attachments added while a query is streaming are no longer cleared once that query finishes","category":"fixed"}

--- a/apps/claude-sdk-cli/src/app/PrimaryPresentation.ts
+++ b/apps/claude-sdk-cli/src/app/PrimaryPresentation.ts
@@ -6,9 +6,11 @@ import type { Presentation } from './Presentation.js';
 /**
  * The primary presentation. Its render surface is PrimaryView; its chain is
  * chosen from its own turn phase: the editor chain when awaiting input, the
- * streaming chain mid-turn. The editor chain includes the command and editor
- * handlers and no cancel handler; the streaming chain includes the cancel
- * handler and omits command and editor (decision 5 gating by composition).
+ * streaming chain mid-turn. Both chains include CommandKeyHandler, so command
+ * mode can be entered, navigated, and exited in either phase. The editor chain
+ * adds EditorHandler (submit); the streaming chain adds CancelHandler instead,
+ * placed after CommandKeyHandler so escape pops a command-mode level before it
+ * cancels the running turn (decision 5 gating by composition).
  */
 export class PrimaryPresentation implements Presentation {
   readonly #view: View;

--- a/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandKeyHandler.ts
@@ -60,6 +60,11 @@ export class CommandKeyHandler implements InputHandler {
     if (!this.commandModeState.commandMode) {
       return false;
     }
+    if (key.type === 'ctrl+enter') {
+      // Submit is the editor's concern even while command mode is open — let it
+      // fall through to EditorHandler rather than being swallowed here.
+      return false;
+    }
     if (this.commandModeState.context === 'cdEdit') {
       return this.#handleCdEditorKey(key);
     }

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -41,7 +41,6 @@ import { GitStateMonitor } from './GitStateMonitor.js';
 import { printUsage, printVersion, printVersionInfo, startupBannerText } from './help.js';
 import { logger } from './logger.js';
 import { buildSubmitText } from './model/buildSubmitText.js';
-import { CommandModeState } from './model/CommandModeState.js';
 import { ConversationSession } from './model/ConversationSession.js';
 import { ConversationState } from './model/ConversationState.js';
 import { EditorState } from './model/EditorState.js';
@@ -329,7 +328,6 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
   const statusState = provider.resolve(StatusState);
   const conversationState = provider.resolve(ConversationState);
   const toolApprovalState = provider.resolve(ToolApprovalState);
-  const commandModeState = provider.resolve(CommandModeState);
   const editorState = provider.resolve(EditorState);
   const primaryViewState = provider.resolve(PrimaryViewState);
   const terminalState = provider.resolve(TerminalState);
@@ -602,7 +600,6 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
       {
         conversationState,
         toolApprovalState,
-        commandModeState,
         editorState,
         primaryViewState,
       },

--- a/apps/claude-sdk-cli/src/model/CommandModeState.ts
+++ b/apps/claude-sdk-cli/src/model/CommandModeState.ts
@@ -178,7 +178,7 @@ export class CommandModeState {
     return consumed;
   }
 
-  /** Enter or exit command mode. Only meaningful in editor mode. */
+  /** Enter or exit command mode. Available in any turn phase. */
   public toggleCommandMode(): void {
     this.#commandMode = !this.#commandMode;
     if (!this.#commandMode) {
@@ -200,13 +200,6 @@ export class CommandModeState {
     this.#cdEditor = null;
     this.#cdError = null;
     this.#modelEditor = null;
-  }
-
-  /** Reset all command mode state — used when streaming completes. */
-  public reset(): void {
-    this.exitCommandMode();
-    this.#attachments.clear();
-    this.#emitter.emit('change');
   }
 
   /** Toggle attachment preview for the selected item. No-op if nothing is selected. */

--- a/apps/claude-sdk-cli/src/runAgent.ts
+++ b/apps/claude-sdk-cli/src/runAgent.ts
@@ -2,7 +2,7 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaImageBlockParam, BetaTextBlockParam } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { QueryRunner, Sender, SystemReminder, TransformToolResult } from '@shellicar/claude-sdk';
 import { logger } from './logger.js';
-import type { CommandModeState, ImageAttachment } from './model/CommandModeState.js';
+import type { ImageAttachment } from './model/CommandModeState.js';
 import type { ConversationState } from './model/ConversationState.js';
 import type { EditorState } from './model/EditorState.js';
 import type { PrimaryViewState } from './model/PrimaryViewState.js';
@@ -73,13 +73,12 @@ export function buildRunAgentInput(userInput: UserInput): RunAgentInput {
 export type RunAgentStores = {
   conversationState: ConversationState;
   toolApprovalState: ToolApprovalState;
-  commandModeState: CommandModeState;
   editorState: EditorState;
   primaryViewState: PrimaryViewState;
 };
 
 export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, stores: RunAgentStores, flushToScroll: () => void, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string, skillDelta?: string | null, cwdDelta?: string | null): Promise<void> {
-  const { conversationState, toolApprovalState, commandModeState, editorState, primaryViewState } = stores;
+  const { conversationState, toolApprovalState, editorState, primaryViewState } = stores;
 
   // On resume there is no new user message: don't open a prompt block.
   if (input.message !== null) {
@@ -121,7 +120,6 @@ export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, s
     conversationState.completeActive();
     toolApprovalState.clearTools();
     toolApprovalState.resetExpanded();
-    commandModeState.reset();
     editorState.reset();
     primaryViewState.setPhase('editor');
     flushToScroll();

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -378,7 +378,7 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(TerminalRenderer).to(TerminalRenderer, (x) => new TerminalRenderer(x.resolve(Screen), x.resolve(TerminalState)));
   services.register(PrimaryPresentation).to(PrimaryPresentation, (x) => {
     const editorChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ScrollHandler), x.resolve(ApprovalHandler), x.resolve(CommandKeyHandler), x.resolve(EditorHandler)];
-    const streamingChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ScrollHandler), x.resolve(ApprovalHandler), x.resolve(CancelHandler)];
+    const streamingChain: readonly InputHandler[] = [x.resolve(QuitHandler), x.resolve(ViewSelectHandler), x.resolve(ScrollHandler), x.resolve(ApprovalHandler), x.resolve(CommandKeyHandler), x.resolve(CancelHandler)];
     return new PrimaryPresentation(x.resolve(PrimaryView), x.resolve(PrimaryViewState), editorChain, streamingChain);
   });
   services.register(HistoryPresentation).to(HistoryPresentation, (x) => {

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -106,6 +106,36 @@ describe('CommandKeyHandler — ctrl+/', () => {
   });
 });
 
+describe('CommandKeyHandler — ctrl+enter', () => {
+  it('passes ctrl+enter through when command mode is open at root', () => {
+    const { handler } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    const expected = false;
+    const actual = handler.handleKey({ type: 'ctrl+enter' });
+    expect(actual).toBe(expected);
+  });
+
+  it('passes ctrl+enter through when the cd path editor is open', async () => {
+    const { handler } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'char', value: 'c' });
+    handler.handleKey({ type: 'char', value: 'd' });
+    await flush();
+    const expected = false;
+    const actual = handler.handleKey({ type: 'ctrl+enter' });
+    expect(actual).toBe(expected);
+  });
+
+  it('does not close command mode', () => {
+    const { handler, commandModeState } = makeHandler();
+    handler.handleKey({ type: 'ctrl+/' });
+    handler.handleKey({ type: 'ctrl+enter' });
+    const expected = true;
+    const actual = commandModeState.commandMode;
+    expect(actual).toBe(expected);
+  });
+});
+
 describe('CommandKeyHandler — command mode closed', () => {
   it('passes through a non-ctrl+/ key', () => {
     const { handler } = makeHandler();

--- a/apps/claude-sdk-cli/test/CommandModeState.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandModeState.spec.ts
@@ -250,7 +250,6 @@ describe('CommandModeState — context', () => {
     const actual = state.context;
     expect(actual).toBe(expected);
   });
-
 });
 
 describe('CommandModeState — cd sub-mode', () => {

--- a/apps/claude-sdk-cli/test/CommandModeState.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandModeState.spec.ts
@@ -79,36 +79,6 @@ describe('CommandModeState — exitCommandMode', () => {
   });
 });
 
-describe('CommandModeState — reset', () => {
-  it('sets commandMode to false', () => {
-    const state = new CommandModeState();
-    state.toggleCommandMode();
-    state.reset();
-    const expected = false;
-    const actual = state.commandMode;
-    expect(actual).toBe(expected);
-  });
-
-  it('sets previewMode to false', () => {
-    const state = new CommandModeState();
-    state.addText('hello');
-    state.togglePreview();
-    state.reset();
-    const expected = false;
-    const actual = state.previewMode;
-    expect(actual).toBe(expected);
-  });
-
-  it('clears attachments', () => {
-    const state = new CommandModeState();
-    state.addText('hello');
-    state.reset();
-    const expected = 0;
-    const actual = state.attachments.length;
-    expect(actual).toBe(expected);
-  });
-});
-
 describe('CommandModeState — togglePreview', () => {
   it('is a no-op when nothing is selected', () => {
     const state = new CommandModeState();
@@ -281,15 +251,6 @@ describe('CommandModeState — context', () => {
     expect(actual).toBe(expected);
   });
 
-  it('reset resets context to root', () => {
-    const state = new CommandModeState();
-    state.toggleCommandMode();
-    state.enterModelSubMode();
-    state.reset();
-    const expected = 'root';
-    const actual = state.context;
-    expect(actual).toBe(expected);
-  });
 });
 
 describe('CommandModeState — cd sub-mode', () => {

--- a/apps/claude-sdk-cli/test/PrimaryPresentation.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryPresentation.spec.ts
@@ -27,6 +27,19 @@ describe('PrimaryPresentation — activeChain', () => {
   });
 });
 
+describe('PrimaryPresentation — command mode during streaming', () => {
+  it('reaches a handler in the streaming chain, not the editor chain', () => {
+    const phase = new PrimaryViewState();
+    phase.setPhase('streaming');
+    const editorOnly: readonly InputHandler[] = [{ handleKey: () => true }];
+    const streamingWithCommand: readonly InputHandler[] = [{ handleKey: () => true }];
+    const presentation = new PrimaryPresentation(stubView, phase, editorOnly, streamingWithCommand);
+    const expected = streamingWithCommand;
+    const actual = presentation.activeChain();
+    expect(actual).toBe(expected);
+  });
+});
+
 describe('PrimaryPresentation — view', () => {
   it('exposes the injected view', () => {
     const phase = new PrimaryViewState();

--- a/apps/claude-sdk-cli/test/StoreEmissions.spec.ts
+++ b/apps/claude-sdk-cli/test/StoreEmissions.spec.ts
@@ -274,16 +274,6 @@ describe('CommandModeState emissions', () => {
     expect(actual).toBe(expected);
   });
 
-  it('emits on reset', () => {
-    const state = new CommandModeState();
-    let count = 0;
-    state.on('change', () => count++);
-    state.reset();
-    const expected = true;
-    const actual = count >= 1;
-    expect(actual).toBe(expected);
-  });
-
   it('emits on takeAttachments', () => {
     const state = new CommandModeState();
     const expected = 1;


### PR DESCRIPTION
## Summary
- Command mode can now be opened, navigated, and closed while a query is streaming, not just while awaiting input
- Submitting with ctrl+enter now works while command mode is open, instead of requiring it closed first
- Attachments added mid-query, and command mode's open/closed state, no longer get reset once that query finishes
