### PR TITLE
Fix mcp-memory README storage section and credit ctxrs/ctx in mcp-history

### DIFF
--- a/packages/mcp-exec/README.md
+++ b/packages/mcp-exec/README.md
@@ -35,7 +35,7 @@ It runs as a stdio MCP server under the `mcp-exec` command. Point your MCP clien
 
 ## Motivation
 
-The CLI exposes its Exec tool to its own model. This package exposes the same tool to any MCP client, so other agents can run commands through the same structured interface.
+Running a command through a shell string invites quoting bugs and injection. This package exposes a structured Exec tool to any MCP client, so an agent runs commands through a typed schema instead.
 
 ## The exec tool
 

--- a/packages/mcp-history/README.md
+++ b/packages/mcp-history/README.md
@@ -9,7 +9,7 @@
 
 - 🔎 **Search past conversations** - full-text search over your own conversation history, with citations to the source.
 - 📖 **Read a hit in context** - open a matched conversation with the surrounding turns, not just the snippet.
-- 🗃️ **Own local index** - a separate store from the CLI's, built from the shared history it produces.
+- 🗃️ **Own local index** - a dedicated SQLite index, built from your own conversation history.
 - 🔌 **stdio transport** - drop it into any MCP client that speaks stdio.
 
 ## Installation & Quick Start

--- a/packages/mcp-history/README.md
+++ b/packages/mcp-history/README.md
@@ -52,3 +52,4 @@ The index lives in a SQLite file, `history.db`, under the platform's standard da
 ## Credits & Inspiration
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
+- [ctxrs/ctx](https://github.com/ctxrs/ctx)

--- a/packages/mcp-memory/README.md
+++ b/packages/mcp-memory/README.md
@@ -9,7 +9,7 @@
 
 - 🧠 **Persists across sessions** - what one conversation learns, the next can find, with no shared context required.
 - 🔎 **Relevance search, not recall by id** - describe what you need in plain words; ranked hits come back, best first.
-- 💾 **Shares the CLI's store** - reads and writes the same `~/.claude/memory.db` as `claude-sdk-cli`, so a memory written by one is found by the other.
+- 🗃️ **Own local store** - a separate store from the CLI's, so this server works standalone without `claude-sdk-cli` installed.
 - 🔌 **stdio transport** - drop it into any MCP client that speaks stdio.
 
 ## Installation & Quick Start
@@ -40,7 +40,12 @@ Claude's context doesn't survive between sessions. Anthropic's own documented pa
 
 ## Storage
 
-Memories live in `~/.claude/memory.db`, the same SQLite file `claude-sdk-cli` itself reads and writes. This server doesn't keep a separate store: a memory written through the CLI shows up here, and a memory written here shows up in the CLI, because they're the same database.
+Memories live in a SQLite file, `memory.db`, under the platform's standard data directory for `shellicar-mcp-memory`. `$XDG_DATA_HOME`, if set, wins on every platform, not just Linux:
+
+- **`$XDG_DATA_HOME` set** - `$XDG_DATA_HOME/shellicar-mcp-memory`
+- **Linux** - `~/.local/share/shellicar-mcp-memory`
+- **macOS** - `~/Library/Application Support/shellicar-mcp-memory`
+- **Windows** - `%LOCALAPPDATA%\shellicar-mcp-memory`
 
 Each memory is stamped with the git remote of the working directory it was written from, when available, so a search hit can announce where it came from.
 

--- a/packages/mcp-memory/README.md
+++ b/packages/mcp-memory/README.md
@@ -9,7 +9,7 @@
 
 - 🧠 **Persists across sessions** - what one conversation learns, the next can find, with no shared context required.
 - 🔎 **Relevance search, not recall by id** - describe what you need in plain words; ranked hits come back, best first.
-- 🗃️ **Own local store** - a separate store from the CLI's, so this server works standalone without `claude-sdk-cli` installed.
+- 🗃️ **Own local store** - a dedicated SQLite database, so this server runs standalone with no other install required.
 - 🔌 **stdio transport** - drop it into any MCP client that speaks stdio.
 
 ## Installation & Quick Start


### PR DESCRIPTION
mcp-memory's README still described the old shared `~/.claude/memory.db`, left over from before #457 moved it to its own XDG data dir. Updated it to match mcp-history's Storage section shape.

Also added the missing ctxrs/ctx credit to mcp-history's Credits & Inspiration.