### PR TITLE
Raise default tsserver request timeout from 3s to 30s

### DIFF
--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub_PullRequest_AutoMerge takes a required strategy (merge, squash, rebase) when enabling, so it can queue a specific merge method instead of only accepting the repo default
 - Normalise tilde and environment variable paths in EditFile
 - Package now publishes CJS alongside ESM with working sourcemaps
+- Raise the default tsserver per-request timeout from 3s to 30s so a cold spawn's first request (loading the whole program/type graph) doesn't get abandoned as a timeout
 - ReadFile rejects images whose base64 payload exceeds the Anthropic API 5 MB per-image cap
 - Tear down a pipe stage's upstream when its consumer exits, so pipelines like find | head no longer hang
 - The TypeScript tools now read each file fresh from disk, spawning a short-lived tsserver per tool block instead of a session-long server that kept reporting its first snapshot

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -72,3 +72,4 @@
 {"description":"AzureDevOps_PullRequest_* and Az tools resolve org/project/repository from the target repo's own git remote when not given explicitly, and accept an optional cwd so they can target a repo other than the CLI's own working directory","category":"added"}
 {"description":"AzureDevOps_PullRequest_Create always opens as a draft; AzureDevOps_PullRequest_AutoMerge generates its merge commit message from the pull request's own title and description rather than accepting one from the caller","category":"added"}
 {"description":"GitHub_PullRequest_* tools accept an optional cwd so they can target a repo other than the CLI's own working directory","category":"added"}
+{"description":"Raise the default tsserver per-request timeout from 3s to 30s so a cold spawn's first request (loading the whole program/type graph) doesn't get abandoned as a timeout","category":"fixed"}

--- a/packages/claude-sdk-tools/src/typescript/ITsServerOptions.ts
+++ b/packages/claude-sdk-tools/src/typescript/ITsServerOptions.ts
@@ -12,6 +12,11 @@ export abstract class ITsServerOptions {
   public abstract readonly timeoutMs: number;
 }
 
-/** Default per-request timeout: a fresh spawn answers a real query in ~1s, so a
- * couple of seconds is ample headroom without the old 15s POC stall. */
-export const DEFAULT_TSSERVER_TIMEOUT_MS = 3000;
+/** Default per-request timeout. The bridge spawns a fresh tsserver per tool
+ * block, so the first request of every block pays the cold cost of loading
+ * the whole program/type graph — on a real repo that can run well past a few
+ * seconds, not just the ~1s a small fixture answers in. 3s was sized for a
+ * server spawned once at startup and reused; now that it's spawned per block,
+ * that cold load happens on every block's first request, so it needs real
+ * headroom. */
+export const DEFAULT_TSSERVER_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary
- TS tools (diagnostics, hover, references, definition) no longer time out on a cold tsserver spawn's first request against a real-sized project
- Default per-request timeout raised from 3 seconds to 30 seconds