### PR TITLE
Run tool batches concurrently and cache az login across calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Four roles: Model/State (pure data, owned by whoever updates it), ViewModel/Rend
 - **Zod** for config validation and tool schemas
 - **Dependency injection** via `@shellicar/core-di-lite` (`@dependsOn`), wired in `main.ts`. **Every injectable class has an abstract class, named with an `I` prefix** (`IFoo` for the concrete `Foo`): register the abstract to the concrete (`register(IFoo).to(Foo)`) and depend on the abstract (`@dependsOn(IFoo)`). Registering or depending on a bare concrete is concrete injection (CI), not DI. A manual construction factory is a smell — declare the class's dependencies with `@dependsOn` instead.
 - **No TUI framework** — raw ANSI escape sequences on `process.stdout`
+- **Never read the system clock directly** (`Date.now()`, `new Date()`) in anything that decides behaviour — inject `Clock` (`@js-joda/core`) and read through it (`clock.millis()`, `clock.instant()`). The consumer wires a real clock (`Clock.systemDefaultZone()`/`systemUTC()`) once at composition; a test wires a fake one it can move by hand. This is what makes time-based logic (retry backoff, token refresh/expiry, `since`/`until` bounds) provable without waiting out real time or faking `Date` globally with `vi.useFakeTimers`. `new Date().toISOString()` for a one-off, non-decisional log timestamp is not covered by this — the rule is about anything a branch or comparison depends on.
 - **JSONL** for audit log
 - Build output: `dist/esm/` and `dist/cjs/` via tsup (ESM + CJS + DTS)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,12 @@ The CLI bundles its own SQLite schema authority. There is no server and no API t
 | `ado-push-group-create.sh` | Create a project-scoped Azure DevOps security group with specific Git permission bits and add a member — for shapes the built-in groups don't cover |
 | `az-holder-remove-delete.sh` | Replace an identity's Azure RBAC role assignment with a custom role that strips delete permissions |
 
+## Local Dev Gotchas
+
+**`keychain-native` needs a build, and the running CLI needs a restart to see it.** `packages/keychain-native/*.node` is build output (gitignored), not source-controlled. `esbuild` deliberately keeps `@shellicar/keychain-native` external (see `build.ts`) so it resolves as an ordinary Node `require` through the `node_modules` symlink to the package, rather than getting inlined — that's correct and matches how the published platform package ships the compiled binary alongside the SEA build. Locally this means: a fresh checkout, or any change that touches `packages/keychain-native`, leaves the `.node` binary missing until you run `pnpm --filter @shellicar/keychain-native run build`. And rebuilding alone isn't enough — a CLI process already running (including the one hosting your current session) resolved that `require` once at startup and won't retry it; you have to restart the CLI process for it to load the freshly built binary. Symptom: `Cannot find module './keychain-native.darwin-arm64.node'` from every `AzCli`/`EscalatedAzCli` call, unaffected by rebuilding until the process restarts.
+
+This is a local dev-loop gap only, not a pipeline defect: CI always builds `keychain-native` fresh as part of the same release that wraps and publishes the SEA binary, so there's no stale-artifact window in the shipped product.
+
 ## Known Debt
 
 1. **AuditWriter is fatal-on-error** — any write failure calls `process.exit(1)`

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -143,6 +143,7 @@ export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, his
         getTenantId: (account) => azAccounts[account].tenantId,
       },
       azAccounts,
+      logger,
     ),
   );
 

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -143,6 +143,7 @@ export function createAppTools({ fs, tsServer, toolsConfig, objects, memory, his
         getTenantId: (account) => azAccounts[account].tenantId,
       },
       azAccounts,
+      clock,
       logger,
     ),
   );

--- a/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
+++ b/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { IExecutor } from '@shellicar/exec-core';
-import { ensureAzExtensionDir, removeConfigDir, runOnce, type RunResult } from '../az-shared';
+import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '../az-shared';
 import type { AzDeps } from './runAz';
 
 type Session = { configDir: string; extensionDir: string; refreshAt: number; hardExpireAt: number };

--- a/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
+++ b/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
@@ -6,7 +6,7 @@ import type { Clock } from '@js-joda/core';
 import { Instant } from '@js-joda/core';
 import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { IExecutor } from '@shellicar/exec-core';
-import { ensureAzExtensionDir, removeConfigDir, runOnce, type RunResult } from '../az-shared';
+import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '../az-shared';
 import type { AzDeps } from './runAz';
 
 type Session = { configDir: string; extensionDir: string; refreshAt: number; hardExpireAt: number };

--- a/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
+++ b/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
@@ -79,7 +79,10 @@ export class AzSessionCache {
     if (now >= entry.session.refreshAt && !entry.refreshing) {
       entry.refreshing = true;
       this.#logger?.info('az_session_background_refresh_started', { key, refreshAt: new Date(entry.session.refreshAt).toISOString() });
-      void this.#backgroundRefresh(key, deps, identity, account, cwd);
+      // Pass the current entry so the completion can tell whether it's still the one being refreshed
+      // (see #backgroundRefresh) — a hard-expiry relogin can replace this entry while the background
+      // login is still in flight.
+      void this.#backgroundRefresh(key, entry, deps, identity, account, cwd);
     }
     this.#logger?.debug('az_session_cache_hit', { key });
     return Promise.resolve(entry.session);
@@ -102,16 +105,32 @@ export class AzSessionCache {
 
   /** Soft-refresh path (50-75% window): logs in without touching the cache until the new session is
    *  ready, so every caller in the meantime keeps getting the still-valid old session — the point of
-   *  doing this in the background at all. */
-  async #backgroundRefresh(key: string, deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string): Promise<void> {
+   *  doing this in the background at all.
+   *
+   *  `staleEntry` is the entry this refresh set out to replace, captured by the caller before the
+   *  login started. A hard-expiry relogin (`#login`) can replace the map entry for this key while
+   *  this login is still in flight — it always wins immediately and unconditionally, since past
+   *  `hardExpireAt` there is no valid old session left to preserve. If that happened, `this` login is
+   *  now redundant: writing its result would clobber the newer, already-current session with an
+   *  older one for no reason. So the write only happens if the entry for this key is still the exact
+   *  one this refresh started from — nothing has superseded it in the meantime. */
+  async #backgroundRefresh(key: string, staleEntry: Entry, deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string): Promise<void> {
     const result = await this.#doLogin(deps, identity, account, cwd, key);
+    const stillCurrent = this.#entries.get(key) === staleEntry;
     if ('loginFailed' in result) {
-      // Leave the old session serving; clear the flag so the next call past refreshAt tries again.
+      // Leave whatever's serving now in place; clear the flag so a later call past refreshAt retries.
+      // Only touch it if we're still the entry that set the flag — a superseding hard-expiry login
+      // already owns a fresh entry with its own (false) refreshing state.
       this.#logger?.warn('az_session_background_refresh_failed', { key, exitCode: result.loginFailed.exitCode });
-      const entry = this.#entries.get(key);
-      if (entry) {
-        entry.refreshing = false;
+      if (stillCurrent) {
+        staleEntry.refreshing = false;
       }
+      return;
+    }
+    if (!stillCurrent) {
+      this.#logger?.debug('az_session_background_refresh_discarded_stale', { key });
+      await removeConfigDir(result.configDir);
+      this.#allConfigDirs.delete(result.configDir);
       return;
     }
     this.#logger?.info('az_session_background_refresh_completed', { key });

--- a/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
+++ b/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
@@ -2,9 +2,11 @@ import { rmSync } from 'node:fs';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Clock } from '@js-joda/core';
+import { Instant } from '@js-joda/core';
 import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { IExecutor } from '@shellicar/exec-core';
-import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '../az-shared';
+import { ensureAzExtensionDir, removeConfigDir, runOnce, type RunResult } from '../az-shared';
 import type { AzDeps } from './runAz';
 
 type Session = { configDir: string; extensionDir: string; refreshAt: number; hardExpireAt: number };
@@ -34,6 +36,10 @@ const FALLBACK_LIFETIME_MS = 60 * 60 * 1000;
  *  `Executor`'s pid reaping). A superseded dir from a relogin is never removed eagerly: a straggling
  *  `az` call that already holds the old session object could still be mid-flight against it.
  *
+ *  `clock` is the injected time source (see CLAUDE.md: never read the system clock directly) — every
+ *  refresh/expiry decision and every logged timestamp reads through it, so a test can drive the whole
+ *  refresh/hard-expire cycle with a fake clock instead of waiting out a real token's lifetime.
+ *
  *  `logger` is optional only so tests can construct this without one; every real caller supplies it —
  *  it's the only way to see the token's actual lifetime and confirm the refresh/hard-expire timing
  *  are firing where expected, since neither is visible from the tool's own output. */
@@ -41,9 +47,11 @@ export class AzSessionCache {
   readonly #entries = new Map<string, Entry>();
   readonly #allConfigDirs = new Set<string>();
   readonly #onExit: () => void;
+  readonly #clock: Clock;
   readonly #logger?: ILogger;
 
-  public constructor(logger?: ILogger) {
+  public constructor(clock: Clock, logger?: ILogger) {
+    this.#clock = clock;
     this.#logger = logger;
     this.#onExit = () => {
       for (const dir of this.#allConfigDirs) {
@@ -60,7 +68,7 @@ export class AzSessionCache {
   public getSession(deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string): Promise<Session | { loginFailed: RunResult }> {
     const key = `${identity}:${account}`;
     const entry = this.#entries.get(key);
-    const now = Date.now();
+    const now = this.#clock.millis();
 
     if (entry == null) {
       this.#logger?.info('az_session_cache_miss', { key });
@@ -73,12 +81,12 @@ export class AzSessionCache {
       return entry.promise;
     }
     if (now >= entry.session.hardExpireAt) {
-      this.#logger?.info('az_session_hard_expired', { key, hardExpireAt: new Date(entry.session.hardExpireAt).toISOString() });
+      this.#logger?.info('az_session_hard_expired', { key, hardExpireAt: Instant.ofEpochMilli(entry.session.hardExpireAt).toString() });
       return this.#login(deps, identity, account, cwd, key);
     }
     if (now >= entry.session.refreshAt && !entry.refreshing) {
       entry.refreshing = true;
-      this.#logger?.info('az_session_background_refresh_started', { key, refreshAt: new Date(entry.session.refreshAt).toISOString() });
+      this.#logger?.info('az_session_background_refresh_started', { key, refreshAt: Instant.ofEpochMilli(entry.session.refreshAt).toString() });
       // Pass the current entry so the completion can tell whether it's still the one being refreshed
       // (see #backgroundRefresh) — a hard-expiry relogin can replace this entry while the background
       // login is still in flight.
@@ -147,16 +155,16 @@ export class AzSessionCache {
     const tenantId = deps.getTenantId(account);
     const env = { ...process.env, AZURE_CONFIG_DIR: configDir, AZURE_EXTENSION_DIR: extensionDir };
 
-    const loginStartedAt = Date.now();
+    const loginStartedAt = this.#clock.millis();
     const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', clientId, '--tenant', tenantId, '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
     if (login.exitCode !== 0) {
       await removeConfigDir(configDir);
       this.#allConfigDirs.delete(configDir);
-      this.#logger?.warn('az_login_failed', { key, exitCode: login.exitCode, durationMs: Date.now() - loginStartedAt });
+      this.#logger?.warn('az_login_failed', { key, exitCode: login.exitCode, durationMs: this.#clock.millis() - loginStartedAt });
       return { loginFailed: login };
     }
 
-    const loginAt = Date.now();
+    const loginAt = this.#clock.millis();
     const lifetimeMs = await this.#tokenLifetimeMs(deps.executor, cwd, env);
     const refreshAt = loginAt + lifetimeMs * REFRESH_FRACTION;
     const hardExpireAt = loginAt + lifetimeMs * HARD_EXPIRE_FRACTION;
@@ -165,8 +173,8 @@ export class AzSessionCache {
       loginDurationMs: loginAt - loginStartedAt,
       tokenLifetimeMs: lifetimeMs,
       tokenLifetimeMinutes: Math.round(lifetimeMs / 60_000),
-      refreshAt: new Date(refreshAt).toISOString(),
-      hardExpireAt: new Date(hardExpireAt).toISOString(),
+      refreshAt: Instant.ofEpochMilli(refreshAt).toString(),
+      hardExpireAt: Instant.ofEpochMilli(hardExpireAt).toString(),
     });
     return { configDir, extensionDir, refreshAt, hardExpireAt };
   }
@@ -183,7 +191,7 @@ export class AzSessionCache {
     try {
       const parsed = JSON.parse(result.stdout) as { expires_on?: number; expiresOn?: string };
       const expiresAtMs = parsed.expires_on != null ? parsed.expires_on * 1000 : parsed.expiresOn != null ? new Date(parsed.expiresOn.replace(' ', 'T')).getTime() : Number.NaN;
-      const lifetimeMs = expiresAtMs - Date.now();
+      const lifetimeMs = expiresAtMs - this.#clock.millis();
       if (!Number.isFinite(lifetimeMs) || lifetimeMs <= 0) {
         this.#logger?.debug('az_token_lifetime_unparseable', { raw: result.stdout, fallbackMs: FALLBACK_LIFETIME_MS });
         return FALLBACK_LIFETIME_MS;

--- a/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
+++ b/packages/claude-sdk-tools/src/Az/AzSessionCache.ts
@@ -1,0 +1,178 @@
+import { rmSync } from 'node:fs';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import type { IExecutor } from '@shellicar/exec-core';
+import { ensureAzExtensionDir, removeConfigDir, runOnce, type RunResult } from '../az-shared';
+import type { AzDeps } from './runAz';
+
+type Session = { configDir: string; extensionDir: string; refreshAt: number; hardExpireAt: number };
+type Entry = { promise: Promise<Session | { loginFailed: RunResult }>; session?: Session; refreshing?: boolean };
+
+// Standard proactive-refresh shape: a session is usable for 3/4 of the token's real lifetime, with a
+// background relogin kicked off at the halfway point so a caller landing in the 50-75% window is
+// never blocked on it. A caller landing past 75% — the background relogin never started, or hasn't
+// finished — pays a synchronous relogin instead of risking a call against a token near expiry.
+const REFRESH_FRACTION = 0.5;
+const HARD_EXPIRE_FRACTION = 0.75;
+// Used only when az doesn't report a parseable expiry — a conservative default AAD access-token lifetime.
+const FALLBACK_LIFETIME_MS = 60 * 60 * 1000;
+
+/** Caches one `az login` per (identity, account), reused across every tool-execution block for as
+ *  long as the underlying token is fresh — not torn down per block. This is the same shape as a
+ *  person running `az login` once and staying signed in: a live session at rest, bounded by the
+ *  token's own expiry rather than by any block boundary.
+ *
+ *  A session is served as-is until `refreshAt` (50% of the token's real lifetime); a background
+ *  relogin starts there so nothing ever waits on it, and the old session keeps serving every caller
+ *  until the new one is ready and swapped in. Past `hardExpireAt` (75%) a call synchronously relogs
+ *  in rather than risk a stale token — the backstop for a background relogin that never started or
+ *  hasn't finished.
+ *
+ *  Every config dir this cache ever creates is tracked and swept on process exit (mirroring
+ *  `Executor`'s pid reaping). A superseded dir from a relogin is never removed eagerly: a straggling
+ *  `az` call that already holds the old session object could still be mid-flight against it.
+ *
+ *  `logger` is optional only so tests can construct this without one; every real caller supplies it —
+ *  it's the only way to see the token's actual lifetime and confirm the refresh/hard-expire timing
+ *  are firing where expected, since neither is visible from the tool's own output. */
+export class AzSessionCache {
+  readonly #entries = new Map<string, Entry>();
+  readonly #allConfigDirs = new Set<string>();
+  readonly #onExit: () => void;
+  readonly #logger?: ILogger;
+
+  public constructor(logger?: ILogger) {
+    this.#logger = logger;
+    this.#onExit = () => {
+      for (const dir of this.#allConfigDirs) {
+        try {
+          rmSync(dir, { recursive: true, force: true });
+        } catch {
+          // best-effort — the process is already exiting
+        }
+      }
+    };
+    process.on('exit', this.#onExit);
+  }
+
+  public getSession(deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string): Promise<Session | { loginFailed: RunResult }> {
+    const key = `${identity}:${account}`;
+    const entry = this.#entries.get(key);
+    const now = Date.now();
+
+    if (entry == null) {
+      this.#logger?.info('az_session_cache_miss', { key });
+      return this.#login(deps, identity, account, cwd, key);
+    }
+    if (entry.session == null) {
+      // Still resolving (or already failed and about to be evicted) — every caller shares the one
+      // in-flight attempt rather than each starting its own.
+      this.#logger?.debug('az_session_join_inflight', { key });
+      return entry.promise;
+    }
+    if (now >= entry.session.hardExpireAt) {
+      this.#logger?.info('az_session_hard_expired', { key, hardExpireAt: new Date(entry.session.hardExpireAt).toISOString() });
+      return this.#login(deps, identity, account, cwd, key);
+    }
+    if (now >= entry.session.refreshAt && !entry.refreshing) {
+      entry.refreshing = true;
+      this.#logger?.info('az_session_background_refresh_started', { key, refreshAt: new Date(entry.session.refreshAt).toISOString() });
+      void this.#backgroundRefresh(key, deps, identity, account, cwd);
+    }
+    this.#logger?.debug('az_session_cache_hit', { key });
+    return Promise.resolve(entry.session);
+  }
+
+  /** Cold-start / hard-expired path: replaces the cache entry immediately, so every caller from this
+   *  point on waits on the new login — there is no valid old session left worth serving. */
+  async #login(deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string, key: string): Promise<Session | { loginFailed: RunResult }> {
+    const promise = this.#doLogin(deps, identity, account, cwd, key);
+    const entry: Entry = { promise };
+    this.#entries.set(key, entry);
+    const result = await promise;
+    if ('loginFailed' in result) {
+      this.#entries.delete(key);
+      return result;
+    }
+    entry.session = result;
+    return result;
+  }
+
+  /** Soft-refresh path (50-75% window): logs in without touching the cache until the new session is
+   *  ready, so every caller in the meantime keeps getting the still-valid old session — the point of
+   *  doing this in the background at all. */
+  async #backgroundRefresh(key: string, deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string): Promise<void> {
+    const result = await this.#doLogin(deps, identity, account, cwd, key);
+    if ('loginFailed' in result) {
+      // Leave the old session serving; clear the flag so the next call past refreshAt tries again.
+      this.#logger?.warn('az_session_background_refresh_failed', { key, exitCode: result.loginFailed.exitCode });
+      const entry = this.#entries.get(key);
+      if (entry) {
+        entry.refreshing = false;
+      }
+      return;
+    }
+    this.#logger?.info('az_session_background_refresh_completed', { key });
+    this.#entries.set(key, { promise: Promise.resolve(result), session: result });
+  }
+
+  async #doLogin(deps: AzDeps, identity: 'reader' | 'holder', account: string, cwd: string, key: string): Promise<Session | { loginFailed: RunResult }> {
+    const configDir = await mkdtemp(join(tmpdir(), 'az-'));
+    this.#allConfigDirs.add(configDir);
+    const extensionDir = await ensureAzExtensionDir();
+    const certPath = join(configDir, 'cert.pem');
+    await writeFile(certPath, deps.getCert(account, identity), { mode: 0o600 });
+    const clientId = deps.getClientId(account, identity);
+    const tenantId = deps.getTenantId(account);
+    const env = { ...process.env, AZURE_CONFIG_DIR: configDir, AZURE_EXTENSION_DIR: extensionDir };
+
+    const loginStartedAt = Date.now();
+    const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', clientId, '--tenant', tenantId, '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
+    if (login.exitCode !== 0) {
+      await removeConfigDir(configDir);
+      this.#allConfigDirs.delete(configDir);
+      this.#logger?.warn('az_login_failed', { key, exitCode: login.exitCode, durationMs: Date.now() - loginStartedAt });
+      return { loginFailed: login };
+    }
+
+    const loginAt = Date.now();
+    const lifetimeMs = await this.#tokenLifetimeMs(deps.executor, cwd, env);
+    const refreshAt = loginAt + lifetimeMs * REFRESH_FRACTION;
+    const hardExpireAt = loginAt + lifetimeMs * HARD_EXPIRE_FRACTION;
+    this.#logger?.info('az_login_succeeded', {
+      key,
+      loginDurationMs: loginAt - loginStartedAt,
+      tokenLifetimeMs: lifetimeMs,
+      tokenLifetimeMinutes: Math.round(lifetimeMs / 60_000),
+      refreshAt: new Date(refreshAt).toISOString(),
+      hardExpireAt: new Date(hardExpireAt).toISOString(),
+    });
+    return { configDir, extensionDir, refreshAt, hardExpireAt };
+  }
+
+  /** Reads the token's real lifetime so refresh/expiry are bounded by fact, not an assumption. Falls
+   *  back to a conservative default if `az` can't report an expiry (older CLI, transient failure) —
+   *  the fallback only ever makes the cache refresh sooner than a longer-lived real token needed. */
+  async #tokenLifetimeMs(executor: IExecutor, cwd: string, env: NodeJS.ProcessEnv): Promise<number> {
+    const result = await runOnce(executor, 'az', ['account', 'get-access-token', '--output', 'json'], cwd, env);
+    if (result.exitCode !== 0) {
+      this.#logger?.debug('az_token_lifetime_unavailable', { exitCode: result.exitCode, fallbackMs: FALLBACK_LIFETIME_MS });
+      return FALLBACK_LIFETIME_MS;
+    }
+    try {
+      const parsed = JSON.parse(result.stdout) as { expires_on?: number; expiresOn?: string };
+      const expiresAtMs = parsed.expires_on != null ? parsed.expires_on * 1000 : parsed.expiresOn != null ? new Date(parsed.expiresOn.replace(' ', 'T')).getTime() : Number.NaN;
+      const lifetimeMs = expiresAtMs - Date.now();
+      if (!Number.isFinite(lifetimeMs) || lifetimeMs <= 0) {
+        this.#logger?.debug('az_token_lifetime_unparseable', { raw: result.stdout, fallbackMs: FALLBACK_LIFETIME_MS });
+        return FALLBACK_LIFETIME_MS;
+      }
+      return lifetimeMs;
+    } catch {
+      this.#logger?.debug('az_token_lifetime_unparseable', { raw: result.stdout, fallbackMs: FALLBACK_LIFETIME_MS });
+      return FALLBACK_LIFETIME_MS;
+    }
+  }
+}

--- a/packages/claude-sdk-tools/src/Az/createAzTool.ts
+++ b/packages/claude-sdk-tools/src/Az/createAzTool.ts
@@ -1,5 +1,6 @@
 import { defineTool, type ToolOperation } from '@shellicar/claude-sdk';
 import type { z } from 'zod';
+import type { AzSessionCache } from './AzSessionCache';
 import type { AzDeps } from './runAz';
 import { runAz } from './runAz';
 import { AzOutputSchema } from './schema';
@@ -17,7 +18,9 @@ export type AzToolSpec<TSchema extends z.ZodType<{ account?: string; args: strin
   defaultAccount?: string;
 };
 
-export function createAzTool<TSchema extends z.ZodType<{ account?: string; args: string[] }>>(spec: AzToolSpec<TSchema>, deps: AzDeps) {
+/** `cache` is one `AzSessionCache` shared across every Az tool built by `createAzTools`. Its
+ *  lifetime is the process, not a tool-execution block — see `AzSessionCache` for why. */
+export function createAzTool<TSchema extends z.ZodType<{ account?: string; args: string[] }>>(spec: AzToolSpec<TSchema>, deps: AzDeps, cache: AzSessionCache) {
   return defineTool({
     name: spec.name,
     operation: spec.operation,
@@ -30,7 +33,7 @@ export function createAzTool<TSchema extends z.ZodType<{ account?: string; args:
       if (account == null) {
         throw new Error('account is required when more than one Azure account is configured');
       }
-      const result = await runAz(deps, spec.identity, account, input.args, process.cwd());
+      const result = await runAz(deps, cache, spec.identity, account, input.args, process.cwd());
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },
   });

--- a/packages/claude-sdk-tools/src/Az/runAz.ts
+++ b/packages/claude-sdk-tools/src/Az/runAz.ts
@@ -1,12 +1,12 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import type { IExecutor } from '@shellicar/exec-core';
-import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '../az-shared';
+import type { AzSessionCache } from './AzSessionCache';
+import { runOnce, type RunResult } from '../az-shared';
 
 /** Deps one `az` call needs: the executor to run az/az-login through, and fresh reads of the
  *  certificate and the account's tenant/client id. Nothing here is cached beyond one call's
- *  lifetime — a rotated certificate takes effect on the very next call. */
+ *  lifetime by this function itself — the login session is cached by `AzSessionCache` for as long
+ *  as the token stays fresh, so a rotated certificate takes effect on the next relogin, not the
+ *  next call. */
 export type AzDeps = {
   executor: IExecutor;
   /** PEM (cert + private key) content for one account's reader or holder identity. */
@@ -17,34 +17,14 @@ export type AzDeps = {
   getTenantId: (account: string) => string;
 };
 
-/** Runs one `az <args>` as one account's reader or holder identity: writes the certificate to a
- *  throwaway temp dir, `az login --service-principal --certificate` into an isolated
- *  AZURE_CONFIG_DIR scoped to that dir (never the caller's own logged-in session), runs the real
- *  command against that same config dir, then deletes the temp dir — certificate and session both
- *  gone once the call returns. No standing login, nothing left at rest beyond the Keychain item
- *  `getCert` reads from.
- *
- *  AZURE_EXTENSION_DIR points at a persistent, shared directory instead of the throwaway config
- *  dir: an installed extension (e.g. azure-devops) is not a credential, and re-downloading it on
- *  every single call — because the previous call's throwaway directory is already gone — is what
- *  made every call slow. Only the login/token cache is ephemeral; the extension install is not. */
-export async function runAz(deps: AzDeps, identity: 'reader' | 'holder', account: string, args: string[], cwd: string): Promise<RunResult> {
-  const configDir = await mkdtemp(join(tmpdir(), 'az-'));
-  const extensionDir = await ensureAzExtensionDir();
-  try {
-    const certPath = join(configDir, 'cert.pem');
-    await writeFile(certPath, deps.getCert(account, identity), { mode: 0o600 });
-    const clientId = deps.getClientId(account, identity);
-    const tenantId = deps.getTenantId(account);
-    const env = { ...process.env, AZURE_CONFIG_DIR: configDir, AZURE_EXTENSION_DIR: extensionDir };
-
-    const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', clientId, '--tenant', tenantId, '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
-    if (login.exitCode !== 0) {
-      return login;
-    }
-
-    return await runOnce(deps.executor, 'az', args, cwd, env);
-  } finally {
-    await removeConfigDir(configDir);
+/** Runs one `az <args>` as one account's reader or holder identity, reusing the cached login session
+ *  for this identity/account (see `AzSessionCache`) instead of paying a fresh `az login` round-trip
+ *  on every call. */
+export async function runAz(deps: AzDeps, cache: AzSessionCache, identity: 'reader' | 'holder', account: string, args: string[], cwd: string): Promise<RunResult> {
+  const session = await cache.getSession(deps, identity, account, cwd);
+  if ('loginFailed' in session) {
+    return session.loginFailed;
   }
+  const env = { ...process.env, AZURE_CONFIG_DIR: session.configDir, AZURE_EXTENSION_DIR: session.extensionDir };
+  return await runOnce(deps.executor, 'az', args, cwd, env);
 }

--- a/packages/claude-sdk-tools/src/Az/runAz.ts
+++ b/packages/claude-sdk-tools/src/Az/runAz.ts
@@ -1,6 +1,6 @@
 import type { IExecutor } from '@shellicar/exec-core';
+import { type RunResult, runOnce } from '../az-shared';
 import type { AzSessionCache } from './AzSessionCache';
-import { runOnce, type RunResult } from '../az-shared';
 
 /** Deps one `az` call needs: the executor to run az/az-login through, and fresh reads of the
  *  certificate and the account's tenant/client id. Nothing here is cached beyond one call's

--- a/packages/claude-sdk-tools/src/Az/tools.ts
+++ b/packages/claude-sdk-tools/src/Az/tools.ts
@@ -1,3 +1,5 @@
+import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { AzSessionCache } from './AzSessionCache';
 import { createAzTool } from './createAzTool';
 import type { AzDeps } from './runAz';
 import { createAzInputSchema } from './schema';
@@ -17,7 +19,7 @@ function isNonEmpty(names: string[]): names is [string, ...string[]] {
  *  itself is the enforcement point: each account gets its own reader/holder service principal,
  *  scoped by RBAC, and the tool stays a free-text proposer. Neither tool is registered at all if
  *  no account has that identity configured. */
-export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig) {
+export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, logger?: ILogger) {
   const readerAccounts = Object.entries(accounts)
     .filter(([, a]) => a.readerClientId != null)
     .map(([name]) => name);
@@ -25,6 +27,10 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig) {
     .filter(([, a]) => a.holderClientId != null)
     .map(([name]) => name);
 
+  // One cache shared by every Az tool this call builds, so a reader and holder call against the
+  // same account in one block still share nothing (different identities → different cache keys),
+  // but repeated calls under the same identity/account do.
+  const cache = new AzSessionCache(logger);
   const tools = [];
 
   if (isNonEmpty(readerAccounts)) {
@@ -39,6 +45,7 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig) {
           defaultAccount: readerAccounts.length === 1 ? readerAccounts[0] : undefined,
         },
         deps,
+        cache,
       ),
     );
   }
@@ -55,6 +62,7 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig) {
           defaultAccount: holderAccounts.length === 1 ? holderAccounts[0] : undefined,
         },
         deps,
+        cache,
       ),
     );
   }

--- a/packages/claude-sdk-tools/src/Az/tools.ts
+++ b/packages/claude-sdk-tools/src/Az/tools.ts
@@ -30,6 +30,14 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, logger?:
   // One cache shared by every Az tool this call builds, so a reader and holder call against the
   // same account in one block still share nothing (different identities → different cache keys),
   // but repeated calls under the same identity/account do.
+  //
+  // This is a real process-lifetime singleton, not just per-call: `createAzTools` is only ever
+  // invoked once, inside the DI container's `AppToolsService` factory registration
+  // (apps/claude-sdk-cli/src/setup/container.ts) — `core-di-lite` memoizes a factory registration by
+  // the registration itself, so `AppToolsService.resolve()` constructs it once and every later
+  // resolve returns the same cached instance for the container's (i.e. the process's) lifetime. If
+  // that factory wiring ever changes to construct `AppToolsService` more than once, this cache stops
+  // being a singleton and the "process lifetime" claim above breaks silently.
   const cache = new AzSessionCache(logger);
   const tools = [];
 

--- a/packages/claude-sdk-tools/src/Az/tools.ts
+++ b/packages/claude-sdk-tools/src/Az/tools.ts
@@ -1,3 +1,4 @@
+import type { Clock } from '@js-joda/core';
 import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { AzSessionCache } from './AzSessionCache';
 import { createAzTool } from './createAzTool';
@@ -19,7 +20,7 @@ function isNonEmpty(names: string[]): names is [string, ...string[]] {
  *  itself is the enforcement point: each account gets its own reader/holder service principal,
  *  scoped by RBAC, and the tool stays a free-text proposer. Neither tool is registered at all if
  *  no account has that identity configured. */
-export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, logger?: ILogger) {
+export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, clock: Clock, logger?: ILogger) {
   const readerAccounts = Object.entries(accounts)
     .filter(([, a]) => a.readerClientId != null)
     .map(([name]) => name);
@@ -38,7 +39,7 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, logger?:
   // resolve returns the same cached instance for the container's (i.e. the process's) lifetime. If
   // that factory wiring ever changes to construct `AppToolsService` more than once, this cache stops
   // being a singleton and the "process lifetime" claim above breaks silently.
-  const cache = new AzSessionCache(logger);
+  const cache = new AzSessionCache(clock, logger);
   const tools = [];
 
   if (isNonEmpty(readerAccounts)) {

--- a/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
+++ b/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
@@ -1,5 +1,5 @@
-import type { PassThrough } from 'node:stream';
 import { rm } from 'node:fs/promises';
+import type { PassThrough } from 'node:stream';
 import { Clock, Instant, ZoneOffset } from '@js-joda/core';
 import type { CommandSpec, ExitStatus, IExecutor, SpawnOpts } from '@shellicar/exec-core';
 import { afterEach, describe, expect, it } from 'vitest';

--- a/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
+++ b/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
@@ -1,9 +1,46 @@
 import type { PassThrough } from 'node:stream';
 import { rm } from 'node:fs/promises';
+import { Clock, Instant, ZoneOffset } from '@js-joda/core';
 import type { CommandSpec, ExitStatus, IExecutor, SpawnOpts } from '@shellicar/exec-core';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { AzSessionCache } from '../src/Az/AzSessionCache';
 import type { AzDeps } from '../src/Az/runAz';
+
+// A settable fake clock, injected exactly the way CLAUDE.md's "never read the system clock
+// directly" convention expects: the test moves time by hand between steps instead of faking
+// `Date` globally, so the cache's own refresh/hard-expiry decisions are driven deterministically.
+class MutableClock extends Clock {
+  #millis: number;
+
+  public constructor(initialMillis: number) {
+    super();
+    this.#millis = initialMillis;
+  }
+
+  public set(millis: number): void {
+    this.#millis = millis;
+  }
+
+  public instant(): Instant {
+    return Instant.ofEpochMilli(this.#millis);
+  }
+
+  public millis(): number {
+    return this.#millis;
+  }
+
+  public withZone(): Clock {
+    return this;
+  }
+
+  public zone() {
+    return ZoneOffset.UTC;
+  }
+
+  public equals(other: unknown): boolean {
+    return other === this;
+  }
+}
 
 // Resolves each `run()` call on demand rather than immediately, so a test can control the
 // order two concurrent `az login` sequences complete in.
@@ -55,7 +92,6 @@ describe('AzSessionCache — background refresh vs hard-expiry relogin race', ()
   const configDirs: string[] = [];
 
   afterEach(async () => {
-    vi.useRealTimers();
     await Promise.all(configDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})));
   });
 
@@ -66,13 +102,12 @@ describe('AzSessionCache — background refresh vs hard-expiry relogin race', ()
   // it finishes after it — so a caller can be served a session that is one full cycle stale even
   // though a fresher one was already obtained.
   it('serves the hard-expiry relogin, not a background refresh that lands after it', async () => {
-    vi.useFakeTimers({ toFake: ['Date'] });
+    const clock = new MutableClock(0);
     const executor = new ControllableExecutor();
     const deps = makeDeps(executor);
-    const cache = new AzSessionCache();
+    const cache = new AzSessionCache(clock);
 
     // Cold start at t=0: a 1000ms-lifetime token, so refreshAt=500, hardExpireAt=750.
-    vi.setSystemTime(0);
     const coldPromise = cache.getSession(deps, 'reader', 'acct', '/cwd');
     await waitForCallCount(executor, 1);
     await executor.resolve(0);
@@ -87,7 +122,7 @@ describe('AzSessionCache — background refresh vs hard-expiry relogin race', ()
     // t=600: past refreshAt (500), before hardExpireAt (750) — starts a background refresh.
     // Its login/token calls (indices 2 and 3) are deliberately left unresolved: this is the slow
     // background attempt that will land last.
-    vi.setSystemTime(600);
+    clock.set(600);
     const duringRefreshWindow = await cache.getSession(deps, 'reader', 'acct', '/cwd');
     if ('loginFailed' in duringRefreshWindow) {
       throw new Error('unreachable');
@@ -100,7 +135,7 @@ describe('AzSessionCache — background refresh vs hard-expiry relogin race', ()
     // background refresh above. The refresh's own token call (which would occupy index 3) never
     // registers until its login at index 2 resolves, which this test is deliberately withholding —
     // so this relogin's login/token calls land at indices 3 and 4, not 4 and 5.
-    vi.setSystemTime(800);
+    clock.set(800);
     const hardExpiryPromise = cache.getSession(deps, 'reader', 'acct', '/cwd');
     await waitForCallCount(executor, 4);
     await executor.resolve(3);

--- a/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
+++ b/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
@@ -1,0 +1,133 @@
+import type { PassThrough } from 'node:stream';
+import { rm } from 'node:fs/promises';
+import type { CommandSpec, ExitStatus, IExecutor, SpawnOpts } from '@shellicar/exec-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AzSessionCache } from '../src/Az/AzSessionCache';
+import type { AzDeps } from '../src/Az/runAz';
+
+// Resolves each `run()` call on demand rather than immediately, so a test can control the
+// order two concurrent `az login` sequences complete in.
+class ControllableExecutor implements IExecutor {
+  public readonly calls: Array<{ cmd: CommandSpec; opts?: SpawnOpts }> = [];
+  readonly #pending: Array<(status: ExitStatus) => void> = [];
+
+  public run(cmd: CommandSpec, opts?: SpawnOpts): Promise<ExitStatus> {
+    return new Promise((resolve) => {
+      this.calls.push({ cmd, opts });
+      this.#pending.push(resolve);
+    });
+  }
+
+  public async resolve(index: number, stdout = ''): Promise<void> {
+    const call = this.calls[index];
+    const out = call?.opts?.stdout as PassThrough | undefined;
+    if (out != null) {
+      await new Promise<void>((res) => {
+        out.on('end', res);
+        out.end(stdout);
+      });
+    }
+    call?.opts?.stderr?.end();
+    this.#pending[index]?.({ exitCode: 0, signal: null });
+  }
+}
+
+function makeDeps(executor: IExecutor): AzDeps {
+  return {
+    executor,
+    getCert: () => 'cert-pem',
+    getClientId: () => 'client-id',
+    getTenantId: () => 'tenant-id',
+  };
+}
+
+function tokenJson(expiresAtMs: number): string {
+  return JSON.stringify({ expires_on: Math.floor(expiresAtMs / 1000) });
+}
+
+async function waitForCallCount(executor: ControllableExecutor, n: number): Promise<void> {
+  while (executor.calls.length < n) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe('AzSessionCache — background refresh vs hard-expiry relogin race', () => {
+  const configDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await Promise.all(configDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})));
+  });
+
+  // A background refresh started at the 50% mark is meant to be a non-blocking courtesy: if a
+  // caller crosses hardExpireAt before it finishes, that caller synchronously relogs in and its
+  // session is the one that should be current. AzSessionCache#backgroundRefresh instead lands its
+  // own result with an unconditional `entries.set(...)`, clobbering the newer hard-expiry login if
+  // it finishes after it — so a caller can be served a session that is one full cycle stale even
+  // though a fresher one was already obtained.
+  it('serves the hard-expiry relogin, not a background refresh that lands after it', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const executor = new ControllableExecutor();
+    const deps = makeDeps(executor);
+    const cache = new AzSessionCache();
+
+    // Cold start at t=0: a 1000ms-lifetime token, so refreshAt=500, hardExpireAt=750.
+    vi.setSystemTime(0);
+    const coldPromise = cache.getSession(deps, 'reader', 'acct', '/cwd');
+    await waitForCallCount(executor, 1);
+    await executor.resolve(0);
+    await waitForCallCount(executor, 2);
+    await executor.resolve(1, tokenJson(1000));
+    const sessionA = await coldPromise;
+    if ('loginFailed' in sessionA) {
+      throw new Error('unreachable');
+    }
+    configDirs.push(sessionA.configDir);
+
+    // t=600: past refreshAt (500), before hardExpireAt (750) — starts a background refresh.
+    // Its login/token calls (indices 2 and 3) are deliberately left unresolved: this is the slow
+    // background attempt that will land last.
+    vi.setSystemTime(600);
+    const duringRefreshWindow = await cache.getSession(deps, 'reader', 'acct', '/cwd');
+    if ('loginFailed' in duringRefreshWindow) {
+      throw new Error('unreachable');
+    }
+    // Only the background refresh's login call (index 2) registers yet; its token call (index 3)
+    // won't be issued until that login resolves, which this test deliberately delays.
+    await waitForCallCount(executor, 3);
+
+    // t=800: past hardExpireAt (750) — a synchronous relogin, independent of the still-pending
+    // background refresh above. The refresh's own token call (which would occupy index 3) never
+    // registers until its login at index 2 resolves, which this test is deliberately withholding —
+    // so this relogin's login/token calls land at indices 3 and 4, not 4 and 5.
+    vi.setSystemTime(800);
+    const hardExpiryPromise = cache.getSession(deps, 'reader', 'acct', '/cwd');
+    await waitForCallCount(executor, 4);
+    await executor.resolve(3);
+    await waitForCallCount(executor, 5);
+    await executor.resolve(4, tokenJson(800 + 1000));
+    const sessionC = await hardExpiryPromise;
+    if ('loginFailed' in sessionC) {
+      throw new Error('unreachable');
+    }
+    configDirs.push(sessionC.configDir);
+
+    // Now let the earlier, slower background refresh land, after the hard-expiry relogin already
+    // replaced the cache entry. Its token call only registers once this login resolves, landing at
+    // index 5 (everything up to 4 is already taken by the cold start and the hard-expiry relogin).
+    await executor.resolve(2);
+    await waitForCallCount(executor, 6);
+    await executor.resolve(5, tokenJson(600 + 1000));
+    // Let the background refresh's own .then() run and land its entries.set(...).
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const served = await cache.getSession(deps, 'reader', 'acct', '/cwd');
+    if ('loginFailed' in served) {
+      throw new Error('unreachable');
+    }
+
+    const expected = sessionC.configDir;
+    const actual = served.configDir;
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -224,11 +224,15 @@ export class QueryRunner extends IQueryRunner {
    *    tool_result via `#emitOutcome`: `unavailable` stays silent on the
    *    channel, `rejected` broadcasts. `ready` results are accumulated with their
    *    `run` closures for the second phase.
-   * 2. Execute the `ready` list. If approval is required, all approval
-   *    requests are fired in parallel and the closures are invoked in the
-   *    order the approvals arrive (`Promise.race`). Otherwise the closures
-   *    run sequentially in the model's order. Both paths respect the
-   *    `cancelled` flag between items.
+   * 2. Execute the `ready` list concurrently. If approval is required, every
+   *    approval request is fired in parallel; each tool's `run` is kicked off
+   *    the moment its own approval arrives (`Promise.race` only picks which
+   *    approval to react to next, never gates one tool's execution behind
+   *    another's), and every started run is awaited together at the end.
+   *    Otherwise every ready tool's `run` starts at once via `Promise.all`.
+   *    Both paths share one `toolController`: a cancel aborts every tool
+   *    still running in the batch, exactly as it did when execution was
+   *    sequential — only the concurrency changed, not the cancel contract.
    */
   async #runTools(toolUses: ToolUseResult[], transformToolResult: TransformToolResult | undefined) {
     const requireApproval = this.durableProvider.config.requireToolApproval ?? false;
@@ -275,6 +279,10 @@ export class QueryRunner extends IQueryRunner {
         };
       });
 
+      // Approved runs are started immediately and collected here; they are never awaited one
+      // at a time, so an early approval's tool does not block a later approval from starting.
+      const running: Promise<ToolResultBlock>[] = [];
+
       while (pending.length > 0) {
         if (this.approval.cancelled) {
           break;
@@ -291,23 +299,22 @@ export class QueryRunner extends IQueryRunner {
         }
 
         this.approval.toolRunStarted(toolController);
+        running.push(run(transformToolResult));
+      }
+
+      if (running.length > 0) {
         try {
-          toolResults.push(await run(transformToolResult));
+          toolResults.push(...(await Promise.all(running)));
         } finally {
           this.approval.toolRunFinished();
         }
       }
-    } else {
-      for (const { run } of ready) {
-        if (this.approval.cancelled) {
-          break;
-        }
-        this.approval.toolRunStarted(toolController);
-        try {
-          toolResults.push(await run(transformToolResult));
-        } finally {
-          this.approval.toolRunFinished();
-        }
+    } else if (!this.approval.cancelled && ready.length > 0) {
+      this.approval.toolRunStarted(toolController);
+      try {
+        toolResults.push(...(await Promise.all(ready.map(({ run }) => run(transformToolResult)))));
+      } finally {
+        this.approval.toolRunFinished();
       }
     }
     return toolResults;

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -282,6 +282,13 @@ export class QueryRunner extends IQueryRunner {
       // Approved runs are started immediately and collected here; they are never awaited one
       // at a time, so an early approval's tool does not block a later approval from starting.
       const running: Promise<ToolResultBlock>[] = [];
+      // `toolRunStarted` registers the batch's one shared `toolController` and resets the coordinator's
+      // cancel-escalation state for it. That reset must happen exactly once per batch, not once per
+      // approved tool: since every tool in the batch shares the same controller, calling it again for
+      // a later approval while an earlier tool is still running would clear `#toolCancelled` on an
+      // already-cancelled controller, silently downgrading what should be a second (escalating) cancel
+      // back into a no-op abort of a dead controller. `batchStarted` guards against that.
+      let batchStarted = false;
 
       while (pending.length > 0) {
         if (this.approval.cancelled) {
@@ -298,7 +305,10 @@ export class QueryRunner extends IQueryRunner {
           continue;
         }
 
-        this.approval.toolRunStarted(toolController);
+        if (!batchStarted) {
+          this.approval.toolRunStarted(toolController);
+          batchStarted = true;
+        }
         running.push(run(transformToolResult));
       }
 

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -159,6 +159,10 @@ function toolUseResult(id: string, name: string, input: Record<string, unknown> 
   return { blocks: [{ type: 'tool_use', id, name, input }], stopReason: 'tool_use', contextManagementOccurred: false, usage: zeroUsage() };
 }
 
+function multiToolUseResult(uses: Array<{ id: string; name: string; input?: Record<string, unknown> }>): MessageStreamResult {
+  return { blocks: uses.map((u) => ({ type: 'tool_use' as const, id: u.id, name: u.name, input: u.input ?? {} })), stopReason: 'tool_use', contextManagementOccurred: false, usage: zeroUsage() };
+}
+
 // stop_reason tool_use but only a text block — the garbled-tool-use condition.
 function garbledResult(text = 'let me check'): MessageStreamResult {
   return { blocks: [{ type: 'text', text }], stopReason: 'tool_use', contextManagementOccurred: false, usage: zeroUsage() };
@@ -212,6 +216,32 @@ function makeCancellableTool(name: string): { tool: AnyToolDefinition; started: 
       return await new Promise<{ textContent: unknown }>((_resolve, reject) => {
         signal?.addEventListener('abort', () => reject(new ToolCancelledError()));
       });
+    }) as AnyToolDefinition['handler'],
+  };
+  return { tool, started };
+}
+
+// A tool that records the moment it starts and then waits on a shared, externally-resolved
+// gate before returning. Two such tools in one batch prove concurrency: both `started` promises
+// resolve before the gate is released, which is only possible if both handlers are in flight at
+// once. Under sequential dispatch, the second tool never starts until the first (still blocked on
+// the ungated `gate`) returns, so its `started` promise hangs and the test above it times out.
+function makeGatedTool(name: string, gate: Promise<void>): { tool: AnyToolDefinition; started: Promise<void> } {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const schema = z.object({ value: z.string() });
+  const tool: AnyToolDefinition = {
+    name,
+    description: `Tool ${name}`,
+    input_schema: schema,
+    output_schema: z.unknown(),
+    input_examples: [{ value: 'example' }],
+    handler: (async (input: { value: string }) => {
+      markStarted();
+      await gate;
+      return { textContent: `got: ${input.value}` };
     }) as AnyToolDefinition['handler'],
   };
   return { tool, started };
@@ -723,6 +753,90 @@ describe('QueryRunner — tool cancellation', () => {
     await runPromise;
     const actual = w.turnRunner.calls.length;
     expect(actual).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent tool execution. Proves #runTools fires every ready tool in a
+// batch at once instead of awaiting them one at a time.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — concurrent tool execution', () => {
+  it('starts both tools before either is released', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const a = makeGatedTool('a', gate);
+    const b = makeGatedTool('b', gate);
+    const w = makeWiring([multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')], [a.tool, b.tool]);
+
+    const runPromise = w.queryRunner.run(makeInput());
+    // Deterministic, not a timing race: under sequential dispatch this can never resolve
+    // without `release()`, because `b` cannot start until `a` returns, and `a` cannot return
+    // until the gate opens — which this test has not done yet. A regression here times out
+    // the test rather than passing it.
+    await Promise.all([a.started, b.started]);
+    release();
+    await runPromise;
+
+    const actual = getTextBlock(findToolResult(w.conversation))?.text;
+    expect(actual).toBeDefined();
+  });
+
+  it('runs both tools to completion once released', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const a = makeGatedTool('a', gate);
+    const b = makeGatedTool('b', gate);
+    const w = makeWiring([multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')], [a.tool, b.tool]);
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await Promise.all([a.started, b.started]);
+    release();
+    await runPromise;
+
+    const actual = w.conversation.messages.some((m) => {
+      const blocks = Array.isArray(m.content) ? m.content : [];
+      return blocks.some((block) => typeof block === 'object' && 'type' in block && block.type === 'tool_result' && JSON.stringify(block).includes('got: y'));
+    });
+    expect(actual).toBe(true);
+  });
+
+  it('starts both approved tools before either, gated one, is released', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const a = makeGatedTool('a', gate);
+    const b = makeGatedTool('b', gate);
+    const w = makeWiring(
+      [multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')],
+      [a.tool, b.tool],
+      { requireToolApproval: true },
+    );
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    const requests = w.channel.messages.filter((m): m is Extract<SdkMessage, { type: 'tool_approval_request' }> => m.type === 'tool_approval_request');
+    const requestA = requests.find((r) => r.name === 'a');
+    const requestB = requests.find((r) => r.name === 'b');
+    if (requestA == null || requestB == null) {
+      throw new Error('unreachable');
+    }
+    w.approval.handle({ type: 'tool_approval_response', requestId: requestA.requestId, approved: true });
+    w.approval.handle({ type: 'tool_approval_response', requestId: requestB.requestId, approved: true });
+    // Deterministic: if an approved run were awaited before the next approval's run could
+    // start, `b` would never start (its approval, once granted, still needs `a` to finish
+    // first) — and `a` cannot finish without the release this test hasn't issued yet.
+    await Promise.all([a.started, b.started]);
+    release();
+    await runPromise;
+
+    const actual = w.turnRunner.calls.length;
+    expect(actual).toBe(2);
   });
 });
 

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -865,6 +865,73 @@ describe('QueryRunner — concurrent tool execution', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cancel escalation across concurrent approvals (regression).
+//
+// A second cancel is supposed to escalate to a full query-cancel once a tool is already
+// running (see ApprovalCoordinator.handle). With concurrent execution, `toolRunStarted` is
+// called again for every later approval in the same batch, which resets the coordinator's
+// escalation flag on the still-shared, already-aborted controller — so a second cancel that
+// arrives after a later tool has started is misread as a fresh tool-cancel instead of the
+// query-cancel the user pressed twice for.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — cancel escalation across concurrent approvals (regression)', () => {
+  it('escalates to a full query cancel on the second cancel, even when a later approval started after the first', async () => {
+    let releaseA!: () => void;
+    let releaseB!: () => void;
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const gateB = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    const a = makeGatedTool('a', gateA);
+    const b = makeGatedTool('b', gateB);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+        endTurnResult('done'),
+      ],
+      [a.tool, b.tool],
+      { requireToolApproval: true },
+    );
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    const requests = w.channel.messages.filter((m): m is Extract<SdkMessage, { type: 'tool_approval_request' }> => m.type === 'tool_approval_request');
+    const requestA = requests.find((r) => r.name === 'a');
+    const requestB = requests.find((r) => r.name === 'b');
+    if (requestA == null || requestB == null) {
+      throw new Error('unreachable');
+    }
+
+    // Approve only A; it starts running (gated, so it never returns on its own).
+    w.approval.handle({ type: 'tool_approval_response', requestId: requestA.requestId, approved: true });
+    await a.started;
+
+    // First cancel: a tool is running, so this is interpreted as a tool-cancel, not a query-cancel.
+    w.approval.handle({ type: 'cancel' });
+
+    // Approve B next — it starts under the same batch controller, after the first cancel already fired.
+    w.approval.handle({ type: 'tool_approval_response', requestId: requestB.requestId, approved: true });
+    await b.started;
+
+    // Second cancel: the user pressed cancel again meaning to kill the query outright.
+    w.approval.handle({ type: 'cancel' });
+
+    releaseA();
+    releaseB();
+    await runPromise;
+
+    const actual = w.approval.cancelled;
+    expect(actual).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Account-limit give-up termination (§9)
 // ---------------------------------------------------------------------------
 

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -769,7 +769,16 @@ describe('QueryRunner — concurrent tool execution', () => {
     });
     const a = makeGatedTool('a', gate);
     const b = makeGatedTool('b', gate);
-    const w = makeWiring([multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')], [a.tool, b.tool]);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+        endTurnResult('done'),
+      ],
+      [a.tool, b.tool],
+    );
 
     const runPromise = w.queryRunner.run(makeInput());
     // Deterministic, not a timing race: under sequential dispatch this can never resolve
@@ -791,7 +800,16 @@ describe('QueryRunner — concurrent tool execution', () => {
     });
     const a = makeGatedTool('a', gate);
     const b = makeGatedTool('b', gate);
-    const w = makeWiring([multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')], [a.tool, b.tool]);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+        endTurnResult('done'),
+      ],
+      [a.tool, b.tool],
+    );
 
     const runPromise = w.queryRunner.run(makeInput());
     await Promise.all([a.started, b.started]);
@@ -813,7 +831,13 @@ describe('QueryRunner — concurrent tool execution', () => {
     const a = makeGatedTool('a', gate);
     const b = makeGatedTool('b', gate);
     const w = makeWiring(
-      [multiToolUseResult([{ id: 'tu_1', name: 'a', input: { value: 'x' } }, { id: 'tu_2', name: 'b', input: { value: 'y' } }]), endTurnResult('done')],
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+        endTurnResult('done'),
+      ],
       [a.tool, b.tool],
       { requireToolApproval: true },
     );


### PR DESCRIPTION
## Summary

- Tool calls in a single batch now run concurrently instead of one at a time, so a turn with several tool calls finishes in the time of the slowest one rather than the sum of all of them.
- `az` commands reuse one login across calls instead of re-authenticating every time, cutting repeated az tool calls from seconds to near-instant.
- The az login session is bounded by the token's own lifetime: it refreshes in the background before expiry instead of expiring mid-use.
- Documents a local dev gotcha where rebuilding the native keychain binding needs a CLI restart to take effect.
