### PR TITLE
Abstract createWriteStream and platform/arch behind IFileSystem

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hook input delivered via stdin instead of command arguments
 - Internal: split AppLayout into TerminalRenderer, TerminalInput, View, and PrimaryView for future peer views
 - Introduce core-di-lite for dependency resolution; separate composition from logic
+- Keychain platform/arch support check now reads through IFileSystem instead of process.platform/process.arch directly
 - List --file in --help output
 - Move source files into `model/`, `view/`, and `controller/` subdirectories; add biome.json boundary enforcement
 - Read the SDK-normalised path in the display summary and the permission check instead of each re-deriving it, removing the two hand-maintained path inspectors

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -135,3 +135,4 @@
 {"description":"Command mode can now be entered, navigated, and exited while a query is streaming, not only in the editor phase","category":"changed"}
 {"description":"Submitting with ctrl+enter now works while command mode is open, instead of requiring it to be closed first","category":"fixed"}
 {"description":"Attachments added while a query is streaming are no longer cleared once that query finishes","category":"fixed"}
+{"description":"Keychain platform/arch support check now reads through IFileSystem instead of process.platform/process.arch directly","category":"changed"}

--- a/apps/claude-sdk-cli/src/secrets/EnvProvider.ts
+++ b/apps/claude-sdk-cli/src/secrets/EnvProvider.ts
@@ -1,17 +1,14 @@
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { buildEnvFrom, IEnvProvider } from '@shellicar/claude-sdk-tools/ExecV3';
 import { dependsOn } from '@shellicar/core-di-lite';
 import { ISecrets } from './Secrets.js';
 
 /** Extracted as a pure function so the boundary (darwin + arm64, nothing else) is unit-testable
- *  directly, without mocking process.platform/process.arch. */
+ *  directly, without mocking `IFileSystem.platform()`/`arch()`. */
 export function isKeychainPlatformSupported(platform: NodeJS.Platform, arch: NodeJS.Architecture): boolean {
   return platform === 'darwin' && arch === 'arm64';
 }
-
-/** Static for the process's lifetime — the running binary's platform cannot change mid-session,
- *  so this is computed once rather than re-checked (or probed via module resolution) per call. */
-const KEYCHAIN_PLATFORM_SUPPORTED = isKeychainPlatformSupported(process.platform, process.arch);
 
 const GH_ENV_KEYS = ['GH_TOKEN', 'GITHUB_TOKEN', 'SSH_AUTH_SOCK'];
 
@@ -43,10 +40,11 @@ const GH_ENV_KEYS = ['GH_TOKEN', 'GITHUB_TOKEN', 'SSH_AUTH_SOCK'];
 export class EnvProvider extends IEnvProvider {
   @dependsOn(ISecrets) private readonly secrets!: ISecrets;
   @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<any>;
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
 
   public buildEnv(cmdEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     const { stripGhCredentials, ghScoping } = this.configLoader.config.secrets;
-    const scopingEnabled = KEYCHAIN_PLATFORM_SUPPORTED && ghScoping;
+    const scopingEnabled = isKeychainPlatformSupported(this.fs.platform(), this.fs.arch()) && ghScoping;
     return buildEnvFrom(
       {
         strip: stripGhCredentials ? GH_ENV_KEYS : [],

--- a/apps/claude-sdk-cli/test/EnvProvider.spec.ts
+++ b/apps/claude-sdk-cli/test/EnvProvider.spec.ts
@@ -1,8 +1,10 @@
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { createServiceCollection } from '@shellicar/core-di-lite';
 import { describe, expect, it } from 'vitest';
-import { EnvProvider, isKeychainPlatformSupported } from '../src/secrets/EnvProvider.js';
+import { EnvProvider } from '../src/secrets/EnvProvider.js';
 import { ISecrets } from '../src/secrets/Secrets.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
 
 type SecretsConfig = { stripGhCredentials: boolean; ghScoping: boolean };
 
@@ -24,10 +26,11 @@ function makeConfigLoader(secrets: SecretsConfig): ConfigLoader<never> {
   } as unknown as ConfigLoader<never>;
 }
 
-function buildEnvProvider(secrets: SecretsConfig): EnvProvider {
+function buildEnvProvider(secrets: SecretsConfig, fs: IFileSystem = new MemoryFileSystem()): EnvProvider {
   const services = createServiceCollection();
   services.register(ISecrets).to(ISecrets, () => new FakeSecrets());
   services.register(ConfigLoader).to(ConfigLoader, () => makeConfigLoader(secrets));
+  services.register(IFileSystem).to(IFileSystem, () => fs);
   services.register(EnvProvider).to(EnvProvider);
   return services.buildProvider().resolve(EnvProvider);
 }
@@ -66,23 +69,48 @@ describe('EnvProvider', () => {
   });
 
   describe('ghScoping', () => {
-    // This suite runs on ubuntu-24.04 in CI, and on whatever the developer's own machine is
-    // locally, neither guaranteed to be darwin arm64, so the expected outcome is computed with
-    // the same predicate the production code uses rather than hardcoded, keeping this test
-    // deterministic on any machine. The predicate's own boundary (darwin + arm64, nothing else)
-    // is covered exhaustively by isKeychainPlatformSupported.spec.ts; this test only verifies
-    // buildEnv actually consults it.
-    it('injects a reader token only when ghScoping is enabled and the platform supports it', () => {
-      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: true });
+    // Platform/arch are read through the injected IFileSystem (not the real host), so these
+    // are deterministic on any machine, unlike relying on the real process.platform/arch. The
+    // predicate's own boundary (darwin + arm64, nothing else) is covered exhaustively by
+    // isKeychainPlatformSupported.spec.ts; this suite only verifies buildEnv consults it via fs.
+    it('injects a reader token when ghScoping is enabled on a supported platform', () => {
+      const fs = new MemoryFileSystem();
+      fs.setPlatform('darwin');
+      fs.setArch('arm64');
+      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: true }, fs);
 
       const actual = envProvider.buildEnv({});
 
-      const expected = isKeychainPlatformSupported(process.platform, process.arch) ? 'fake-reader-token' : undefined;
-      expect(actual.GH_TOKEN).toBe(expected);
+      expect(actual.GH_TOKEN).toBe('fake-reader-token');
+    });
+
+    it('does not inject a reader token on an unsupported platform even when ghScoping is enabled', () => {
+      const fs = new MemoryFileSystem();
+      fs.setPlatform('linux');
+      fs.setArch('arm64');
+      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: true }, fs);
+
+      const actual = envProvider.buildEnv({});
+
+      expect(actual.GH_TOKEN).toBeUndefined();
+    });
+
+    it('does not inject a reader token on an unsupported arch even when ghScoping is enabled', () => {
+      const fs = new MemoryFileSystem();
+      fs.setPlatform('darwin');
+      fs.setArch('x64');
+      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: true }, fs);
+
+      const actual = envProvider.buildEnv({});
+
+      expect(actual.GH_TOKEN).toBeUndefined();
     });
 
     it('does not inject a reader token when ghScoping is disabled', () => {
-      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: false });
+      const fs = new MemoryFileSystem();
+      fs.setPlatform('darwin');
+      fs.setArch('arm64');
+      const envProvider = buildEnvProvider({ stripGhCredentials: true, ghScoping: false }, fs);
 
       const actual = envProvider.buildEnv({});
 

--- a/apps/claude-sdk-cli/test/MemoryFileSystem.ts
+++ b/apps/claude-sdk-cli/test/MemoryFileSystem.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'node:stream';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IFileEntry, StatResult } from '@shellicar/claude-core/fs/types';
 
@@ -176,6 +177,29 @@ export class MemoryFileSystem extends IFileSystem {
 
   public platform(): NodeJS.Platform {
     return this.#platform;
+  }
+
+  #arch: NodeJS.Architecture = 'arm64';
+
+  public setArch(a: NodeJS.Architecture): void {
+    this.#arch = a;
+  }
+
+  public arch(): NodeJS.Architecture {
+    return this.#arch;
+  }
+
+  public createWriteStream(path: string, options: { flags: 'a' | 'w' }): Writable {
+    const initial = options.flags === 'a' ? (this.files.get(path) ?? '') : '';
+    const chunks: string[] = [initial];
+    const files = this.files;
+    return new Writable({
+      write(chunk, encoding, callback) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk));
+        files.set(path, chunks.join(''));
+        callback();
+      },
+    });
   }
 
   public async readlink(path: string): Promise<string> {

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a BLUE foreground ANSI colour constant
 - Add a chdir operation to the IFileSystem contract
 - Add a README describing the package and pointing to the main documentation
+- Add arch and createWriteStream operations to the IFileSystem contract
 - Add IObjectStore interface for injectable persistence
 - Add overrides option to ConfigLoader for a highest-precedence config layer
 - Add rename and platform operations to the IFileSystem contract

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -17,3 +17,4 @@
 {"description":"Parse mouse-wheel events from stdin into scroll_up/scroll_down key actions; add enableMouse/disableMouse escape sequences","category":"added"}
 {"description":"Add a BLUE foreground ANSI colour constant","category":"added"}
 {"description":"Add the conversation-history model: store types, read/write interfaces, and near-duplicate detection (shingle, minhash, LSH) for the sweep","category":"added"}
+{"description":"Add arch and createWriteStream operations to the IFileSystem contract","category":"added"}

--- a/packages/claude-core/src/fs/interfaces.ts
+++ b/packages/claude-core/src/fs/interfaces.ts
@@ -1,3 +1,4 @@
+import type { Writable } from 'node:stream';
 import type { FileRecord } from './records';
 import type { FindOptions, IFileEntry, StatResult } from './types';
 import { walk } from './walk';
@@ -25,4 +26,7 @@ export abstract class IFileSystem {
   public abstract readlink(path: string): Promise<string>;
   public abstract getEnvVar(name: string): string | undefined;
   public abstract platform(): NodeJS.Platform;
+  public abstract arch(): NodeJS.Architecture;
+  /** Open a writable stream to a file, for a redirect target rather than a one-shot write. */
+  public abstract createWriteStream(path: string, options: { flags: 'a' | 'w' }): Writable;
 }

--- a/packages/claude-core/test/MemoryFileSystem.ts
+++ b/packages/claude-core/test/MemoryFileSystem.ts
@@ -1,3 +1,4 @@
+import type { Writable } from 'node:stream';
 import { IFileSystem } from '../src/fs/interfaces';
 import type { IFileEntry, StatResult } from '../src/fs/types';
 
@@ -79,6 +80,14 @@ export class MemoryFileSystem extends IFileSystem {
 
   public platform(): NodeJS.Platform {
     throw new Error('MemoryFileSystem: platform() not supported');
+  }
+
+  public arch(): NodeJS.Architecture {
+    throw new Error('MemoryFileSystem: arch() not supported');
+  }
+
+  public createWriteStream(): Writable {
+    throw new Error('MemoryFileSystem: createWriteStream() not supported');
   }
 
   public readlink(): Promise<string> {

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidate process spawn behind a shared exec-core interface and detach spawned commands from the controlling terminal
 - EditFile returns a plain-text, line-numbered diff instead of a JSON object, so the result is readable without unescaping
 - EditFile's insert after_line accepts negative indices (-1 = after the last line) so appending no longer requires knowing the file's line count
+- Exec, ExecV2, and ExecV3 redirect writes now go through IFileSystem instead of importing node:fs directly
 - ExecV3 requires an IEnvProvider argument; createExecV3 and configureExecV3 signatures changed to accept it
 - Mark every filesystem-path field on the tool schemas so the SDK normalises it, and drop the per-handler path expansion; DeleteFile and DeleteDirectory now take a files array
 - Merge PreviewEdit and EditFile into a single EditFile tool that validates, writes, and returns a diff in one call, removing the preview/confirm step and its in-memory patch store

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -64,3 +64,4 @@
 {"description":"ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph","category":"fixed"}
 {"description":"GitHub_PullRequest_AutoMerge takes a required strategy (merge, squash, rebase) when enabling, so it can queue a specific merge method instead of only accepting the repo default","category":"fixed"}
 {"description":"ExecV3 command results now include durationMs, the wall-clock time from spawn to settle for that stage; the response also carries a top-level durationMs for the whole run","category":"added"}
+{"description":"Exec, ExecV2, and ExecV3 redirect writes now go through IFileSystem instead of importing node:fs directly","category":"changed"}

--- a/packages/claude-sdk-tools/src/Exec/Exec.ts
+++ b/packages/claude-sdk-tools/src/Exec/Exec.ts
@@ -45,7 +45,7 @@ export function createExec(fs: IFileSystem, executor: IExecutor) {
         };
       }
 
-      const result = await execute(normalised, cwd, execSignal(signal, input.timeout), executor);
+      const result = await execute(normalised, cwd, execSignal(signal, input.timeout), executor, fs);
       if (signal?.aborted) {
         throw new ToolCancelledError();
       }

--- a/packages/claude-sdk-tools/src/Exec/execCommand.ts
+++ b/packages/claude-sdk-tools/src/Exec/execCommand.ts
@@ -1,11 +1,12 @@
 import { Readable } from 'node:stream';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { fromStream, type IExecutor } from '@shellicar/exec-core';
 import { resolveSinks } from '../exec-shared';
 import type { Command, StepResult } from './types';
 
 /** Execute a single command via exec-core, routing and collecting its output. */
-export async function execCommand(cmd: Command, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor): Promise<StepResult> {
-  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(cmd);
+export async function execCommand(cmd: Command, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor, fs: IFileSystem): Promise<StepResult> {
+  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(cmd, fs);
 
   // Collect concurrently with the run. Invoking fromStream starts the drain
   // immediately, so a full capture buffer can never block the child.

--- a/packages/claude-sdk-tools/src/Exec/execPipeline.ts
+++ b/packages/claude-sdk-tools/src/Exec/execPipeline.ts
@@ -1,5 +1,5 @@
-import { createWriteStream } from 'node:fs';
 import { PassThrough, Readable, type Writable } from 'node:stream';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { type ExitStatus, fromStream, type IExecutor } from '@shellicar/exec-core';
 import type { PipelineCommands, StepResult } from './types';
 
@@ -13,7 +13,7 @@ import type { PipelineCommands, StepResult } from './types';
  *  - the final stage's stdout is always captured, and additionally written to the
  *    redirect file when one is present.
  */
-export async function execPipeline(commands: PipelineCommands, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor): Promise<StepResult> {
+export async function execPipeline(commands: PipelineCommands, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor, fs: IFileSystem): Promise<StepResult> {
   const n = commands.length;
   const bridges = Array.from({ length: n - 1 }, () => new PassThrough());
   const lastCapture = new PassThrough();
@@ -27,7 +27,7 @@ export async function execPipeline(commands: PipelineCommands, cwd: string, abor
 
     const stdout: Writable = isLast ? lastCapture : bridges[i];
     if (isLast && redirect && (redirect.stream === 'stdout' || redirect.stream === 'both')) {
-      const file = createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' });
+      const file = fs.createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' });
       file.on('error', () => {});
       lastCapture.pipe(file);
     }
@@ -37,7 +37,7 @@ export async function execPipeline(commands: PipelineCommands, cwd: string, abor
     if (cmd.merge_stderr) {
       stderr = stdout;
     } else if (isLast && redirect && (redirect.stream === 'stderr' || redirect.stream === 'both')) {
-      const file = createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' });
+      const file = fs.createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' });
       file.on('error', () => {});
       stderr = file;
     } else {

--- a/packages/claude-sdk-tools/src/Exec/execStep.ts
+++ b/packages/claude-sdk-tools/src/Exec/execStep.ts
@@ -1,13 +1,14 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IExecutor } from '@shellicar/exec-core';
 import { execCommand } from './execCommand';
 import { execPipeline } from './execPipeline';
 import type { Step, StepResult } from './types';
 
 /** Execute a single step: one command runs directly, two or more form a pipeline. */
-export async function execStep(step: Step, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor): Promise<StepResult> {
+export async function execStep(step: Step, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor, fs: IFileSystem): Promise<StepResult> {
   const [first, second, ...rest] = step.commands;
   if (second == null) {
-    return execCommand(first, cwd, abortSignal, executor);
+    return execCommand(first, cwd, abortSignal, executor, fs);
   }
-  return execPipeline([first, second, ...rest], cwd, abortSignal, executor);
+  return execPipeline([first, second, ...rest], cwd, abortSignal, executor, fs);
 }

--- a/packages/claude-sdk-tools/src/Exec/execute.ts
+++ b/packages/claude-sdk-tools/src/Exec/execute.ts
@@ -1,12 +1,13 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IExecutor } from '@shellicar/exec-core';
 import { execStep } from './execStep';
 import type { ExecInput, ExecOutput } from './types';
 
 /** Execute all steps according to the chaining strategy. The timeout is already folded into abortSignal. */
-export async function execute(input: ExecInput, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor): Promise<ExecOutput> {
+export async function execute(input: ExecInput, cwd: string, abortSignal: AbortSignal | undefined, executor: IExecutor, fs: IFileSystem): Promise<ExecOutput> {
   // independent: all steps run concurrently — no step waits for another
   if (input.chaining === 'independent') {
-    const results = await Promise.all(input.steps.map((step) => execStep(step, cwd, abortSignal, executor)));
+    const results = await Promise.all(input.steps.map((step) => execStep(step, cwd, abortSignal, executor, fs)));
     const success = results.every((r) => r.exitCode === 0);
     return { results, success };
   }
@@ -14,7 +15,7 @@ export async function execute(input: ExecInput, cwd: string, abortSignal: AbortS
   // sequential / bail_on_error: steps run one at a time
   const results = [];
   for (const step of input.steps) {
-    const result = await execStep(step, cwd, abortSignal, executor);
+    const result = await execStep(step, cwd, abortSignal, executor, fs);
     results.push(result);
 
     if (input.chaining === 'bail_on_error' && result.exitCode !== 0) {

--- a/packages/claude-sdk-tools/src/ExecV2/ExecV2.ts
+++ b/packages/claude-sdk-tools/src/ExecV2/ExecV2.ts
@@ -76,7 +76,7 @@ export function createExecV2(fs: IFileSystem, executor: IExecutor) {
         };
       }
 
-      const [results, aggregateExit] = await executeTree(normalised, { cwd, signal: execSignal(signal, input.timeout), executor });
+      const [results, aggregateExit] = await executeTree(normalised, { cwd, signal: execSignal(signal, input.timeout), executor, fs });
       if (signal?.aborted) {
         throw new ToolCancelledError();
       }

--- a/packages/claude-sdk-tools/src/ExecV2/executeTree.ts
+++ b/packages/claude-sdk-tools/src/ExecV2/executeTree.ts
@@ -1,5 +1,6 @@
 import { PassThrough, Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { fromStream, type IExecutor } from '@shellicar/exec-core';
 import { resolveSinks } from '../exec-shared';
 import type { Command, CommandResult, Pipeline } from './types';
@@ -8,6 +9,7 @@ export interface ExecContext {
   cwd: string;
   signal?: AbortSignal;
   executor: IExecutor;
+  fs: IFileSystem;
 }
 
 type Aggregated = [CommandResult[], number | null];
@@ -32,7 +34,7 @@ function combineUnguarded(leftExit: number | null, rightExit: number | null): nu
 
 /** Run one command to completion, routing and capturing its output. */
 async function runLeaf(cmd: Command, ctx: ExecContext): Promise<Aggregated> {
-  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(cmd);
+  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(cmd, ctx.fs);
   const [status, out, err] = await Promise.all([ctx.executor.run(specOf(cmd, ctx), { stdin: stdinOf(cmd), stdout, stderr, signal: ctx.signal }), stdoutCapture ? fromStream(stdoutCapture) : Promise.resolve(''), stderrCapture ? fromStream(stderrCapture) : Promise.resolve('')]);
   return [[{ id: cmd.id, stdout: out, stderr: err, exitCode: status.exitCode, signal: status.signal }], status.exitCode];
 }
@@ -96,7 +98,7 @@ async function executePipe(left: Pipeline, right: Pipeline, ctx: ExecContext): P
     return agg;
   });
 
-  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(right);
+  const { stdout, stderr, stdoutCapture, stderrCapture } = resolveSinks(right, ctx.fs);
   const rightP = Promise.all([ctx.executor.run(specOf(right, ctx), { stdin: bridge, stdout, stderr, signal: ctx.signal }), stdoutCapture ? fromStream(stdoutCapture) : Promise.resolve(''), stderrCapture ? fromStream(stderrCapture) : Promise.resolve('')]);
 
   const [leftResults] = await leftP;
@@ -120,7 +122,7 @@ async function pump(pipeline: Pipeline, sink: PassThrough, ctx: ExecContext, std
   if ('program' in pipeline) {
     const fwd = new PassThrough();
     fwd.pipe(sink, { end: false });
-    const { stdout, stderr, stderrCapture } = resolveSinks(pipeline, fwd);
+    const { stdout, stderr, stderrCapture } = resolveSinks(pipeline, ctx.fs, fwd);
     const fwdUsed = stdout === fwd; // a redirect can divert stdout away from fwd
     const [status, err] = await Promise.all([ctx.executor.run(specOf(pipeline, ctx), { stdin: stdin ?? stdinOf(pipeline), stdout, stderr, signal: ctx.signal }), stderrCapture ? fromStream(stderrCapture) : Promise.resolve(''), fwdUsed ? finished(fwd).catch(() => undefined) : Promise.resolve(undefined)]);
     if (!fwdUsed) {

--- a/packages/claude-sdk-tools/src/ExecV3/ExecV3.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/ExecV3.ts
@@ -101,7 +101,7 @@ export function createExecV3(fs: IFileSystem, executor: IExecutor, envProvider: 
         throw new ToolRefusedError(errors.join('\n'));
       }
 
-      const result = await evaluate(commands, { cwd, signal: execSignal(signal, input.timeout), executor, envProvider, now });
+      const result = await evaluate(commands, { cwd, signal: execSignal(signal, input.timeout), executor, envProvider, now, fs });
       if (signal?.aborted) {
         throw new ToolCancelledError();
       }

--- a/packages/claude-sdk-tools/src/ExecV3/engine.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/engine.ts
@@ -1,3 +1,4 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IExecutor } from '@shellicar/exec-core';
 import type { IEnvProvider } from '../exec-shared';
 import { group } from './group';
@@ -10,6 +11,7 @@ export interface EngineContext {
   executor: IExecutor;
   envProvider: IEnvProvider;
   now: () => number;
+  fs: IFileSystem;
 }
 
 /**

--- a/packages/claude-sdk-tools/src/ExecV3/runPipeline.ts
+++ b/packages/claude-sdk-tools/src/ExecV3/runPipeline.ts
@@ -1,6 +1,6 @@
-import { createWriteStream } from 'node:fs';
 import { resolve } from 'node:path';
 import { PassThrough, Readable, type Writable } from 'node:stream';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { fromStream, PipeConsumerGone } from '@shellicar/exec-core';
 import type { EngineContext } from './engine';
 import type { Command, CommandResult } from './types';
@@ -17,14 +17,14 @@ interface StageSinks {
  * stderr "&1" = merge). `downstream` is the bridge a non-terminal stage feeds; when
  * present and no stdout redirect diverts it, stdout flows onward and is NOT captured.
  */
-function resolveStageSinks(cmd: Command, downstream: Writable | undefined, cwd: string): StageSinks {
+function resolveStageSinks(cmd: Command, downstream: Writable | undefined, cwd: string, fs: IFileSystem): StageSinks {
   const redirect = cmd.redirect;
   const mergeStderr = redirect?.stderr === '&1';
 
   let stdout: Writable;
   let stdoutCapture: PassThrough | undefined;
   if (redirect?.stdout != null) {
-    const file = createWriteStream(resolve(cwd, redirect.stdout), { flags: 'w' });
+    const file = fs.createWriteStream(resolve(cwd, redirect.stdout), { flags: 'w' });
     file.on('error', () => {
       // Redirect write errors should not crash the run.
     });
@@ -44,7 +44,7 @@ function resolveStageSinks(cmd: Command, downstream: Writable | undefined, cwd: 
   if (mergeStderr) {
     stderr = stdout;
   } else if (redirect?.stderr != null) {
-    const file = createWriteStream(resolve(cwd, redirect.stderr), { flags: 'w' });
+    const file = fs.createWriteStream(resolve(cwd, redirect.stderr), { flags: 'w' });
     file.on('error', () => {
       // Redirect write errors should not crash the run.
     });
@@ -107,7 +107,7 @@ export async function runPipeline(commands: Command[], ctx: EngineContext): Prom
     const isLast = i === n - 1;
     const downstream = isLast ? undefined : bridges[i];
     const stageCwd = cmd.cwd ?? ctx.cwd;
-    const { stdout, stderr, stdoutCapture, stderrCapture } = resolveStageSinks(cmd, downstream, stageCwd);
+    const { stdout, stderr, stdoutCapture, stderrCapture } = resolveStageSinks(cmd, downstream, stageCwd, ctx.fs);
     const stdin: Readable | undefined = i === 0 ? (cmd.stdin != null ? Readable.from(cmd.stdin) : undefined) : bridges[i - 1];
     // Combine the external cancel with this stage's own teardown controller. Either one
     // aborting kills the stage; Executor.run honours a single signal, so merge them.

--- a/packages/claude-sdk-tools/src/exec-shared.ts
+++ b/packages/claude-sdk-tools/src/exec-shared.ts
@@ -1,5 +1,5 @@
-import { createWriteStream } from 'node:fs';
 import { PassThrough, type Writable } from 'node:stream';
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { Executor } from '@shellicar/exec-core';
 
 /**
@@ -89,9 +89,9 @@ export interface Sinks {
  * destination; a redirect points either at a file. Returns the sinks plus the
  * capture streams the caller should collect.
  */
-export function resolveSinks(cmd: OutputRouting, stdoutDest?: Writable): Sinks {
+export function resolveSinks(cmd: OutputRouting, fs: IFileSystem, stdoutDest?: Writable): Sinks {
   const redirect = cmd.redirect;
-  const file = redirect ? createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' }) : undefined;
+  const file = redirect ? fs.createWriteStream(redirect.path, { flags: redirect.append ? 'a' : 'w' }) : undefined;
   file?.on('error', () => {
     // Redirect write errors should not crash the run.
   });

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -1,7 +1,8 @@
-import { existsSync } from 'node:fs';
+import { createWriteStream, existsSync } from 'node:fs';
 import { appendFile, readdir as fsReaddir, readlink as fsReadlink, realpath as fsRealpath, rename as fsRename, stat as fsStat, mkdir, readFile, rm, rmdir, writeFile } from 'node:fs/promises';
 import { homedir as osHomedir } from 'node:os';
 import { dirname } from 'node:path';
+import type { Writable } from 'node:stream';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IFileEntry, StatResult } from '@shellicar/claude-core/fs/types';
 
@@ -80,6 +81,14 @@ export class NodeFileSystem extends IFileSystem {
 
   public platform(): NodeJS.Platform {
     return process.platform;
+  }
+
+  public arch(): NodeJS.Architecture {
+    return process.arch;
+  }
+
+  public createWriteStream(path: string, options: { flags: 'a' | 'w' }): Writable {
+    return createWriteStream(path, options);
   }
 
   public async readlink(path: string): Promise<string> {

--- a/packages/claude-sdk-tools/test/Exec/execCommand.spec.ts
+++ b/packages/claude-sdk-tools/test/Exec/execCommand.spec.ts
@@ -5,6 +5,7 @@ import { Executor } from '@shellicar/exec-core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { execCommand } from '../../src/Exec/execCommand';
 import type { Command } from '../../src/Exec/types';
+import { nodeFs } from '../../src/fs/nodeFs';
 
 describe('execCommand', () => {
   // A megabyte is well past the PassThrough and OS pipe buffers. If execCommand
@@ -20,7 +21,7 @@ describe('execCommand', () => {
       merge_stderr: false,
     } satisfies Command;
 
-    const actual = await execCommand(cmd, process.cwd(), undefined, executor);
+    const actual = await execCommand(cmd, process.cwd(), undefined, executor, nodeFs);
 
     expect(actual.stdout.length).toBe(expected);
   });
@@ -46,7 +47,7 @@ describe('execCommand merge_stderr + redirect:stdout', () => {
       redirect: { path: redirectPath, stream: 'stdout', append: false },
     } satisfies Command;
 
-    result = await execCommand(cmd, process.cwd(), undefined, executor);
+    result = await execCommand(cmd, process.cwd(), undefined, executor, nodeFs);
   });
 
   afterAll(() => {

--- a/packages/claude-sdk-tools/test/ExecV3/pipeline-teardown.spec.ts
+++ b/packages/claude-sdk-tools/test/ExecV3/pipeline-teardown.spec.ts
@@ -5,6 +5,7 @@ import type { z } from 'zod';
 import { evaluate } from '../../src/ExecV3/engine';
 import type { Command } from '../../src/ExecV3/types';
 import { ExecV3, ExecV3InputSchema, passthroughEnvProvider } from '../../src/entry/ExecV3';
+import { nodeFs } from '../../src/fs/nodeFs';
 
 // Pipe-teardown tests — the hang and the SIGPIPE death of a torn-down producer.
 //
@@ -205,7 +206,7 @@ describe('middle-consumer exit — find | head -n 1 | sleep 500', () => {
     const timer = setTimeout(() => controller.abort(), 500);
     const executor = new Executor();
     try {
-      const output = await evaluate(commands, { cwd: homedir(), signal: controller.signal, executor, envProvider: passthroughEnvProvider, now: () => performance.now() });
+      const output = await evaluate(commands, { cwd: homedir(), signal: controller.signal, executor, envProvider: passthroughEnvProvider, now: () => performance.now(), fs: nodeFs });
       const expected = 'SIGPIPE';
       const actual = output.results[0]?.signal;
       expect(actual).toBe(expected);

--- a/packages/claude-sdk-tools/test/MemoryFileSystem.ts
+++ b/packages/claude-sdk-tools/test/MemoryFileSystem.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'node:stream';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IFileEntry, StatResult } from '@shellicar/claude-core/fs/types';
 
@@ -164,6 +165,29 @@ export class MemoryFileSystem extends IFileSystem {
 
   public platform(): NodeJS.Platform {
     return this.#platform;
+  }
+
+  #arch: NodeJS.Architecture = 'arm64';
+
+  public setArch(a: NodeJS.Architecture): void {
+    this.#arch = a;
+  }
+
+  public arch(): NodeJS.Architecture {
+    return this.#arch;
+  }
+
+  public createWriteStream(path: string, options: { flags: 'a' | 'w' }): Writable {
+    const initial = options.flags === 'a' ? (this.files.get(path) ?? Buffer.alloc(0)) : Buffer.alloc(0);
+    const chunks: Buffer[] = [initial];
+    const files = this.files;
+    return new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        files.set(path, Buffer.concat(chunks));
+        callback();
+      },
+    });
   }
 
   public async readlink(path: string): Promise<string> {

--- a/packages/claude-sdk-tools/test/NodeFileSystem.spec.ts
+++ b/packages/claude-sdk-tools/test/NodeFileSystem.spec.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { finished } from 'node:stream/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NodeFileSystem } from '../src/fs/NodeFileSystem';
+
+describe('NodeFileSystem', () => {
+  let dir: string;
+  let fs: NodeFileSystem;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'node-file-system-'));
+    fs = new NodeFileSystem();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('platform', () => {
+    it('returns the real process platform', () => {
+      const expected = process.platform;
+      const actual = fs.platform();
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('arch', () => {
+    it('returns the real process arch', () => {
+      const expected = process.arch;
+      const actual = fs.arch();
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('createWriteStream', () => {
+    it('writes content to a new file with flags "w"', async () => {
+      const path = join(dir, 'out.txt');
+      const stream = fs.createWriteStream(path, { flags: 'w' });
+      stream.end('hello');
+      await finished(stream);
+
+      const actual = readFileSync(path, 'utf-8');
+      expect(actual).toBe('hello');
+    });
+
+    it('overwrites existing content with flags "w"', async () => {
+      const path = join(dir, 'out.txt');
+      const first = fs.createWriteStream(path, { flags: 'w' });
+      first.end('first');
+      await finished(first);
+
+      const second = fs.createWriteStream(path, { flags: 'w' });
+      second.end('second');
+      await finished(second);
+
+      const actual = readFileSync(path, 'utf-8');
+      expect(actual).toBe('second');
+    });
+
+    it('appends content with flags "a"', async () => {
+      const path = join(dir, 'out.txt');
+      const first = fs.createWriteStream(path, { flags: 'w' });
+      first.end('first-');
+      await finished(first);
+
+      const second = fs.createWriteStream(path, { flags: 'a' });
+      second.end('second');
+      await finished(second);
+
+      const actual = readFileSync(path, 'utf-8');
+      expect(actual).toBe('first-second');
+    });
+  });
+});

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import type { Writable } from 'node:stream';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import type { IFileEntry, StatResult } from '@shellicar/claude-core/fs/types';
 import { describe, expect, it } from 'vitest';
@@ -53,6 +54,14 @@ class SymlinkMockFileSystem extends IFileSystem {
 
   public platform(): NodeJS.Platform {
     return 'linux';
+  }
+
+  public arch(): NodeJS.Architecture {
+    return 'x64';
+  }
+
+  public createWriteStream(): Writable {
+    throw new Error('not implemented');
   }
 
   public cwd(): string {


### PR DESCRIPTION
## Summary
- Exec, ExecV2, and ExecV3 redirect writes go through `IFileSystem.createWriteStream` instead of importing `node:fs` directly
- Keychain platform/arch support check reads through `IFileSystem` instead of `process.platform`/`process.arch`
- Adds test coverage for `NodeFileSystem` (previously untested) and fixes `EnvProvider` tests to be deterministic across host platforms
