### PR TITLE
ReadFile returns plain text for a successful read

### DIFF
--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark every filesystem-path field on the tool schemas so the SDK normalises it, and drop the per-handler path expansion; DeleteFile and DeleteDirectory now take a files array
 - Merge PreviewEdit and EditFile into a single EditFile tool that validates, writes, and returns a diff in one call, removing the preview/confirm step and its in-memory patch store
 - ReadFile accepts image/* to read any supported image format; the format is detected from file content rather than the declared type
+- ReadFile returns a successful text read as plain path-and-line text instead of a JSON object, matching the Pipe Read stage's output
 - Regex pattern fields now reject a malformed pattern as a schema validation error, naming the cause, before any tool runs
 - Removed the 500KB limit on text file reads
 - replace_text edits are applied as a literal string replace instead of being escaped into a regex

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -73,3 +73,4 @@
 {"description":"AzureDevOps_PullRequest_Create always opens as a draft; AzureDevOps_PullRequest_AutoMerge generates its merge commit message from the pull request's own title and description rather than accepting one from the caller","category":"added"}
 {"description":"GitHub_PullRequest_* tools accept an optional cwd so they can target a repo other than the CLI's own working directory","category":"added"}
 {"description":"Raise the default tsserver per-request timeout from 3s to 30s so a cold spawn's first request (loading the whole program/type graph) doesn't get abandoned as a timeout","category":"fixed"}
+{"description":"ReadFile returns a successful text read as plain path-and-line text instead of a JSON object, matching the Pipe Read stage's output","category":"changed"}

--- a/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/ReadFile.ts
@@ -127,12 +127,7 @@ export function createReadFile(fs: IFileSystem, sips: SipsBridge, logger: ILogge
       }
 
       return {
-        textContent: {
-          type: 'content',
-          values: result.lines,
-          totalLines: result.lines.length,
-          path: filePath,
-        } satisfies ReadFileOutput,
+        textContent: [filePath, ...result.lines.map((text, i) => `${i + 1}:${text}`)].join('\n') satisfies ReadFileOutput,
       };
     },
   });

--- a/packages/claude-sdk-tools/src/ReadFile/schema.ts
+++ b/packages/claude-sdk-tools/src/ReadFile/schema.ts
@@ -22,14 +22,11 @@ export const ReadFileBinarySuccessSchema = z.object({
   sizeKb: z.number(),
 });
 
-// ReadFile is the non-pipe single-file read; it carries its own text-content shape rather than the
-// pipe transport (which the redesign removed). path is always set on a successful text read.
-export const ReadFileOutputSuccessSchema = z.object({
-  type: z.literal('content'),
-  values: z.array(z.string()),
-  totalLines: z.number().int(),
-  path: z.string(),
-});
+// ReadFile is the non-pipe single-file read. A successful text read is rendered as plain
+// text (path header line, then one `n:text` line per line \u2014 the same convention as
+// Pipe's Read stage) rather than a JSON object, since a large file makes the JSON escaping
+// and per-line array overhead balloon the output for no benefit to the reader.
+export const ReadFileOutputSuccessSchema = z.string();
 
 export const ReadFileOutputFailureSchema = z.object({
   error: z.literal(true),

--- a/packages/claude-sdk-tools/test/ReadFile.spec.ts
+++ b/packages/claude-sdk-tools/test/ReadFile.spec.ts
@@ -11,34 +11,25 @@ const makeFs = () =>
   });
 
 describe('createReadFile \u2014 success', () => {
-  it('returns lines as content output', async () => {
+  it('returns a path header followed by numbered lines', async () => {
     const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
-    expect(result).toMatchObject({
-      type: 'content',
-      values: ['const a = 1;', 'const b = 2;', 'const c = 3;'],
-      totalLines: 3,
-      path: '/src/hello.ts',
-    });
+    const expected = '/src/hello.ts\n1:const a = 1;\n2:const b = 2;\n3:const c = 3;';
+    expect(result).toBe(expected);
   });
 
-  it('returns a single-element array for a single-line file', async () => {
+  it('returns a single numbered line for a single-line file', async () => {
     const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/single.ts' });
-    expect(result).toMatchObject({ type: 'content', values: ['single line'], totalLines: 1 });
+    const expected = '/src/single.ts\n1:single line';
+    expect(result).toBe(expected);
   });
 
-  it('returns correct totalLines matching values length', async () => {
+  it('echoes the resolved path as the header line', async () => {
     const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
     const result = await call(ReadFile, { path: '/src/hello.ts' });
-    const content = result as { values: string[]; totalLines: number };
-    expect(content.totalLines).toBe(content.values.length);
-  });
-
-  it('echoes the resolved path in the output', async () => {
-    const ReadFile = createReadFile(makeFs(), passthroughSips, noopLogger);
-    const result = await call(ReadFile, { path: '/src/hello.ts' });
-    expect((result as { path: string }).path).toBe('/src/hello.ts');
+    const actual = (result as string).split('\n')[0];
+    expect(actual).toBe('/src/hello.ts');
   });
 });
 
@@ -170,14 +161,13 @@ describe('createReadFile — binary files (mimeType)', () => {
     expect(actual).toBe(expected);
   });
 
-  it('textContent type is content for text/plain', async () => {
+  it('textContent is plain text for text/plain', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'const a = 1;' });
     const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts', mimeType: 'text/plain' });
 
-    const expected = 'content';
-    const actual = (result.textContent as any).type;
-    expect(actual).toBe(expected);
+    const expected = '/src/hello.ts\n1:const a = 1;';
+    expect(result.textContent).toBe(expected);
   });
 
   it('omits attachments for text/plain', async () => {
@@ -190,14 +180,13 @@ describe('createReadFile — binary files (mimeType)', () => {
     expect(actual).toBe(expected);
   });
 
-  it('textContent type is content when mimeType defaults', async () => {
+  it('textContent is plain text when mimeType defaults', async () => {
     const fs = new MemoryFileSystem({ '/src/hello.ts': 'line1' });
     const ReadFile = createReadFile(fs, passthroughSips, noopLogger);
     const result = await callFull(ReadFile, { path: '/src/hello.ts' });
 
-    const expected = 'content';
-    const actual = (result.textContent as any).type;
-    expect(actual).toBe(expected);
+    const expected = '/src/hello.ts\n1:line1';
+    expect(result.textContent).toBe(expected);
   });
 
   it('omits attachments when mimeType defaults', async () => {


### PR DESCRIPTION
## Summary
- A successful text read now returns plain path-and-line text instead of a JSON object, matching the Pipe `Read` stage's output
- Binary metadata and error messages are unchanged (small, single-object payloads where the JSON shape doesn't cost anything)