### PR TITLE
Persist the clock stamp as leading context on the user's own turn

### DIFF
--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bracket the whole tool-handling method as tool time, so the tools clock includes the approval wait
 - Calculate costs for Opus 4.7
 - Carry structured API error detail (status, type, message) to consumers, not only the status
-- Clock stamp is now written into history as a leading block of the user's own message, instead of an ephemeral trailing reminder on every turn including tool round-trips
+- Clock stamp now leads the user's message in history instead of trailing every request
 - defineTool validates a tool's name against Anthropic's required pattern (letters, digits, underscore, hyphen; 1-128 characters) at definition time instead of surfacing as an API error on first use
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
 - Fix context window size for Sonnet 4 (200k to 1M)

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bracket the whole tool-handling method as tool time, so the tools clock includes the approval wait
 - Calculate costs for Opus 4.7
 - Carry structured API error detail (status, type, message) to consumers, not only the status
+- Clock stamp is now written into history as a leading block of the user's own message, instead of an ephemeral trailing reminder on every turn including tool round-trips
 - defineTool validates a tool's name against Anthropic's required pattern (letters, digits, underscore, hyphen; 1-128 characters) at definition time instead of surfacing as an API error on first use
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
 - Fix context window size for Sonnet 4 (200k to 1M)

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -52,5 +52,5 @@
 {"description":"defineTool validates a tool's name against Anthropic's required pattern (letters, digits, underscore, hyphen; 1-128 characters) at definition time instead of surfacing as an API error on first use","category":"fixed"}
 {"description":"Publish defineTool, ToolCancelledError, ToolRefusedError, and pathSchema as their own subpath exports, so a consumer can import just one without pulling in the whole SDK module graph","category":"added"}
 {"description":"Add Conversation.healDanglingToolUse(): self-heal a conversation whose last message is an assistant tool_use with no matching tool_result (a prior process died between the two) by appending an honest synthetic failure result for each dangling call","category":"added"}
-
 {"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
+{"description":"Clock stamp is now written into history as a leading block of the user's own message, instead of an ephemeral trailing reminder on every turn including tool round-trips","category":"fixed"}

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -53,4 +53,4 @@
 {"description":"Publish defineTool, ToolCancelledError, ToolRefusedError, and pathSchema as their own subpath exports, so a consumer can import just one without pulling in the whole SDK module graph","category":"added"}
 {"description":"Add Conversation.healDanglingToolUse(): self-heal a conversation whose last message is an assistant tool_use with no matching tool_result (a prior process died between the two) by appending an honest synthetic failure result for each dangling call","category":"added"}
 {"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
-{"description":"Clock stamp is now written into history as a leading block of the user's own message, instead of an ephemeral trailing reminder on every turn including tool round-trips","category":"fixed"}
+{"description":"Clock stamp now leads the user's message in history instead of trailing every request","category":"fixed"}

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -111,6 +111,24 @@ export class Conversation {
   }
 
   /**
+   * Prepend content blocks to the last stored message's content, converting a string body to a
+   * text block first. Mutates the actual stored item, so this is a persisted write into history
+   * (unlike `cloneForRequest`'s caller-owned clone, which never touches stored state). No-op if
+   * there is no last message or `blocks` is empty.
+   */
+  public prependToLast(blocks: Anthropic.Beta.Messages.BetaContentBlockParam[]): void {
+    if (blocks.length === 0) {
+      return;
+    }
+    const last = this.#items.at(-1);
+    if (last == null) {
+      return;
+    }
+    const content = Array.isArray(last.msg.content) ? last.msg.content : [{ type: 'text' as const, text: last.msg.content as string }];
+    last.msg = { ...last.msg, content: [...blocks, ...content] };
+  }
+
+  /**
    * Remove the last message tagged with `id`.
    * Returns `true` if found and removed, `false` if no message with that id exists.
    */

--- a/packages/claude-sdk/src/private/RequestBuilder.ts
+++ b/packages/claude-sdk/src/private/RequestBuilder.ts
@@ -23,9 +23,10 @@ export type RequestBuilderOptions = {
    * the end of that run. */
   cachedReminders?: string[];
   /** Per-turn ephemeral `<system-reminder>` blocks. Assembled by TurnRunner from the one-shot git
-   * delta (TurnInput.ephemeralReminders) and the per-turn clock stamp (formatClockStamp). A trailing
-   * reminder sits after the cache boundary (uncached); a leading one prepends to the message head.
-   * Not persisted in conversation history. */
+   * delta (TurnInput.ephemeralReminders). A trailing reminder sits after the cache boundary
+   * (uncached); a leading one prepends to the message head. Not persisted in conversation history.
+   * The clock stamp is not one of these: it is written into history directly by
+   * `Conversation.prependToLast`, before the request clone is taken. */
   ephemeralReminders?: SystemReminder[];
   tools: AnyToolDefinition[];
   /** Server-side tools prepended to the wire tools array before client tools. */

--- a/packages/claude-sdk/src/private/TurnRunner.ts
+++ b/packages/claude-sdk/src/private/TurnRunner.ts
@@ -10,7 +10,7 @@ import type { ContentBlock, DurableConfig, SystemReminder, TurnInput } from '../
 import { AccountLimitListener, IRequestClockListener, StreamInterruptListener } from '../public/types';
 import { ACCOUNT_LIMIT_BUDGET_MS, calculateBackoffDelay, isAccountLimit, isRetryable, MAX_RETRIES, RETRY_AFTER_CAP_MS, STREAM_INTERRUPT_DELAY_MS, STREAM_INTERRUPT_MAX_RETRIES } from './backoff';
 import type { Conversation } from './Conversation';
-import { ensureClaudeMdReminders } from './claudeMdReminders';
+import { buildReminderBlocks, ensureClaudeMdReminders } from './claudeMdReminders';
 import { formatClockStamp } from './clockStamp';
 import { AccountLimitStoppedError, StreamInterruptedError } from './http/errors';
 import { IMessageStreamer } from './MessageStreamer';
@@ -66,6 +66,19 @@ export class TurnRunner extends ITurnRunner {
 
   public async run(conversation: Conversation, durable: DurableConfig, turnInput: TurnInput): Promise<MessageStreamResult> {
     const compactEnabled = durable.compact?.enabled ?? false;
+
+    // Write the clock stamp into history as a leading block of the tip message, before taking the
+    // request clone. Persisted, not ephemeral, and leading rather than trailing: it reads as calm
+    // background context instead of the freshest thing in the request, which is what drove the
+    // model to narrate it turn after turn when it sat trailing and un-persisted.
+    // Only on a real ask (human/orchestrator), not an agent-authored tool_result continuation: a
+    // tool loop runs seconds apart, so restamping every round trip would bake near-duplicate
+    // timestamps into history for no orientation value. Missing identity (a legacy conversation)
+    // is treated as a real ask, since there is nothing to say otherwise.
+    if (conversation.items.at(-1)?.identity?.from.kind !== 'agent') {
+      conversation.prependToLast(buildReminderBlocks([formatClockStamp(this.clock)]));
+    }
+
     const messages = conversation.cloneForRequest(compactEnabled);
 
     // The request delta is the conversation tip: the trailing user-role message
@@ -85,11 +98,9 @@ export class TurnRunner extends ITurnRunner {
     // leading blocks) is untouched.
     ensureClaudeMdReminders(messages, durable.cachedReminders);
 
-    // Assemble per-turn ephemeral reminders: any query-supplied ones (e.g. the git delta, first turn
-    // only) then the clock stamp (always). Ephemeral and trailing, so they are re-injected every turn
-    // and never flash out of context on the model's own turns.
+    // Assemble per-turn ephemeral reminders: query-supplied ones only (e.g. the git delta, first
+    // turn only). The clock stamp is handled above, persisted into history instead.
     const ephemeralReminders: SystemReminder[] = [...(turnInput.ephemeralReminders ?? [])];
-    ephemeralReminders.push({ text: formatClockStamp(this.clock), persisted: false, position: 'trailing' });
 
     const builderOptions: RequestBuilderOptions = {
       model: durable.model,


### PR DESCRIPTION
## Summary
- Time stamp now sits at the front of the user's own message, written into history, instead of trailing every request and prompting Claude to narrate it
- Tool round-trips within a query no longer get their own stamp: only the human/orchestrator turn does