### PR TITLE
Add duration to ExecV3 results

### DIFF
--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exec subprocess is cancelled on ESC; elapsed time appears in the cancellation tool result
 - Exec tool with structured args, multi-step pipelines, and permission model
 - ExecV3 accepts a configurable blocklist of command patterns (program plus an ordered subsequence of args) that it refuses to start
+- ExecV3 command results now include durationMs, the wall-clock time from spawn to settle for that stage; the response also carries a top-level durationMs for the whole run
 - Export IFileSystem, NodeFileSystem, MemoryFileSystem, nodeFs singleton via ./fs entry
 - File read tools: Find, ReadFile, Grep, Head, Tail, Range, SearchFiles
 - File write tools: CreateFile, DeleteFile, DeleteDirectory

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -63,3 +63,4 @@
 {"description":"Add a permissions regression test asserting an escalate operation always resolves to Ask, even when every other operation is configured to auto-approve","category":"added"}
 {"description":"ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph","category":"fixed"}
 {"description":"GitHub_PullRequest_AutoMerge takes a required strategy (merge, squash, rebase) when enabling, so it can queue a specific merge method instead of only accepting the repo default","category":"fixed"}
+{"description":"ExecV3 command results now include durationMs, the wall-clock time from spawn to settle for that stage; the response also carries a top-level durationMs for the whole run","category":"added"}

--- a/packages/claude-sdk-tools/src/ExecV3/ExecV3.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/ExecV3.ts
@@ -31,7 +31,7 @@ function blockedCommandRules(blocked: BlockedCommand[]): ExecRule[] {
   }));
 }
 
-export function createExecV3(fs: IFileSystem, executor: IExecutor, envProvider: IEnvProvider, blockedCommands: BlockedCommand[] = []) {
+export function createExecV3(fs: IFileSystem, executor: IExecutor, envProvider: IEnvProvider, blockedCommands: BlockedCommand[] = [], now: () => number = () => performance.now()) {
   const rules = [...builtinRules, ...blockedCommandRules(blockedCommands)];
   return defineTool({
     name: 'ExecV3',
@@ -101,7 +101,7 @@ export function createExecV3(fs: IFileSystem, executor: IExecutor, envProvider: 
         throw new ToolRefusedError(errors.join('\n'));
       }
 
-      const result = await evaluate(commands, { cwd, signal: execSignal(signal, input.timeout), executor, envProvider });
+      const result = await evaluate(commands, { cwd, signal: execSignal(signal, input.timeout), executor, envProvider, now });
       if (signal?.aborted) {
         throw new ToolCancelledError();
       }
@@ -111,6 +111,7 @@ export function createExecV3(fs: IFileSystem, executor: IExecutor, envProvider: 
         textContent: {
           results: result.results.map((r) => (r == null ? null : { ...r, stdout: clean(r.stdout).trimEnd(), stderr: clean(r.stderr).trimEnd() })),
           success: result.success,
+          durationMs: result.durationMs,
         },
       };
     },

--- a/packages/claude-sdk-tools/src/ExecV3/engine.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/engine.ts
@@ -9,6 +9,7 @@ export interface EngineContext {
   signal: AbortSignal | undefined;
   executor: IExecutor;
   envProvider: IEnvProvider;
+  now: () => number;
 }
 
 /**
@@ -19,6 +20,7 @@ export interface EngineContext {
  * step after a short-circuited chain still runs, exactly as bash does.
  */
 export async function evaluate(commands: Command[], ctx: EngineContext): Promise<ExecV3Output> {
+  const startedAt = ctx.now();
   const { pipelines, connectors } = group(commands);
   const results: (CommandResult | null)[] = new Array(commands.length).fill(null);
   let lastExit: number | null = 0;
@@ -49,5 +51,5 @@ export async function evaluate(commands: Command[], ctx: EngineContext): Promise
     lastExit = stageResults[stageResults.length - 1].exitCode;
   }
 
-  return { results, success: lastExit === 0 };
+  return { results, success: lastExit === 0, durationMs: Math.round(ctx.now() - startedAt) };
 }

--- a/packages/claude-sdk-tools/src/ExecV3/runPipeline.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/runPipeline.ts
@@ -113,6 +113,7 @@ export async function runPipeline(commands: Command[], ctx: EngineContext): Prom
     // aborting kills the stage; Executor.run honours a single signal, so merge them.
     const signal = ctx.signal ? AbortSignal.any([ctx.signal, controllers[i].signal]) : controllers[i].signal;
 
+    const startedAt = ctx.now();
     return Promise.all([ctx.executor.run({ program: cmd.program, args: cmd.args, cwd: stageCwd, env: ctx.envProvider.buildEnv(cmd.env) }, { stdin, stdout, stderr, signal }), stdoutCapture ? fromStream(stdoutCapture) : Promise.resolve(''), stderrCapture ? fromStream(stderrCapture) : Promise.resolve('')]).then(
       ([status, out, err]): CommandResult => {
         settled[i] = true;
@@ -125,6 +126,7 @@ export async function runPipeline(commands: Command[], ctx: EngineContext): Prom
           stderr: err,
           exitCode: status.exitCode,
           signal: status.signal,
+          durationMs: Math.round(ctx.now() - startedAt),
         };
       },
     );

--- a/packages/claude-sdk-tools/src/ExecV3/schema.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/schema.ts
@@ -140,6 +140,7 @@ export const CommandResultSchema = z.object({
   stderr: z.string(), // captured per command, even inside a pipe
   exitCode: z.number().int().nullable(), // null when signal-killed
   signal: z.string().nullable(),
+  durationMs: z.number(), // wall-clock from spawn to settle for this stage
 });
 
 export const ExecV3OutputSchema = z.object({
@@ -148,6 +149,7 @@ export const ExecV3OutputSchema = z.object({
   // keeps `exitCode: null` meaning only "signal-killed". Read with results[i]?.exitCode.
   results: CommandResultSchema.nullable().array(),
   success: z.boolean(), // $? == 0 under bash list exit status (see engine)
+  durationMs: z.number(), // wall-clock for the whole run; NOT the sum of per-command durationMs, which overlap inside a pipe
 });
 
 export const ExecV3ToolDescription = `Run commands with structured input — no shell, no quoting, no string-splitting.
@@ -164,8 +166,10 @@ right). \`a && b || c\` means \`(a && b) || c\`. Omit \`op\` on the last command
 \`results\` has one slot per command, position-aligned to \`commands\` (results[i] is
 commands[i]); a command that was short-circuited (skipped) is \`null\`, so read it
 defensively (results[i]?.exitCode). \`success\` is the exit status of the last command
-that actually ran, bash-style. Per-command exit/stderr is always in \`results\`, so a
-pipe's per-stage truth is never lost.
+that actually ran, bash-style. Per-command exit/stderr/durationMs is always in \`results\`,
+so a pipe's per-stage truth is never lost. The top-level \`durationMs\` is the whole run's
+wall-clock — it is NOT the sum of the per-command values, since stages inside a pipe run
+concurrently and overlap.
 
 Anything needing grouping, variables, \`$(...)\`, loops or globbing is a script — write
 it to a file and run the file. Redirect is overwrite-only ({ stdout, stderr }; stderr

--- a/packages/claude-sdk-tools/test/ExecV3/duration.spec.ts
+++ b/packages/claude-sdk-tools/test/ExecV3/duration.spec.ts
@@ -1,0 +1,53 @@
+import type { CommandSpec, ExitStatus, IExecutor, SpawnOpts } from '@shellicar/exec-core';
+import { describe, expect, it } from 'vitest';
+import { createExecV3 } from '../../src/ExecV3/ExecV3';
+import { passthroughEnvProvider } from '../../src/entry/ExecV3';
+import { executor } from '../../src/exec-shared';
+import { nodeFs } from '../../src/fs/nodeFs';
+
+const echoExecutor: IExecutor = {
+  run: async (cmd: CommandSpec, opts?: SpawnOpts): Promise<ExitStatus> => {
+    opts?.stdout?.end(cmd.program);
+    opts?.stderr?.end();
+    return { exitCode: 0, signal: null };
+  },
+};
+
+// The clock is injected (EngineContext.now / createExecV3's `now` param), so durationMs is
+// deterministic under test instead of depending on real elapsed time. A single command makes
+// exactly 4 calls in a fixed order: evaluate start, stage start, stage end, evaluate end.
+describe('ExecV3 — durationMs uses the injected clock', () => {
+  it('computes per-command and top-level durationMs from the clock, not real time', async () => {
+    const ticks = [1000, 1010, 1050, 1070];
+    const now = () => ticks.shift() as number;
+    const tool = createExecV3(nodeFs, echoExecutor, passthroughEnvProvider, [], now);
+    const input = tool.input_schema.parse({ intent: 'echo hello', commands: [{ program: 'echo', args: ['hello'] }] });
+
+    const { textContent } = await tool.handler(input);
+    const expected = { command: 40, total: 70 };
+    const actual = { command: textContent.results[0]?.durationMs, total: textContent.durationMs };
+    expect(actual).toEqual(expected);
+  });
+});
+
+// Real timing: a pipe's stages run concurrently, so the top-level durationMs is not the sum of
+// the per-command ones. sleep 0.1 (the consumer) settles first and tears sleep 0.3 (the
+// producer) down early via SIGPIPE, so the whole run finishes in ~0.1s, not ~0.3s.
+describe('ExecV3 — pipe durationMs reflects overlap, not addition', () => {
+  it('top-level durationMs is less than the sum of the per-stage durationMs', async () => {
+    const tool = createExecV3(nodeFs, executor, passthroughEnvProvider);
+    const input = tool.input_schema.parse({
+      intent: 'pipe a slow producer into a fast consumer to show they overlap',
+      commands: [
+        { program: 'sleep', args: ['0.3'], op: '|' as const },
+        { program: 'sleep', args: ['0.1'] },
+      ],
+    });
+
+    const { textContent } = await tool.handler(input);
+    const sum = (textContent.results[0]?.durationMs ?? 0) + (textContent.results[1]?.durationMs ?? 0);
+    const expected = true;
+    const actual = textContent.durationMs < sum;
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-sdk-tools/test/ExecV3/pipeline-teardown.spec.ts
+++ b/packages/claude-sdk-tools/test/ExecV3/pipeline-teardown.spec.ts
@@ -205,7 +205,7 @@ describe('middle-consumer exit — find | head -n 1 | sleep 500', () => {
     const timer = setTimeout(() => controller.abort(), 500);
     const executor = new Executor();
     try {
-      const output = await evaluate(commands, { cwd: homedir(), signal: controller.signal, executor, envProvider: passthroughEnvProvider });
+      const output = await evaluate(commands, { cwd: homedir(), signal: controller.signal, executor, envProvider: passthroughEnvProvider, now: () => performance.now() });
       const expected = 'SIGPIPE';
       const actual = output.results[0]?.signal;
       expect(actual).toBe(expected);


### PR DESCRIPTION
## Summary
- ExecV3 results now carry a `durationMs`, per command and for the whole run
- A pipe's overlapping stages are measured correctly, so the total isn't just a sum of the parts