### PR TITLE
Cancelling a running tool now shows immediately, not after a ~500ms delay

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -135,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `--init-config` to include all schema options in generated file
 - Fix `gatherGitSnapshot` crashing when any git command fails (e.g. `rev-parse HEAD` in a repo with no commits)
 - Fix `GitStateMonitor` reporting the agent's own file edits and commits as human activity between turns
+- Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure
 - Fix AgentMessageHandler re-rendering every tool in a batch on every single tool's own state change (each streamed input-JSON delta, resolve, approve/deny, or result), when the Anthropic API only ever streams one tool at a time; ToolObject.render() now caches its own output, invalidated only by its own mutators
 - Fix batch tool approvals: a local Y/N keypress now settles the tool you have selected by its request id, instead of the head of an anonymous queue. Previously one keypress could approve or deny a different tool in the same batch (or two at once)
 - Fix colour loss when syntax-highlighted code scrolls off screen

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -167,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop duplicated content (ghost text) stranding at the wrap boundary in the TUI: the renderer now builds and diffs a cell grid and writes every row at an absolute position with autowrap disabled
 - Stop the CLI freezing on an account-limit retry-after wait; retries are capped, ESC-abortable, and give up with a single account-limit notice
 - Submitting with ctrl+enter now works while command mode is open, instead of requiring it to be closed first
+- Tool status now shows the approval decision (✔/✘) before the tool name and the real execution outcome (✅ ok, ❌ failed, ❗ cancelling, ‼️ cancelled) after it, instead of a single checkmark that only meant the tool was approved
 - Up/down arrows now move between visual rows when input wraps, instead of skipping over the wrapped portion
 - Write session marker and history at turn start so they survive mid-response crashes
 

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add web search and web fetch as built-in server tools
 - Added az.accounts config, a closed set of named Azure accounts (tenant ID plus reader/holder service principal client IDs) the AzCli/EscalatedAzCli and AzureDevOps_PullRequest_* tools select between
 - Added disabledTools config: names of loaded tools to hide from the model and refuse as unavailable, applied live without a restart
+- Added input.escFastPath config: disables the immediate-Escape fast path, for a bare remote shell with no multiplexer in between where a real escape sequence could arrive fragmented. Read live: takes effect on the next keypress without a restart
 - Added ISecrets.adoHolderToken(), read from Keychain (service '@shellicar/credentials', account 'ado-holder'), for the AzureDevOps_PullRequest_* escalated tools
 - Added ISecrets.azCert(account, identity), read from Keychain as az-<account>-<identity>-cert, backing the Az and AzureDevOps tool packages' certificate-based service principal logins
 - Added secrets.azReaderConfigDir and secrets.azHolderConfigDir config fields, selecting the AZURE_CONFIG_DIR profile AzCli and EscalatedAzCli run under

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -153,3 +153,4 @@
 
 {"description":"Added disabledTools config: names of loaded tools to hide from the model and refuse as unavailable, applied live without a restart","category":"added"}
 {"description":"Tool status now shows the approval decision (\u2714/\u2718) before the tool name and the real execution outcome (\u2705 ok, \u274c failed, \u2757 cancelling, \u203c\ufe0f cancelled) after it, instead of a single checkmark that only meant the tool was approved","category":"fixed"}
+{"description":"Added input.escFastPath config: disables the immediate-Escape fast path, for a bare remote shell with no multiplexer in between where a real escape sequence could arrive fragmented. Read live: takes effect on the next keypress without a restart","category":"added"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -154,3 +154,4 @@
 {"description":"Added disabledTools config: names of loaded tools to hide from the model and refuse as unavailable, applied live without a restart","category":"added"}
 {"description":"Tool status now shows the approval decision (\u2714/\u2718) before the tool name and the real execution outcome (\u2705 ok, \u274c failed, \u2757 cancelling, \u203c\ufe0f cancelled) after it, instead of a single checkmark that only meant the tool was approved","category":"fixed"}
 {"description":"Added input.escFastPath config: disables the immediate-Escape fast path, for a bare remote shell with no multiplexer in between where a real escape sequence could arrive fragmented. Read live: takes effect on the next keypress without a restart","category":"added"}
+{"description":"Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure","category":"fixed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -152,3 +152,4 @@
 {"description":"Fix EditorState's bounded grapheme-boundary scan trusting a candidate landing exactly at its window edge as a real boundary; a grapheme cluster longer than the window (a long combining-mark chain or complex ZWJ emoji sequence) could land the cursor mid-cluster. Now re-verifies with a full-line scan only in that one ambiguous case","category":"fixed"}
 
 {"description":"Added disabledTools config: names of loaded tools to hide from the model and refuse as unavailable, applied live without a restart","category":"added"}
+{"description":"Tool status now shows the approval decision (\u2714/\u2718) before the tool name and the real execution outcome (\u2705 ok, \u274c failed, \u2757 cancelling, \u203c\ufe0f cancelled) after it, instead of a single checkmark that only meant the tool was approved","category":"fixed"}

--- a/apps/claude-sdk-cli/src/ReadLine.ts
+++ b/apps/claude-sdk-cli/src/ReadLine.ts
@@ -7,12 +7,12 @@ import { type KeyAction, setupKeypressHandler } from '@shellicar/claude-core/inp
 export class ReadLine implements Disposable {
   readonly #cleanup: () => void;
 
-  public constructor(onKey: (key: KeyAction) => void) {
+  public constructor(onKey: (key: KeyAction) => void, escFastPathEnabled?: () => boolean) {
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(true);
     }
     process.stdin.resume();
-    this.#cleanup = setupKeypressHandler(onKey);
+    this.#cleanup = setupKeypressHandler(onKey, escFastPathEnabled);
   }
 
   public [Symbol.dispose](): void {

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -303,6 +303,21 @@ const azSchema = z
   .default({ accounts: {} })
   .catch({ accounts: {} });
 
+const inputSchema = z
+  .object({
+    escFastPath: z
+      .boolean()
+      .optional()
+      .default(true)
+      .catch(true)
+      .describe(
+        'A stdin chunk containing only the ESC byte is treated as an immediate Escape keypress, skipping readline\'s ~500ms wait to see whether a CSI/SS3 sequence follows. Safe when the terminal writes each escape sequence as one atomic chunk (the normal case, including through tmux). Disable if input arrives fragmented (e.g. a bare remote shell over a lossy link with no multiplexer in between), where a split arrow-key/Alt-key sequence could otherwise be misread as a bare Escape. Read live: takes effect on the next keypress without a restart.',
+      ),
+  })
+  .optional()
+  .default({ escFastPath: true })
+  .catch({ escFastPath: true });
+
 const natsSchema = z
   .object({
     enabled: z.boolean().optional().default(false).catch(false).describe('Participate on NATS: serve say/cancel, raise/answer approvals, and speak the agent concern (ready/pulse/attached/service/drain/chdir). Disabled (default) has zero effect'),
@@ -334,6 +349,7 @@ export const sdkConfigSchema = z
     serverTools: serverToolsSchema,
     hooks: hooksSchema.describe('Hook configuration'),
     tools: toolsSchema.describe('Execution tool selection'),
+    input: inputSchema.describe('Raw keyboard input handling configuration'),
     disabledTools: z.array(z.string()).optional().default([]).catch([]).describe('Names of loaded tools to hide from the model and refuse as unavailable. Read live: takes effect on the next turn without a restart.'),
     statusBar: statusBarSchema.describe('Status bar configuration'),
     permissions: permissionsSchema.describe('Tool approval permission matrix'),

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -311,7 +311,7 @@ const inputSchema = z
       .default(true)
       .catch(true)
       .describe(
-        'A stdin chunk containing only the ESC byte is treated as an immediate Escape keypress, skipping readline\'s ~500ms wait to see whether a CSI/SS3 sequence follows. Safe when the terminal writes each escape sequence as one atomic chunk (the normal case, including through tmux). Disable if input arrives fragmented (e.g. a bare remote shell over a lossy link with no multiplexer in between), where a split arrow-key/Alt-key sequence could otherwise be misread as a bare Escape. Read live: takes effect on the next keypress without a restart.',
+        "A stdin chunk containing only the ESC byte is treated as an immediate Escape keypress, skipping readline's ~500ms wait to see whether a CSI/SS3 sequence follows. Safe when the terminal writes each escape sequence as one atomic chunk (the normal case, including through tmux). Disable if input arrives fragmented (e.g. a bare remote shell over a lossy link with no multiplexer in between), where a split arrow-key/Alt-key sequence could otherwise be misread as a bare Escape. Read live: takes effect on the next keypress without a restart.",
       ),
   })
   .optional()

--- a/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/AgentMessageHandler.ts
@@ -319,6 +319,15 @@ export class AgentMessageHandler {
           if (line !== null) {
             obj.setResultLine(line);
           }
+          if (obj.kind === 'client') {
+            if (msg.cancelled) {
+              obj.cancel();
+            } else if (msg.isError) {
+              obj.fail();
+            } else {
+              obj.succeed();
+            }
+          }
         }
         // emit drives #redrawTools
         break;
@@ -372,6 +381,14 @@ export class AgentMessageHandler {
         // Error during tool dispatch — no active block at this point, appendStreaming
         // opens a notice block so the error lands visibly without a new tools block.
         this.conversation.appendStreaming(`${msg.name} error\n\`\`\`json\n${JSON.stringify(msg.input, null, 2)}\n\`\`\`\n\n${msg.error}\n`);
+        break;
+      case 'tool_cancelling':
+        // ESC aborted the batch's shared controller; every tool still running (not yet
+        // resolved to a terminal phase) shows the cancelling glyph until its own
+        // tool_result lands and moves it to 'cancelled'.
+        for (const id of this.#toolOrder) {
+          this.#toolObjects.get(id)?.cancelling();
+        }
         break;
       case 'message_usage': {
         // The API reports usage in frames across a turn: input + cache land on message_start, output at

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -408,6 +408,8 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
         convChanges.closeQuery(session.id, cancelledQueryId, 'cancelled');
       }
       currentAbortController.abort();
+    } else if (outcome === 'tool_cancel') {
+      sdkChannel.send({ type: 'tool_cancelling' });
     }
   });
 

--- a/apps/claude-sdk-cli/src/model/ToolObject.ts
+++ b/apps/claude-sdk-cli/src/model/ToolObject.ts
@@ -1,12 +1,12 @@
 import EventEmitter from 'node:events';
+import { GREEN, RED, RESET } from '@shellicar/claude-core/ansi';
 
 type ToolObjectEvents = { change: [] };
 
 /**
  * Display state for a single tool use — server or client — within a response.
  *
- * Phase progression:
- *   client: streaming → pending → approved | denied | error
+ *   client: streaming → pending → denied | running → cancelling → cancelled | ok | failed
  *   server: streaming → pending → done
  *
  * Emits `change` on every state mutation so subscribers can redraw without
@@ -17,9 +17,13 @@ export type ToolKind = 'client' | 'server';
 export type ToolPhase =
   | 'streaming' // receiving input deltas
   | 'pending' // client: input complete, resolved view shown, awaiting approval; server: awaiting result
-  | 'approved' // client: user approved ✅
-  | 'denied' // client: user denied ❌
-  | 'error' // client: handler error 💥
+  | 'denied' // client: user denied ✘
+  | 'running' // client: user approved ✔, execution in flight
+  | 'cancelling' // client: ESC requested, waiting for the handler to unwind
+  | 'cancelled' // client: execution aborted ✔ ‼️
+  | 'ok' // client: execution succeeded ✔ ✅
+  | 'failed' // client: execution errored ✔ ❌
+  | 'error' // pre-run failure (lookup miss, exception before a handler ran) 💥
   | 'done'; // server: result received ✅
 
 /** Display snapshot of a tool use for the history view. Built by toEntry(). */
@@ -78,9 +82,39 @@ export class ToolObject {
     this.#dirty = true;
     this.#emitter.emit('change');
   }
-
   public approve(): void {
-    this.#phase = 'approved';
+    this.#phase = 'running';
+    this.#dirty = true;
+    this.#emitter.emit('change');
+  }
+
+  /** ESC requested while running; the handler has not yet unwound. */
+  public cancelling(): void {
+    if (this.#phase !== 'running') {
+      return;
+    }
+    this.#phase = 'cancelling';
+    this.#dirty = true;
+    this.#emitter.emit('change');
+  }
+
+  /** Terminal: the handler unwound on cancellation (ToolCancelledError). */
+  public cancel(): void {
+    this.#phase = 'cancelled';
+    this.#dirty = true;
+    this.#emitter.emit('change');
+  }
+
+  /** Terminal: the tool_result arrived clean. */
+  public succeed(): void {
+    this.#phase = 'ok';
+    this.#dirty = true;
+    this.#emitter.emit('change');
+  }
+
+  /** Terminal: the tool_result arrived with isError, not a cancel. */
+  public fail(): void {
+    this.#phase = 'failed';
     this.#dirty = true;
     this.#emitter.emit('change');
   }
@@ -155,12 +189,24 @@ export class ToolObject {
             `🌐 ${this.#resolvedView!}\n`
           : // biome-ignore lint/style/noNonNullAssertion: pending is only reached via resolve()
             `${this.#resolvedView!}\n`;
-      case 'approved':
-        // biome-ignore lint/style/noNonNullAssertion: approved is only reached after resolve()
-        return `${this.#resolvedView!} ✅${suffix}\n`;
+      case 'running':
+        // biome-ignore lint/style/noNonNullAssertion: running is only reached after resolve()
+        return `${GREEN}\u2714${RESET} ${this.#resolvedView!}\n`;
+      case 'cancelling':
+        // biome-ignore lint/style/noNonNullAssertion: cancelling is only reached after resolve()
+        return `${GREEN}\u2714${RESET} ${this.#resolvedView!} \u2757\n`;
+      case 'cancelled':
+        // biome-ignore lint/style/noNonNullAssertion: cancelled is only reached after resolve()
+        return `${GREEN}\u2714${RESET} ${this.#resolvedView!} \u203c\ufe0f${suffix}\n`;
+      case 'ok':
+        // biome-ignore lint/style/noNonNullAssertion: ok is only reached after resolve()
+        return `${GREEN}\u2714${RESET} ${this.#resolvedView!} \u2705${suffix}\n`;
+      case 'failed':
+        // biome-ignore lint/style/noNonNullAssertion: failed is only reached after resolve()
+        return `${GREEN}\u2714${RESET} ${this.#resolvedView!} \u274c${suffix}\n`;
       case 'denied':
         // biome-ignore lint/style/noNonNullAssertion: denied is only reached after resolve()
-        return `${this.#resolvedView!} ❌\n`;
+        return `${RED}\u2718${RESET} ${this.#resolvedView!}\n`;
       case 'error':
         return `${this.#resolvedView ?? this.name} 💥\n`;
       case 'done':

--- a/apps/claude-sdk-cli/src/model/ToolObject.ts
+++ b/apps/claude-sdk-cli/src/model/ToolObject.ts
@@ -100,6 +100,9 @@ export class ToolObject {
 
   /** Terminal: the handler unwound on cancellation (ToolCancelledError). */
   public cancel(): void {
+    if (this.#phase === 'denied') {
+      return;
+    }
     this.#phase = 'cancelled';
     this.#dirty = true;
     this.#emitter.emit('change');
@@ -107,13 +110,21 @@ export class ToolObject {
 
   /** Terminal: the tool_result arrived clean. */
   public succeed(): void {
+    if (this.#phase === 'denied') {
+      return;
+    }
     this.#phase = 'ok';
     this.#dirty = true;
     this.#emitter.emit('change');
   }
 
-  /** Terminal: the tool_result arrived with isError, not a cancel. */
+  /** Terminal: the tool_result arrived with isError, not a cancel. QueryRunner sends this tool_result
+   * for a denial too (the model needs to see the rejection), so a denied tool must stay denied rather
+   * than being read as an execution failure. */
   public fail(): void {
+    if (this.#phase === 'denied') {
+      return;
+    }
     this.#phase = 'failed';
     this.#dirty = true;
     this.#emitter.emit('change');

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -413,7 +413,11 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
   services.register(TerminalInput).to(TerminalInput);
   services.register(ReadLine).to(ReadLine, (x) => {
     const input = x.resolve(TerminalInput);
-    return new ReadLine((key) => input.handle(key));
+    const loader = x.resolve(ConfigLoader);
+    return new ReadLine(
+      (key) => input.handle(key),
+      () => loader.config.input.escFastPath,
+    );
   });
   services.register(Flasher).to(Flasher, (x) => new Flasher(x.resolve(ToolApprovalState)));
 

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { GREEN, RESET } from '@shellicar/claude-core/ansi';
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -373,7 +374,7 @@ describe('AgentMessageHandler — tool execution split', () => {
     streamTool(handler, 'toolu_01', 'ReadFile');
     handler.handle(makeUsage(1000));
     handler.handle({ type: 'tool_exec_start' });
-    handler.handle({ type: 'tool_result', id: 'toolu_01', content: 'ok', isError: false });
+    handler.handle({ type: 'tool_result', id: 'toolu_01', content: 'ok', isError: false, cancelled: false });
     handler.handle({ type: 'tool_exec_end' });
     const expected = ['tools', 'execution'];
     const actual = conversationState.sealedBlocks.filter((b) => b.type === 'tools' || b.type === 'execution').map((b) => b.type);
@@ -738,7 +739,7 @@ describe('AgentMessageHandler — tool_approval_request', () => {
     streamTool(handler, 'toolu_01', 'Find');
     handler.handle({ type: 'tool_approval_request', requestId: 'toolu_01', name: 'Find', input: {} });
     const expected = true;
-    const actual = conversationState.activeBlock?.content.includes('\u2705') ?? false;
+    const actual = conversationState.activeBlock?.content.includes('\u2714') ?? false;
     expect(actual).toBe(expected);
   });
 
@@ -753,7 +754,7 @@ describe('AgentMessageHandler — tool_approval_request', () => {
     toolApprovalState.resolveApproval('toolu_01', true);
     await flush();
     const expected = true;
-    const actual = conversationState.activeBlock?.content.includes('\u2705') ?? false;
+    const actual = conversationState.activeBlock?.content.includes('\u2714') ?? false;
     expect(actual).toBe(expected);
   });
 
@@ -768,7 +769,7 @@ describe('AgentMessageHandler — tool_approval_request', () => {
     toolApprovalState.resolveApproval('toolu_01', false);
     await flush();
     const expected = true;
-    const actual = conversationState.activeBlock?.content.includes('\u274C') ?? false;
+    const actual = conversationState.activeBlock?.content.includes('\u2718') ?? false;
     expect(actual).toBe(expected);
   });
 
@@ -798,7 +799,7 @@ describe('AgentMessageHandler — tool_approval_request', () => {
     streamTool(handler, 'toolu_02', 'ReadFile', {}, false); // same batch
     handler.handle({ type: 'tool_approval_request', requestId: 'toolu_01', name: 'Find', input: {} });
     handler.handle({ type: 'tool_approval_request', requestId: 'toolu_02', name: 'ReadFile', input: {} });
-    const expected = 'Find \u2705\nReadFile \u2705\n';
+    const expected = `${GREEN}\u2714${RESET} Find\n${GREEN}\u2714${RESET} ReadFile\n`;
     const actual = conversationState.activeBlock?.content ?? '';
     expect(actual).toBe(expected);
   });
@@ -1089,7 +1090,7 @@ describe('AgentMessageHandler — tool-data capture', () => {
     handler.handle({ type: 'tool_batch_start' });
     handler.handle({ type: 'tool_use_start', id: 't1', name: 'ReadFile' });
     handler.handle({ type: 'tool_use_input_stop', id: 't1', input: { path: 'a.ts' } });
-    handler.handle({ type: 'tool_result', id: 't1', content: 'file contents', isError: false });
+    handler.handle({ type: 'tool_result', id: 't1', content: 'file contents', isError: false, cancelled: false });
     const expected = 'file contents';
     const actual = toolsBlockEntries(conversationState)[0]?.output;
     expect(actual).toBe(expected);
@@ -1107,25 +1108,30 @@ describe('AgentMessageHandler — tool-data capture', () => {
   });
 });
 
-describe('AgentMessageHandler — Primary tools content unchanged', () => {
-  // Output capture must not alter the content string Primary renders. Drive the
-  // identical sequence with and without the tool_result (output) event and
-  // assert the tools-block content string is byte-identical; only the entries
-  // (which Primary never reads) differ.
+describe('AgentMessageHandler — tool_result settles the outcome glyph', () => {
+  // Before the outcome glyph existed, tool_result only recorded output/resultLine and left the
+  // rendered phase (and so the content string) untouched. Now it is the one signal that moves a
+  // client tool from 'running' to its terminal outcome, so the content is expected to change.
   function driveToContent(withResult: boolean): string {
     const { handler, conversationState } = makeHandler();
     handler.handle({ type: 'tool_batch_start' });
     handler.handle({ type: 'tool_use_start', id: 't1', name: 'ReadFile' });
     handler.handle({ type: 'tool_use_input_stop', id: 't1', input: { path: 'a.ts' } });
     if (withResult) {
-      handler.handle({ type: 'tool_result', id: 't1', content: 'file contents', isError: false });
+      handler.handle({ type: 'tool_result', id: 't1', content: 'file contents', isError: false, cancelled: false });
     }
     return toolsBlockContent(conversationState);
   }
 
-  it('produces identical content with and without the output event', () => {
-    const expected = driveToContent(false);
+  it('renders the ok glyph once tool_result arrives clean', () => {
+    const expected = `${GREEN}✔${RESET} ReadFile ✅\n`;
     const actual = driveToContent(true);
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves the tool in its resolved (pending) view before tool_result arrives', () => {
+    const expected = 'ReadFile\n';
+    const actual = driveToContent(false);
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -246,7 +246,7 @@ describe('HistoryView — execution block', () => {
       {
         type: 'execution',
         content: 'exec lines',
-        tools: [{ name: 'DeleteFile', kind: 'client', input: { path: 'x.txt' }, output: 'deleted', phase: 'approved' }],
+        tools: [{ name: 'DeleteFile', kind: 'client', input: { path: 'x.txt' }, output: 'deleted', phase: 'ok' }],
       },
     ]);
     model.historyViewState.enterAtLatest(model.conversationState.sealedBlocks.length);

--- a/apps/claude-sdk-cli/test/ToolObject.spec.ts
+++ b/apps/claude-sdk-cli/test/ToolObject.spec.ts
@@ -1,3 +1,4 @@
+import { GREEN, RED, RESET } from '@shellicar/claude-core/ansi';
 import { describe, expect, it } from 'vitest';
 import { ToolObject } from '../src/model/ToolObject.js';
 
@@ -18,11 +19,60 @@ describe('ToolObject — render', () => {
     expect(actual).toBe(expected);
   });
 
-  it('renders the approved phase with a checkmark suffix', () => {
+  it('renders the running phase with a leading approval checkmark', () => {
     const tool = new ToolObject('t1', 'client', 'ReadFile');
     tool.resolve('ReadFile(a.ts)');
     tool.approve();
-    const expected = 'ReadFile(a.ts) ✅\n';
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts)\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the ok phase with a leading checkmark and a trailing success glyph', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.approve();
+    tool.succeed();
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts) ✅\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the cancelling phase with a leading checkmark and a red exclamation', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.approve();
+    tool.cancelling();
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts) ❗\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the cancelled phase with a leading checkmark and a double red exclamation', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.approve();
+    tool.cancel();
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts) ‼️\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the failed phase with a leading checkmark and a cross', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.approve();
+    tool.fail();
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts) ❌\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the denied phase with a leading cross', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.deny();
+    const expected = `${RED}✘${RESET} ReadFile(a.ts)\n`;
     const actual = tool.render();
     expect(actual).toBe(expected);
   });
@@ -70,7 +120,7 @@ describe('ToolObject — render caching', () => {
     tool.resolve('ReadFile(a.ts)');
     tool.render();
     tool.approve();
-    const expected = 'ReadFile(a.ts) ✅\n';
+    const expected = `${GREEN}✔${RESET} ReadFile(a.ts)\n`;
     const actual = tool.render();
     expect(actual).toBe(expected);
   });

--- a/apps/claude-sdk-cli/test/ToolObject.spec.ts
+++ b/apps/claude-sdk-cli/test/ToolObject.spec.ts
@@ -76,6 +76,16 @@ describe('ToolObject — render', () => {
     const actual = tool.render();
     expect(actual).toBe(expected);
   });
+
+  it('stays denied when a trailing tool_result still calls fail() (QueryRunner sends one for a rejected tool)', () => {
+    const tool = new ToolObject('t1', 'client', 'ReadFile');
+    tool.resolve('ReadFile(a.ts)');
+    tool.deny();
+    tool.fail();
+    const expected = `${RED}✘${RESET} ReadFile(a.ts)\n`;
+    const actual = tool.render();
+    expect(actual).toBe(expected);
+  });
 });
 
 /**

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -27,6 +27,7 @@ describe('sdkConfigSchema', () => {
         },
         hooks: { approvalNotify: null },
         tools: { exec: false, execV2: false, execV3: true, blockedCommands: [] },
+        input: { escFastPath: true },
         disabledTools: [],
         statusBar: { showConversationId: true },
         permissions: {
@@ -258,6 +259,29 @@ describe('sdkConfigSchema', () => {
       const actual = config.disabledTools;
       const expected: string[] = [];
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('input.escFastPath', () => {
+    it('defaults to true', () => {
+      const config = parse({});
+      const actual = config.input.escFastPath;
+      const expected = true;
+      expect(actual).toBe(expected);
+    });
+
+    it('overrides escFastPath', () => {
+      const config = parse({ input: { escFastPath: false } });
+      const actual = config.input.escFastPath;
+      const expected = false;
+      expect(actual).toBe(expected);
+    });
+
+    it('falls back to true on wrong type', () => {
+      const config = parse({ input: { escFastPath: 'yes' } });
+      const actual = config.input.escFastPath;
+      const expected = true;
+      expect(actual).toBe(expected);
     });
   });
 

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a perceived ~500ms lag on every Escape keypress: a raw stdin chunk containing only the ESC byte is now emitted immediately as an escape KeyAction instead of waiting on readline's internal CSI-sequence disambiguation timeout
 - Fix absent-file and inode-swap defects in config file watching
 - Package now publishes CJS alongside ESM with working sourcemaps
 - Re-establish ANSI colour state on wrapped continuation lines

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adopt core-di-lite property injection: config loading splits into a pure read, a holder, and a watch handle with no load or start step, and the shared provider and contract abstractions live here for every package to resolve against
 - File discovery returns records carrying type, size, and symlink target instead of bare path strings
+- setupKeypressHandler accepts an optional escFastPathEnabled callback, checked live before taking the lone-ESC fast path, so a consumer can disable it (e.g. over a fragmented remote connection) without a restart
 - Update runtime and build dependencies
 - Updated patch and minor dependencies
 - Updated patch dependencies

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -18,3 +18,4 @@
 {"description":"Add a BLUE foreground ANSI colour constant","category":"added"}
 {"description":"Add the conversation-history model: store types, read/write interfaces, and near-duplicate detection (shingle, minhash, LSH) for the sweep","category":"added"}
 {"description":"Add arch and createWriteStream operations to the IFileSystem contract","category":"added"}
+{"description":"Fix a perceived ~500ms lag on every Escape keypress: a raw stdin chunk containing only the ESC byte is now emitted immediately as an escape KeyAction instead of waiting on readline's internal CSI-sequence disambiguation timeout","category":"fixed"}

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -19,3 +19,4 @@
 {"description":"Add the conversation-history model: store types, read/write interfaces, and near-duplicate detection (shingle, minhash, LSH) for the sweep","category":"added"}
 {"description":"Add arch and createWriteStream operations to the IFileSystem contract","category":"added"}
 {"description":"Fix a perceived ~500ms lag on every Escape keypress: a raw stdin chunk containing only the ESC byte is now emitted immediately as an escape KeyAction instead of waiting on readline's internal CSI-sequence disambiguation timeout","category":"fixed"}
+{"description":"setupKeypressHandler accepts an optional escFastPathEnabled callback, checked live before taking the lone-ESC fast path, so a consumer can disable it (e.g. over a fragmented remote connection) without a restart","category":"changed"}

--- a/packages/claude-core/src/input.ts
+++ b/packages/claude-core/src/input.ts
@@ -339,9 +339,13 @@ export function extractMouseSequences(input: Buffer): { actions: KeyAction[]; pa
  * delay. A real terminal writes an escape sequence as one atomic chunk over the
  * pty, so a chunk that is *only* the ESC byte can never be the start of one —
  * there is nothing left in the chunk to complete it. That makes emitting escape
- * immediately here safe, without waiting on readline at all.
+ * immediately here safe, without waiting on readline at all — provided input
+ * really does arrive atomically, which `escFastPathEnabled` lets the caller
+ * decide live (a bare remote shell with no multiplexer in between can fragment
+ * a real sequence across chunks, which this fast path cannot tell apart from a
+ * bare Escape). Defaults to always enabled so existing callers are unaffected.
  */
-export function setupKeypressHandler(handler: (key: KeyAction) => void): () => void {
+export function setupKeypressHandler(handler: (key: KeyAction) => void, escFastPathEnabled: () => boolean = () => true): () => void {
   const passthrough = new PassThrough();
   readline.emitKeypressEvents(passthrough);
 
@@ -352,7 +356,7 @@ export function setupKeypressHandler(handler: (key: KeyAction) => void): () => v
     for (const action of actions) {
       handler(action);
     }
-    if (pass.length === 1 && pass[0] === 0x1b) {
+    if (pass.length === 1 && pass[0] === 0x1b && escFastPathEnabled()) {
       handler({ type: 'escape' });
       return;
     }

--- a/packages/claude-core/src/input.ts
+++ b/packages/claude-core/src/input.ts
@@ -330,6 +330,16 @@ export function extractMouseSequences(input: Buffer): { actions: KeyAction[]; pa
  * KeyAction. Raw stdin is filtered for mouse sequences first (see
  * extractMouseSequences), then the non-mouse bytes flow through a PassThrough
  * into readline's keypress parser exactly as before. Returns a cleanup function.
+ *
+ * One case is special-cased ahead of readline: a chunk containing nothing but a
+ * single ESC byte (0x1b). readline cannot tell a bare Escape keypress from the
+ * start of a CSI/SS3 sequence (arrow keys, etc., which also start with ESC), so
+ * it holds the byte for ~500ms waiting to see if more follows — measured (see
+ * the ESC-cancel-lag investigation) as the entire source of a perceived cancel
+ * delay. A real terminal writes an escape sequence as one atomic chunk over the
+ * pty, so a chunk that is *only* the ESC byte can never be the start of one —
+ * there is nothing left in the chunk to complete it. That makes emitting escape
+ * immediately here safe, without waiting on readline at all.
  */
 export function setupKeypressHandler(handler: (key: KeyAction) => void): () => void {
   const passthrough = new PassThrough();
@@ -341,6 +351,10 @@ export function setupKeypressHandler(handler: (key: KeyAction) => void): () => v
     leftover = remainder;
     for (const action of actions) {
       handler(action);
+    }
+    if (pass.length === 1 && pass[0] === 0x1b) {
+      handler({ type: 'escape' });
+      return;
     }
     if (pass.length) {
       passthrough.write(pass);

--- a/packages/claude-core/test/extractMouseSequences.spec.ts
+++ b/packages/claude-core/test/extractMouseSequences.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractMouseSequences, type KeyAction } from '../src/input';
+import { extractMouseSequences, type KeyAction, setupKeypressHandler } from '../src/input';
 
 const buf = (s: string): Buffer => Buffer.from(s, 'latin1');
 const wheelUp = '\x1b[<64;10;5M';
@@ -75,6 +75,36 @@ describe('extractMouseSequences — passthrough', () => {
     const expected = emoji.toString('hex');
     const actual = extractMouseSequences(emoji).passthrough.toString('hex');
     expect(actual).toBe(expected);
+  });
+});
+
+// setupKeypressHandler drives process.stdin directly (readline.emitKeypressEvents needs a real
+// stream); process.stdin is a real EventEmitter even under vitest, so emitting 'data' on it and
+// tearing the listener down via the returned cleanup exercises the real path without mocking.
+describe('setupKeypressHandler — lone ESC fast path', () => {
+  it('emits escape immediately for a chunk containing only the ESC byte', () => {
+    const received: KeyAction[] = [];
+    const cleanup = setupKeypressHandler((key) => received.push(key));
+    try {
+      process.stdin.emit('data', Buffer.from([0x1b]));
+      const expected: KeyAction[] = [{ type: 'escape' }];
+      expect(received).toEqual(expected);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not fast-path a chunk where ESC is followed by more bytes (a real CSI sequence)', () => {
+    const received: KeyAction[] = [];
+    const cleanup = setupKeypressHandler((key) => received.push(key));
+    try {
+      process.stdin.emit('data', Buffer.from('\x1b[A', 'latin1'));
+      const expected = false;
+      const actual = received.some((k) => k.type === 'escape');
+      expect(actual).toBe(expected);
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace the placeholder README with a short description and a link to the main documentation
 - Support multiple system prompt sources as separate wire blocks
 - Tool handlers return structured output with optional attachments for binary content
+- Tool result now reports whether a run ended cancelled, distinct from any other error, and a new tool_cancelling message is published the moment ESC aborts a running tool batch
 - Update runtime and build dependencies
 - Updated patch and minor dependencies
 - Updated patch dependencies

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -54,3 +54,6 @@
 {"description":"Add Conversation.healDanglingToolUse(): self-heal a conversation whose last message is an assistant tool_use with no matching tool_result (a prior process died between the two) by appending an honest synthetic failure result for each dangling call","category":"added"}
 {"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
 {"description":"Clock stamp now leads the user's message in history instead of trailing every request","category":"fixed"}
+
+{"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
+{"description":"Tool result now reports whether a run ended cancelled, distinct from any other error, and a new tool_cancelling message is published the moment ESC aborts a running tool batch","category":"changed"}

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -54,6 +54,4 @@
 {"description":"Add Conversation.healDanglingToolUse(): self-heal a conversation whose last message is an assistant tool_use with no matching tool_result (a prior process died between the two) by appending an honest synthetic failure result for each dangling call","category":"added"}
 {"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
 {"description":"Clock stamp now leads the user's message in history instead of trailing every request","category":"fixed"}
-
-{"description":"ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call","category":"added"}
 {"description":"Tool result now reports whether a run ended cancelled, distinct from any other error, and a new tool_cancelling message is published the moment ESC aborts a running tool batch","category":"changed"}

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -300,7 +300,7 @@ export class QueryRunner extends IQueryRunner {
         if (!response.approved) {
           const content = response.reason ?? 'Rejected by user, do not reattempt';
           this.logger.debug('tool_rejected', { name: toolUse.name, reason: content });
-          this.publisher.send({ type: 'tool_result', id: toolUse.id, content, isError: true });
+          this.publisher.send({ type: 'tool_result', id: toolUse.id, content, isError: true, cancelled: false });
           toolResults.push({ type: 'tool_result', tool_use_id: toolUse.id, is_error: true, content: [{ type: 'text' as const, text: content }] });
           continue;
         }
@@ -337,7 +337,7 @@ export class QueryRunner extends IQueryRunner {
   #emitOutcome(toolUse: ToolUseResult, outcome: ToolOutcome): ToolResultBlock {
     const { id, name, input } = toolUse;
     if (outcome.kind === 'ok') {
-      this.publisher.send({ type: 'tool_result', id, content: outcome.content, isError: false });
+      this.publisher.send({ type: 'tool_result', id, content: outcome.content, isError: false, cancelled: false });
       return { type: 'tool_result', tool_use_id: id, content: [{ type: 'text' as const, text: outcome.content }, ...(outcome.blocks ?? [])] };
     }
     const text = outcomeMessage(outcome);
@@ -345,7 +345,7 @@ export class QueryRunner extends IQueryRunner {
     if (outcome.kind !== 'unavailable') {
       this.publisher.send({ type: 'tool_error', name, input, error: text });
     }
-    this.publisher.send({ type: 'tool_result', id, content: text, isError: true });
+    this.publisher.send({ type: 'tool_result', id, content: text, isError: true, cancelled: outcome.kind === 'cancelled' });
     return { type: 'tool_result', tool_use_id: id, is_error: true, content: [{ type: 'text' as const, text }] };
   }
 }

--- a/packages/claude-sdk/src/public/types.ts
+++ b/packages/claude-sdk/src/public/types.ts
@@ -213,14 +213,18 @@ export type SdkMessageEnd = { type: 'message_end'; stopReason: string };
 export type SdkToolApprovalRequest = { type: 'tool_approval_request'; requestId: string; name: string; input: Record<string, unknown> };
 export type SdkServerToolUse = { type: 'server_tool_use'; id: string; name: string; input: Record<string, unknown> };
 export type SdkServerToolResult = { type: 'server_tool_result'; id: string; name: string; result: unknown };
-/** A client tool's result, published as the query runner builds the tool_result block. `content` is post-transform (ref-swapped for large outputs). The history view reads this to show the output the model saw. */
-export type SdkToolResult = { type: 'tool_result'; id: string; content: string; isError: boolean };
+/** A client tool's result, published as the query runner builds the tool_result block. `content` is post-transform (ref-swapped for large outputs). The history view reads this to show the output the model saw. `cancelled` distinguishes a user-aborted run from any other error, so the consumer can render it distinctly from a genuine failure. */
+export type SdkToolResult = { type: 'tool_result'; id: string; content: string; isError: boolean; cancelled: boolean };
 export type SdkToolUseStart = { type: 'tool_use_start'; id: string; name: string };
 export type SdkServerToolUseStart = { type: 'server_tool_use_start'; id: string; name: string };
 export type SdkToolUseInputDelta = { type: 'tool_use_input_delta'; id: string; partialJson: string };
 export type SdkToolUseInputStop = { type: 'tool_use_input_stop'; id: string; input: Record<string, unknown> };
 
 export type SdkToolError = { type: 'tool_error'; name: string; input: Record<string, unknown>; error: string };
+/** Published the moment ESC aborts a running tool batch's controller — before the handler has
+ * actually unwound. Carries no id: one abort cancels every tool still running in the batch, so the
+ * consumer marks every non-terminal tool in the active batch as cancelling rather than one by id. */
+export type SdkToolCancelling = { type: 'tool_cancelling' };
 export type SdkDone = { type: 'done'; stopReason: string };
 export type SdkBlockEnter = { type: 'block_enter'; blockType: string };
 export type SdkBlockExit = { type: 'block_exit'; blockType: string };
@@ -265,6 +269,7 @@ export type SdkMessage =
   | SdkToolUseInputDelta
   | SdkToolUseInputStop
   | SdkToolError
+  | SdkToolCancelling
   | SdkDone
   | SdkError
   | SdkMessageUsage

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -470,6 +470,20 @@
         }
       }
     },
+    "input": {
+      "default": {
+        "escFastPath": true
+      },
+      "description": "Raw keyboard input handling configuration",
+      "type": "object",
+      "properties": {
+        "escFastPath": {
+          "default": true,
+          "description": "A stdin chunk containing only the ESC byte is treated as an immediate Escape keypress, skipping readline's ~500ms wait to see whether a CSI/SS3 sequence follows. Safe when the terminal writes each escape sequence as one atomic chunk (the normal case, including through tmux). Disable if input arrives fragmented (e.g. a bare remote shell over a lossy link with no multiplexer in between), where a split arrow-key/Alt-key sequence could otherwise be misread as a bare Escape. Read live: takes effect on the next keypress without a restart.",
+          "type": "boolean"
+        }
+      }
+    },
     "disabledTools": {
       "default": [],
       "description": "Names of loaded tools to hide from the model and refuse as unavailable. Read live: takes effect on the next turn without a restart.",


### PR DESCRIPTION
## Summary
- Tool status now shows the approval decision (✔/✘) before the tool name, and the real execution outcome (✅ ok, ❌ failed, ❗ cancelling, ‼️ cancelled) after it. Previously a single checkmark just meant "approved," regardless of what actually happened
- Fixed a ~500ms delay between pressing Esc and a running tool actually cancelling, caused by Node's readline waiting to see whether more bytes would turn a bare Escape into an arrow-key/CSI sequence
- Added `input.escFastPath` config (on by default, hot-reloadable) to fall back to the old behaviour for a bare remote shell with no multiplexer in between, where a real escape sequence could arrive fragmented