### PR TITLE
Fix clock stamp landing before tool_result/reminders instead of the user's message

### DIFF
--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a retried turn stacking a duplicate clock stamp onto the resent message instead of replacing the stale one from the discarded attempt
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
 - Fix context window size for Sonnet 4 (200k to 1M)
+- Fix the clock stamp landing before a tool_result or reminder instead of the user's message
 - Keep CLAUDE.md context present in every request after compaction (it previously dropped out)
 - Package now publishes CJS alongside ESM with working sourcemaps
 - Preserve redacted_thinking blocks in conversation history

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -57,3 +57,4 @@
 {"description":"Tool result now reports whether a run ended cancelled, distinct from any other error, and a new tool_cancelling message is published the moment ESC aborts a running tool batch","category":"changed"}
 {"description":"Fix a concurrent tool batch abandoning every still-running tool when one tool's run closure threw, instead of resolving that one tool as failed","category":"fixed"}
 {"description":"Fix a retried turn stacking a duplicate clock stamp onto the resent message instead of replacing the stale one from the discarded attempt","category":"fixed"}
+{"description":"Fix the clock stamp landing before a tool_result or reminder instead of the user's message","category":"fixed"}

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -111,24 +111,6 @@ export class Conversation {
   }
 
   /**
-   * Prepend content blocks to the last stored message's content, converting a string body to a
-   * text block first. Mutates the actual stored item, so this is a persisted write into history
-   * (unlike `cloneForRequest`'s caller-owned clone, which never touches stored state). No-op if
-   * there is no last message or `blocks` is empty.
-   */
-  public prependToLast(blocks: Anthropic.Beta.Messages.BetaContentBlockParam[]): void {
-    if (blocks.length === 0) {
-      return;
-    }
-    const last = this.#items.at(-1);
-    if (last == null) {
-      return;
-    }
-    const content = Array.isArray(last.msg.content) ? last.msg.content : [{ type: 'text' as const, text: last.msg.content as string }];
-    last.msg = { ...last.msg, content: [...blocks, ...content] };
-  }
-
-  /**
    * Remove the last message tagged with `id`.
    * Returns `true` if found and removed, `false` if no message with that id exists.
    */

--- a/packages/claude-sdk/src/private/RequestBuilder.ts
+++ b/packages/claude-sdk/src/private/RequestBuilder.ts
@@ -26,7 +26,7 @@ export type RequestBuilderOptions = {
    * delta (TurnInput.ephemeralReminders). A trailing reminder sits after the cache boundary
    * (uncached); a leading one prepends to the message head. Not persisted in conversation history.
    * The clock stamp is not one of these: it is written into history directly by
-   * `Conversation.prependToLast`, before the request clone is taken. */
+   * `TurnRunner`, before the request clone is taken. */
   ephemeralReminders?: SystemReminder[];
   tools: AnyToolDefinition[];
   /** Server-side tools prepended to the wire tools array before client tools. */

--- a/packages/claude-sdk/src/private/TurnRunner.ts
+++ b/packages/claude-sdk/src/private/TurnRunner.ts
@@ -15,7 +15,7 @@ import { formatClockStamp, isClockStampBlock } from './clockStamp';
 import { AccountLimitStoppedError, StreamInterruptedError } from './http/errors';
 import { IMessageStreamer } from './MessageStreamer';
 import { assistantIdentity } from './messageIdentity';
-import { buildRequestParams, type RequestBuilderOptions } from './RequestBuilder';
+import { buildRequestParams, isSystemReminderBlock, type RequestBuilderOptions } from './RequestBuilder';
 import type { MessageStreamResult } from './types';
 
 /**
@@ -67,29 +67,47 @@ export class TurnRunner extends ITurnRunner {
   public async run(conversation: Conversation, durable: DurableConfig, turnInput: TurnInput): Promise<MessageStreamResult> {
     const compactEnabled = durable.compact?.enabled ?? false;
 
-    // Write the clock stamp into history as a leading block of the tip message, before taking the
-    // request clone. Persisted, not ephemeral, and leading rather than trailing: it reads as calm
-    // background context instead of the freshest thing in the request, which is what drove the
-    // model to narrate it turn after turn when it sat trailing and un-persisted.
-    // Only on a real ask (human/orchestrator), not an agent-authored tool_result continuation: a
-    // tool loop runs seconds apart, so restamping every round trip would bake near-duplicate
-    // timestamps into history for no orientation value. Missing identity (a legacy conversation)
-    // is treated as a real ask, since there is nothing to say otherwise.
+    // Write the clock stamp into history immediately before the tip's own literal message content,
+    // before taking the request clone. Persisted, not ephemeral: it reads as calm background context
+    // instead of the freshest thing in the request, which is what drove the model to narrate it turn
+    // after turn when it sat trailing and un-persisted.
+    //
+    // "Immediately before the message" means after every other leading block, never before one: a
+    // leading tool_result (the API requires tool_result to lead the message it's part of), and any
+    // leading <system-reminder> block (CLAUDE.md, the skill-catalogue delta, the cwd delta — all
+    // framed onto the message by QueryRunner ahead of the literal text). This can't be decided from
+    // the tip's identity: a query cancelled right after its tool_result lands, followed by a brand
+    // new typed message, merges that message onto the same tip (role alternation forces consecutive
+    // user messages to merge), and the merged item keeps the tool_result's own identity (kind:
+    // 'agent') even though it now carries a real human ask. So this reads the content shape instead:
+    // skip every leading tool_result and leading reminder block, and stamp right at the boundary
+    // where the real content starts. A tip that is nothing but that leading run (a pure tool-result
+    // continuation, seconds apart in the same tool loop) has no real content to stamp, and is left
+    // unstamped — restamping every round trip would bake near-duplicate timestamps into history for
+    // no orientation value.
     const tip = conversation.items.at(-1);
-    // A retry that rolls back only the corrupted assistant turn (QueryRunner's empty-tool-use
-    // retry) re-presents this same tip on the next run() call. The retry can span real time (a
-    // give-up-and-resend after backoff, or just the clock ticking), so the resent request should
-    // carry the moment it is actually resent — the stale stamp from the discarded attempt is
-    // stripped first rather than left in place, so this replaces it instead of duplicating it.
-    if (tip?.identity?.from.kind !== 'agent') {
-      if (Array.isArray(tip?.msg.content)) {
-        const content = tip.msg.content;
-        const stampIdx = content.findIndex((b) => b.type === 'text' && isClockStampBlock(b.text));
-        if (stampIdx !== -1) {
-          tip.msg = { ...tip.msg, content: [...content.slice(0, stampIdx), ...content.slice(stampIdx + 1)] };
+    if (tip != null) {
+      const content = Array.isArray(tip.msg.content) ? tip.msg.content : [{ type: 'text' as const, text: tip.msg.content as string }];
+      // A retry that rolls back only the corrupted assistant turn (QueryRunner's empty-tool-use
+      // retry) re-presents this same tip on the next run() call. The retry can span real time (a
+      // give-up-and-resend after backoff, or just the clock ticking), so the resent request should
+      // carry the moment it is actually resent — the stale stamp from the discarded attempt is
+      // stripped first rather than left in place, so this replaces it instead of duplicating it.
+      const stampIdx = content.findIndex((b) => b.type === 'text' && isClockStampBlock(b.text));
+      const withoutStamp = stampIdx === -1 ? content : [...content.slice(0, stampIdx), ...content.slice(stampIdx + 1)];
+      let leading = 0;
+      while (leading < withoutStamp.length) {
+        const block = withoutStamp[leading];
+        if (block?.type === 'tool_result' || (block?.type === 'text' && isSystemReminderBlock(block.text))) {
+          leading++;
+          continue;
         }
+        break;
       }
-      conversation.prependToLast(buildReminderBlocks([formatClockStamp(this.clock)]));
+      const rest = withoutStamp.slice(leading);
+      if (rest.length > 0) {
+        tip.msg = { ...tip.msg, content: [...withoutStamp.slice(0, leading), ...buildReminderBlocks([formatClockStamp(this.clock)]), ...rest] };
+      }
     }
 
     const messages = conversation.cloneForRequest(compactEnabled);

--- a/packages/claude-sdk/test/timestampAfterCancelledToolResult.spec.ts
+++ b/packages/claude-sdk/test/timestampAfterCancelledToolResult.spec.ts
@@ -1,0 +1,239 @@
+import { Clock, Instant, ZoneOffset } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { IRandomProvider } from '@shellicar/claude-core/providers/IRandomProvider';
+import { ISleepProvider } from '@shellicar/claude-core/providers/ISleepProvider';
+import { createServiceCollection } from '@shellicar/core-di-lite';
+import { describe, expect, it } from 'vitest';
+import { ApprovalCoordinator } from '../src/private/ApprovalCoordinator.js';
+import { Conversation } from '../src/private/Conversation.js';
+import { type IMessageStream, IMessageStreamer } from '../src/private/MessageStreamer.js';
+import { QueryRunner } from '../src/private/QueryRunner.js';
+import { TurnRunner } from '../src/private/TurnRunner.js';
+import type { MessageStreamResult } from '../src/private/types.js';
+import { IDurableConfigProvider } from '../src/public/IDurableConfigProvider.js';
+import { ISdkMessagePublisher } from '../src/public/ISdkMessagePublisher.js';
+import { IStreamProcessor, IToolRegistry, ITurnRunner, IWakeLock } from '../src/public/interfaces.js';
+import type { DurableConfig, PerQueryInput, SystemReminder, ToolResolveResult } from '../src/public/types.js';
+import { AccountLimitListener, IRequestClockListener, IToolBlockNotifier, IToolsClockListener, StreamInterruptListener } from '../src/public/types.js';
+
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+const zeroUsage = { inputTokens: 0, cacheCreationTokens: 0, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0, cacheReadTokens: 0, outputTokens: 0 };
+
+class ScriptedStreamer extends IMessageStreamer {
+  public readonly calls: { body: unknown }[] = [];
+  public constructor(private readonly hangUntil?: AbortSignal) {
+    super();
+  }
+  public stream(body: unknown): IMessageStream {
+    this.calls.push({ body });
+    const hangUntil = this.hangUntil;
+    return (async function* () {
+      if (hangUntil) {
+        await new Promise((_resolve, reject) => hangUntil.addEventListener('abort', () => reject(new Error('aborted'))));
+      }
+    })();
+  }
+}
+
+class ScriptedProcessor extends IStreamProcessor {
+  #used = false;
+  public constructor(private readonly result: MessageStreamResult | Error) {
+    super();
+  }
+  public async process(): Promise<MessageStreamResult> {
+    if (this.#used) {
+      throw new Error('ScriptedProcessor: only scripted for a single call');
+    }
+    this.#used = true;
+    if (this.result instanceof Error) {
+      throw this.result;
+    }
+    return this.result;
+  }
+}
+
+class FakeDurableConfigProvider extends IDurableConfigProvider {
+  public config: DurableConfig = { model: 'claude-opus-4-5' as DurableConfig['model'], maxTokens: 1024, tools: [] };
+  public update(): void {}
+  public updateIdentityBody(): void {}
+  public async resolveSystemPromptsFor(): Promise<void> {}
+  public async resolveSkillCatalogue(): Promise<void> {}
+  public needsSystemPromptResolve(): boolean {
+    return false;
+  }
+  public getEffectiveModel(): string {
+    return this.config.model;
+  }
+  public getEffectiveThinkingEnabled(): boolean {
+    return false;
+  }
+  public getEffectiveEffort(): undefined {
+    return undefined;
+  }
+}
+
+// Resolves every tool_use immediately with a fixed ok result — the tool identity/input
+// doesn't matter to this test, only that a tool_result comes back for it.
+class OkToolRegistry extends IToolRegistry {
+  public get wireTools(): never[] {
+    return [];
+  }
+  public resolve(): ToolResolveResult {
+    return { kind: 'ready', run: async () => ({ kind: 'ok', content: 'tool ran' }) };
+  }
+  public normaliseInputPaths(): void {}
+}
+
+function runQuery(conversation: Conversation, streamer: IMessageStreamer, processor: IStreamProcessor, input: PerQueryInput): Promise<void> {
+  const services = createServiceCollection();
+  services.register(IMessageStreamer).to(IMessageStreamer, () => streamer);
+  services.register(IStreamProcessor).to(IStreamProcessor, () => processor);
+  services.register(ILogger).to(ILogger, () => new NoopLogger());
+  services.register(AccountLimitListener).to(AccountLimitListener, () => ({ retrying: () => {}, stopped: () => {} }));
+  services.register(ISleepProvider).to(ISleepProvider, () => ({ sleep: async () => {} }));
+  services.register(IRandomProvider).to(IRandomProvider, () => ({ next: () => 0 }));
+  services.register(Clock).to(Clock, () => Clock.fixed(Instant.ofEpochMilli(0), ZoneOffset.UTC));
+  services.register(IWakeLock).to(IWakeLock, () => ({ acquire: () => ({ release: () => {} }) }));
+  services.register(StreamInterruptListener).to(StreamInterruptListener, () => ({ reconnecting: () => {} }));
+  services.register(IRequestClockListener).to(IRequestClockListener, () => ({ requestStarted: () => {}, requestSettled: () => {} }));
+  services.register(TurnRunner).to(TurnRunner);
+  services.register(ITurnRunner).to(ITurnRunner, (p) => p.resolve(TurnRunner));
+  services.register(Conversation).to(Conversation, () => conversation);
+  services.register(IToolRegistry).to(IToolRegistry, () => new OkToolRegistry());
+  services.register(ApprovalCoordinator).to(ApprovalCoordinator);
+  services.register(ISdkMessagePublisher).to(ISdkMessagePublisher, () => ({ send: () => {}, close: () => {}, drain: async () => {} }));
+  services.register(IDurableConfigProvider).to(IDurableConfigProvider, () => new FakeDurableConfigProvider());
+  services.register(IToolsClockListener).to(IToolsClockListener, () => ({ toolsStarted: () => {}, toolsStopped: () => {} }));
+  services.register(IToolBlockNotifier).to(IToolBlockNotifier, () => ({ blockEnded: async () => {} }));
+  services.register(QueryRunner).to(QueryRunner);
+  return services.buildProvider().resolve(QueryRunner).run(input);
+}
+
+// Mirrors runAgent.ts: the CLI attaches these as persisted-leading reminders on the message
+// that carries them (skill catalogue delta, cwd delta) — the same shape a real ctrl-c-then-resend
+// or a plain cd/skill-update turn produces.
+const cwdAndSkillReminders: SystemReminder[] = [
+  { text: 'skill updated', persisted: true, position: 'leading' },
+  { text: 'cwd changed', persisted: true, position: 'leading' },
+];
+
+async function sendMessageAfterCancelledToolResult(reminders?: SystemReminder[]): Promise<Array<{ type: string; text?: string }>> {
+  const conversation = new Conversation();
+
+  // Query 1: ask -> tool_use -> tool_result pushed -> the next turn (the assistant's
+  // reply to the tool_result) is cancelled via ESC before it resolves.
+  const cancelSignal = new AbortController();
+  await runQuery(conversation, new ScriptedStreamer(), new ScriptedProcessor({ blocks: [{ type: 'tool_use', id: 't1', name: 'Foo', input: {} }], stopReason: 'tool_use', contextManagementOccurred: false, usage: zeroUsage }), {
+    messages: ['first ask'],
+    transformToolResult: undefined,
+    abortController: new AbortController(),
+  });
+  const secondTurn = runQuery(conversation, new ScriptedStreamer(cancelSignal.signal), new ScriptedProcessor(new Error('should not be reached')), {
+    messages: [],
+    transformToolResult: undefined,
+    abortController: cancelSignal,
+  }).catch(() => {});
+  queueMicrotask(() => cancelSignal.abort());
+  await secondTurn;
+
+  // Query 2: the user types a brand new message. It merges onto the tool_result-ending
+  // history (role alternation), so the tip carries the *old* tool_result's identity
+  // (kind: 'agent') even though a real human ask just landed on it. ctrl-c commonly lands the
+  // user back at a prompt where the cwd or the skill catalogue has since changed, so this new
+  // message may itself carry its own leading reminders ahead of the literal typed text.
+  const streamer2 = new ScriptedStreamer();
+  await runQuery(conversation, streamer2, new ScriptedProcessor({ blocks: [{ type: 'text', text: 'ok' }], stopReason: 'end_turn', contextManagementOccurred: false, usage: zeroUsage }), {
+    messages: ['hello again'],
+    reminders,
+    transformToolResult: undefined,
+    abortController: new AbortController(),
+  });
+
+  const sentMessages = (streamer2.calls[0]?.body as { messages: Array<{ role: string; content: unknown }> }).messages;
+  const tip = sentMessages.at(-1);
+  return Array.isArray(tip?.content) ? (tip.content as Array<{ type: string; text?: string }>) : [];
+}
+
+async function sendFirstMessage(reminders?: SystemReminder[]): Promise<Array<{ type: string; text?: string }>> {
+  const conversation = new Conversation();
+  const streamer = new ScriptedStreamer();
+  await runQuery(conversation, streamer, new ScriptedProcessor({ blocks: [{ type: 'text', text: 'ok' }], stopReason: 'end_turn', contextManagementOccurred: false, usage: zeroUsage }), {
+    messages: ['hello'],
+    reminders,
+    transformToolResult: undefined,
+    abortController: new AbortController(),
+  });
+
+  const sentMessages = (streamer.calls[0]?.body as { messages: Array<{ role: string; content: unknown }> }).messages;
+  const tip = sentMessages.at(-1);
+  return Array.isArray(tip?.content) ? (tip.content as Array<{ type: string; text?: string }>) : [];
+}
+
+describe('clock stamp after a query is cancelled following tool results', () => {
+  it('keeps the earlier tool_result as the first content block', async () => {
+    const expected = 'tool_result';
+
+    const content = await sendMessageAfterCancelledToolResult();
+    const actual = content[0]?.type;
+
+    expect(actual).toBe(expected);
+  });
+
+  it('stamps the new message with a fresh timestamp', async () => {
+    const content = await sendMessageAfterCancelledToolResult();
+    const actual = content.some((b) => typeof b.text === 'string' && b.text.includes('<system-reminder>'));
+
+    expect(actual).toBe(true);
+  });
+
+  it('places the timestamp after the tool_result and before the new user text', async () => {
+    const content = await sendMessageAfterCancelledToolResult();
+    const stampIdx = content.findIndex((b) => typeof b.text === 'string' && b.text.includes('<system-reminder>'));
+    const userTextIdx = content.findIndex((b) => b.text === 'hello again');
+    const actual = stampIdx > 0 && stampIdx < userTextIdx;
+
+    expect(actual).toBe(true);
+  });
+});
+
+describe('clock stamp placement relative to a cwd/skill-catalogue reminder on a plain message', () => {
+  it('places the timestamp immediately before the literal user text, after the cwd/skill reminders', async () => {
+    const content = await sendFirstMessage(cwdAndSkillReminders);
+    const userTextIdx = content.findIndex((b) => b.text === 'hello');
+    const expected = userTextIdx - 1;
+
+    const stampIdx = content.findIndex((b) => typeof b.text === 'string' && b.text.includes('Thursday, 1 January 1970 at 00:00:00'));
+    const actual = stampIdx;
+
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('clock stamp placement after a cancelled tool result, with a cwd/skill-catalogue reminder on the resend', () => {
+  it('keeps the tool_result as the first content block', async () => {
+    const expected = 'tool_result';
+
+    const content = await sendMessageAfterCancelledToolResult(cwdAndSkillReminders);
+    const actual = content[0]?.type;
+
+    expect(actual).toBe(expected);
+  });
+
+  it('places the timestamp immediately before the literal user text, after the cwd/skill reminders', async () => {
+    const content = await sendMessageAfterCancelledToolResult(cwdAndSkillReminders);
+    const userTextIdx = content.findIndex((b) => b.text === 'hello again');
+    const expected = userTextIdx - 1;
+
+    const stampIdx = content.findIndex((b) => typeof b.text === 'string' && b.text.includes('Thursday, 1 January 1970 at 00:00:00'));
+    const actual = stampIdx;
+
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- A cancelled query followed by a new message could put the clock stamp ahead of a `tool_result` block, which the API rejects
- The stamp now lands exactly before the user's own message, after any leading `tool_result` or reminder blocks
- Covers the same placement for a plain message carrying a cwd/skill-catalogue reminder