### PR TITLE
Store mcp-memory's db under its own XDG data dir

### DIFF
--- a/packages/mcp-history/src/entry/index.ts
+++ b/packages/mcp-history/src/entry/index.ts
@@ -21,9 +21,8 @@ const consoleLogger: ILogger = {
 
 /**
  * Create a configured McpServer exposing SearchHistory/ReadHistory over this package's own history store.
- * The store lives under `getDataDir('shellicar-mcp-history')`, not the CLI's `~/.claude/history.db` — this is a
- * separate index, not a view onto the CLI's. Nothing currently ingests the CLI's audit logs into it, so the store
- * starts empty until something writes to it.
+ * The store lives under `getDataDir('shellicar-mcp-history')`. Nothing currently ingests any external data
+ * into it, so the store starts empty until something writes to it.
  *
  * There is no live session here, so `includeCurrentSession: false` on SearchHistory has nothing to exclude —
  * `currentSessionId` always returns an id no stored conversation can carry.

--- a/packages/mcp-memory/CHANGELOG.md
+++ b/packages/mcp-memory/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release: MCP server wrapping a SQLite FTS5-backed memory store with write, read, search, delete, and types tools
+
+### Fixed
+
+- Store memory.db under its own XDG data directory

--- a/packages/mcp-memory/changes.jsonl
+++ b/packages/mcp-memory/changes.jsonl
@@ -1,1 +1,2 @@
 {"description":"Initial release: MCP server wrapping a SQLite FTS5-backed memory store with write, read, search, delete, and types tools","category":"added"}
+{"description":"Store memory.db under its own XDG data directory","category":"fixed"}

--- a/packages/mcp-memory/src/entry/index.ts
+++ b/packages/mcp-memory/src/entry/index.ts
@@ -4,9 +4,9 @@ import { openMemoryDatabase } from '../openMemoryDatabase.js';
 import { SqliteMemoryEngine } from '../SqliteMemoryEngine.js';
 import { SqliteMemoryStore } from '../SqliteMemoryStore.js';
 
-/** Create a configured McpServer with the memory tools registered, backed by @shellicar/claude-sdk-tools, sharing the CLI's own `~/.claude/memory.db`. `home` overrides the home directory; tests pass a scratch one instead of the real one. */
-export function createMemoryServer(home?: string): McpServer {
-  const db = home === undefined ? openMemoryDatabase() : openMemoryDatabase('memory.db', home);
+/** Create a configured McpServer with the memory tools registered, backed by @shellicar/claude-sdk-tools, storing to this package's own store under the XDG data directory for `shellicar-mcp-memory`. `dataDir` overrides the resolved directory; tests pass a scratch one instead. */
+export function createMemoryServer(dataDir?: string): McpServer {
+  const db = dataDir === undefined ? openMemoryDatabase() : openMemoryDatabase('memory.db', dataDir);
   const store = new SqliteMemoryStore(new SqliteMemoryEngine(db));
   const server = new McpServer({ name: 'mcp-memory', version: '1.0.0' });
 

--- a/packages/mcp-memory/src/getDataDir.ts
+++ b/packages/mcp-memory/src/getDataDir.ts
@@ -1,0 +1,27 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Resolve the platform-appropriate persistent-data directory for `appName`.
+ * Honours $XDG_DATA_HOME on Linux if set (still the escape hatch everywhere,
+ * since anyone can export it), falls back to each OS's real convention.
+ *
+ * Inlined from @shellicar/mcp-internals (private, never published, designed
+ * to be copied into any MCP server that needs it — see that package's README).
+ */
+export function getDataDir(appName: string) {
+  const home = homedir();
+
+  if (process.env.XDG_DATA_HOME) {
+    return join(process.env.XDG_DATA_HOME, appName);
+  }
+
+  switch (process.platform) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', appName);
+    case 'win32':
+      return join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), appName);
+    default: // linux and friends
+      return join(home, '.local', 'share', appName);
+  }
+}

--- a/packages/mcp-memory/src/openMemoryDatabase.ts
+++ b/packages/mcp-memory/src/openMemoryDatabase.ts
@@ -1,11 +1,11 @@
 import { mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
+import { getDataDir } from './getDataDir.js';
 
-/** Opens (creating if needed) the same `memory.db` the CLI itself reads and writes, under `~/.claude`, so a memory written through either one is visible to the other. `home` defaults to the real home directory; tests pass a scratch one instead. */
-export function openMemoryDatabase(dbFileName = 'memory.db', home = homedir()): DatabaseSync {
-  const path = join(home, '.claude', dbFileName);
+/** Opens (creating if needed) this package's own `memory.db` under the XDG data directory for `shellicar-mcp-memory`. `dataDir` overrides the resolved directory; tests pass a scratch one instead. */
+export function openMemoryDatabase(dbFileName = 'memory.db', dataDir = getDataDir('shellicar-mcp-memory')): DatabaseSync {
+  const path = join(dataDir, dbFileName);
   mkdirSync(dirname(path), { recursive: true });
   const db = new DatabaseSync(path);
   db.exec('PRAGMA busy_timeout = 5000');

--- a/packages/mcp-memory/test/integration.spec.ts
+++ b/packages/mcp-memory/test/integration.spec.ts
@@ -11,8 +11,8 @@ describe('integration', () => {
   });
 
   async function setup() {
-    const home = `/tmp/mcp-memory-test-${Math.random().toString(36).slice(2)}`;
-    const server = createMemoryServer(home);
+    const dataDir = `/tmp/mcp-memory-test-${Math.random().toString(36).slice(2)}`;
+    const server = createMemoryServer(dataDir);
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
     client = new Client({ name: 'test', version: '1.0.0' });


### PR DESCRIPTION
## Summary

- mcp-memory now writes to its own store under the XDG data directory, matching how mcp-history stores its data
- Doc comments no longer describe the store in terms of another process's file layout