### PR TITLE
Fix stale CI badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A terminal-native alternative to Claude Code that talks to the Messages API directly.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/claude-sdk-cli.svg)](https://npmjs.com/package/@shellicar/claude-sdk-cli)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 <!-- BEGIN_ECOSYSTEM -->
 <!-- END_ECOSYSTEM -->

--- a/apps/claude-sdk-cli/README.md
+++ b/apps/claude-sdk-cli/README.md
@@ -3,7 +3,7 @@
 > A terminal-native alternative to Claude Code that talks to the Messages API directly.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/claude-sdk-cli.svg)](https://npmjs.com/package/@shellicar/claude-sdk-cli)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 A terminal client for Claude with a small set of composable tools. It talks to the Messages API directly through [`@shellicar/claude-sdk`](https://github.com/shellicar/claude-cli/tree/main/packages/claude-sdk), signs in with your Claude account, and stores sessions as flat JSONL you can script against.
 

--- a/packages/claude-core/README.md
+++ b/packages/claude-core/README.md
@@ -3,7 +3,7 @@
 > Shared utilities for claude-cli: a filesystem abstraction, path expansion, and terminal helpers.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/claude-core.svg)](https://npmjs.com/package/@shellicar/claude-core)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 The shared building blocks the rest of [claude-cli](https://github.com/shellicar/claude-cli#readme) uses: an `IFileSystem` abstraction, path expansion, and ANSI and terminal helpers.
 

--- a/packages/claude-sdk-tools/README.md
+++ b/packages/claude-sdk-tools/README.md
@@ -3,7 +3,7 @@
 > The tool definitions used by claude-cli: read, search, edit, exec, refs, and TypeScript tools.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/claude-sdk-tools.svg)](https://npmjs.com/package/@shellicar/claude-sdk-tools)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 The tools that [`@shellicar/claude-sdk-cli`](https://github.com/shellicar/claude-cli#readme) registers: file reads (text, PDF, and images), find and content search, slicing, edits, structured command execution, large-output refs, and TypeScript language-server tools.
 

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -3,7 +3,7 @@
 > A minimal agent SDK over the Messages API: own the loop, the context, and the tool pipeline.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/claude-sdk.svg)](https://npmjs.com/package/@shellicar/claude-sdk)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 The agent SDK that [`@shellicar/claude-sdk-cli`](https://github.com/shellicar/claude-cli#readme) is built on. It runs the agent loop in your own process and gives you direct access to the messages, per-turn usage, and the tool pipeline.
 

--- a/packages/exec-core/README.md
+++ b/packages/exec-core/README.md
@@ -3,7 +3,7 @@
 > Process execution used by the claude-cli tools: detached spawning, pipe coordination, and process-group lifecycle.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/exec-core.svg)](https://npmjs.com/package/@shellicar/exec-core)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 The process-execution layer the Exec tools are built on: detached spawning, pipe coordination, and process-group lifecycle.
 

--- a/packages/mcp-exec/README.md
+++ b/packages/mcp-exec/README.md
@@ -3,7 +3,7 @@
 > An MCP server that runs commands through a structured schema, wrapping the Exec tool from @shellicar/claude-sdk-tools.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/mcp-exec.svg)](https://npmjs.com/package/@shellicar/mcp-exec)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 ## Features
 

--- a/packages/mcp-history/README.md
+++ b/packages/mcp-history/README.md
@@ -3,7 +3,7 @@
 > Give an LLM a memory of its own past conversations.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/mcp-history.svg)](https://npmjs.com/package/@shellicar/mcp-history)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 ## Features
 

--- a/packages/mcp-memory/README.md
+++ b/packages/mcp-memory/README.md
@@ -3,7 +3,7 @@
 > Persistent memory for Claude, shared across every session and project.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/mcp-memory.svg)](https://npmjs.com/package/@shellicar/mcp-memory)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 ## Features
 

--- a/packages/mcp-typescript/README.md
+++ b/packages/mcp-typescript/README.md
@@ -3,7 +3,7 @@
 > MCP server exposing TypeScript language intelligence (diagnostics, hover, references, definitions) via a real `tsserver`.
 
 [![npm package](https://img.shields.io/npm/v/@shellicar/mcp-typescript.svg)](https://npmjs.com/package/@shellicar/mcp-typescript)
-[![build status](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/node.js.yml)
+[![build status](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/shellicar/claude-cli/actions/workflows/ci.yml)
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Badge links across the root and package READMEs pointed at `node.js.yml`, a workflow that no longer exists
- All now point at `ci.yml`, the actual CI workflow