### PR TITLE
Add commits-ahead/behind counts to the git delta reminder's HEAD change

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show conversation id in status bar, controlled by statusBar.showConversationId config (default true)
 - Show the --resume flag for the current conversation on clean exit
 - Show the CLI's own build version, dimmed, at the end of the status bar
+- Show the repo root change in the git delta reminder when a directory move crosses into a different repo, and skip the ahead/behind lookup in that case since it no longer refers to the same history
 - Show turn count on the status line
 - Show user, tools, and claude time totals in the status line
 - Show working directory name in status bar
@@ -154,7 +155,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix streaming markdown responses re-lexing and re-highlighting the entire accumulated response on every delta instead of only the newly arrived text, an O(n^2) cost that made long, code-heavy responses render increasingly slowly as they streamed in
 - Fix streaming tool render regression from the main merge
 - Fix the CLI crashing at startup
-- Fix the git delta reminder comparing branch/HEAD across an unrelated repo after a directory move mid-session
 - Fix the TUI repainting every cell of every row on every frame, which made the once-a-second clock tick, every mouse-wheel scroll notch, and every keystroke rewrite the whole terminal; the renderer now diffs against the previous frame and writes only the rows that changed
 - Hook commands support ~, $HOME, and relative paths
 - Keep the editor cursor on a grapheme boundary after an insert that fuses with the following character (combining marks, regional-indicator flags, skin-tone modifiers, ZWJ sequences, VS16), so a later delete can no longer split the cluster into broken codepoints

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -69,9 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Section dividers show when each section started, ended, and how long it took
 - Service `say` and `cancel` on the conversation over NATS and raise and answer tool approvals over the wire, so a client can address the CLI and drive a turn remotely
 - Show conversation id in status bar, controlled by statusBar.showConversationId config (default true)
+- Show repo and worktree changes separately in the git delta reminder: a move between worktrees of the same repo no longer reads as a different project, and the ahead/behind lookup only runs when the repo is actually the same
 - Show the --resume flag for the current conversation on clean exit
 - Show the CLI's own build version, dimmed, at the end of the status bar
-- Show the repo root change in the git delta reminder when a directory move crosses into a different repo, and skip the ahead/behind lookup in that case since it no longer refers to the same history
 - Show turn count on the status line
 - Show user, tools, and claude time totals in the status line
 - Show working directory name in status bar

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a model selector to command mode (Ctrl+/ m m): free-text model entry that always sends, with a blue highlight when the typed id matches a known model. Shares one override slot with the --model flag; empty submit clears back to the config model
 - Add approval notification hook: run a command when tool approval is pending
 - Add command-mode model sub-mode (`m`): `t` toggles thinking, `e` cycles effort, surfaced in the status line
+- Add commits-ahead/behind counts to the git delta reminder's HEAD change
 - Add compact config: control compaction enabled, token threshold, pause, and custom instructions via `sdk-config.json`
 - Add ConversationSession: persistent conversation identity and n key to start new conversation
 - Add gh privilege escalation: every exec call runs read-only under a reader Keychain credential; six named PullRequest tools briefly use a separate holder credential for one call and always prompt for approval first

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -154,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix streaming markdown responses re-lexing and re-highlighting the entire accumulated response on every delta instead of only the newly arrived text, an O(n^2) cost that made long, code-heavy responses render increasingly slowly as they streamed in
 - Fix streaming tool render regression from the main merge
 - Fix the CLI crashing at startup
+- Fix the git delta reminder comparing branch/HEAD across an unrelated repo after a directory move mid-session
 - Fix the TUI repainting every cell of every row on every frame, which made the once-a-second clock tick, every mouse-wheel scroll notch, and every keystroke rewrite the whole terminal; the renderer now diffs against the previous frame and writes only the rows that changed
 - Hook commands support ~, $HOME, and relative paths
 - Keep the editor cursor on a grapheme boundary after an insert that fuses with the following character (combining marks, regional-indicator flags, skin-tone modifiers, ZWJ sequences, VS16), so a later delete can no longer split the cluster into broken codepoints

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -156,3 +156,4 @@
 {"description":"Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure","category":"fixed"}
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
+{"description":"Fix the git delta reminder comparing branch/HEAD across an unrelated repo after a directory move mid-session","category":"fixed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -155,3 +155,4 @@
 {"description":"Added input.escFastPath config: disables the immediate-Escape fast path, for a bare remote shell with no multiplexer in between where a real escape sequence could arrive fragmented. Read live: takes effect on the next keypress without a restart","category":"added"}
 {"description":"Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure","category":"fixed"}
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
+{"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -156,4 +156,4 @@
 {"description":"Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure","category":"fixed"}
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
-{"description":"Show the repo root change in the git delta reminder when a directory move crosses into a different repo, and skip the ahead/behind lookup in that case since it no longer refers to the same history","category":"added"}
+{"description":"Show repo and worktree changes separately in the git delta reminder: a move between worktrees of the same repo no longer reads as a different project, and the ahead/behind lookup only runs when the repo is actually the same","category":"added"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -156,4 +156,4 @@
 {"description":"Fix a denied tool's status glyph being overwritten by failed once its rejection tool_result arrived, reading a user denial as an execution failure","category":"fixed"}
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
-{"description":"Fix the git delta reminder comparing branch/HEAD across an unrelated repo after a directory move mid-session","category":"fixed"}
+{"description":"Show the repo root change in the git delta reminder when a directory move crosses into a different repo, and skip the ahead/behind lookup in that case since it no longer refers to the same history","category":"added"}

--- a/apps/claude-sdk-cli/src/GitStateMonitor.ts
+++ b/apps/claude-sdk-cli/src/GitStateMonitor.ts
@@ -1,5 +1,5 @@
 import { computeDelta, formatDelta } from './gitDelta.js';
-import { type GitSnapshot, type HeadDivergence, gatherGitSnapshot, gatherHeadDivergence } from './gitSnapshot.js';
+import { type GitSnapshot, gatherGitSnapshot, gatherHeadDivergence, type HeadDivergence } from './gitSnapshot.js';
 
 export type SnapshotFn = () => Promise<GitSnapshot>;
 export type DivergenceFn = (from: string, to: string) => Promise<HeadDivergence | null>;

--- a/apps/claude-sdk-cli/src/GitStateMonitor.ts
+++ b/apps/claude-sdk-cli/src/GitStateMonitor.ts
@@ -1,7 +1,8 @@
 import { computeDelta, formatDelta } from './gitDelta.js';
-import { type GitSnapshot, gatherGitSnapshot } from './gitSnapshot.js';
+import { type GitSnapshot, type HeadDivergence, gatherGitSnapshot, gatherHeadDivergence } from './gitSnapshot.js';
 
 export type SnapshotFn = () => Promise<GitSnapshot>;
+export type DivergenceFn = (from: string, to: string) => Promise<HeadDivergence | null>;
 
 /**
  * Tracks git state between turns so the agent sees what changed, not just what is.
@@ -16,9 +17,11 @@ export type SnapshotFn = () => Promise<GitSnapshot>;
 export class GitStateMonitor {
   #previous: GitSnapshot | null = null;
   readonly #takeSnapshot: SnapshotFn;
+  readonly #getDivergence: DivergenceFn;
 
-  public constructor(takeSnapshot: SnapshotFn = gatherGitSnapshot) {
+  public constructor(takeSnapshot: SnapshotFn = gatherGitSnapshot, getDivergence: DivergenceFn = gatherHeadDivergence) {
     this.#takeSnapshot = takeSnapshot;
+    this.#getDivergence = getDivergence;
   }
 
   public async getDelta(): Promise<string | undefined> {
@@ -28,8 +31,18 @@ export class GitStateMonitor {
 
     const current = await this.#takeSnapshot();
     const delta = computeDelta(this.#previous, current);
+    if (!delta) {
+      return undefined;
+    }
 
-    return delta ? formatDelta(delta) : undefined;
+    if (delta.head) {
+      const divergence = await this.#getDivergence(delta.head.from, delta.head.to);
+      if (divergence) {
+        delta.headDivergence = divergence;
+      }
+    }
+
+    return formatDelta(delta);
   }
 
   public async takeSnapshot(): Promise<void> {

--- a/apps/claude-sdk-cli/src/GitStateMonitor.ts
+++ b/apps/claude-sdk-cli/src/GitStateMonitor.ts
@@ -35,7 +35,9 @@ export class GitStateMonitor {
       return undefined;
     }
 
-    if (delta.head) {
+    // A repo/worktree move makes old and new HEAD unrelated commits; the counts from a cross-repo
+    // rev-list would be meaningless, so only look up divergence when the repo root didn't change.
+    if (delta.head && !delta.repo) {
       const divergence = await this.#getDivergence(delta.head.from, delta.head.to);
       if (divergence) {
         delta.headDivergence = divergence;

--- a/apps/claude-sdk-cli/src/gitDelta.ts
+++ b/apps/claude-sdk-cli/src/gitDelta.ts
@@ -12,6 +12,7 @@ export type FileDelta = { added: number; removed: number };
 
 export type DeltaValues = {
   repo?: DeltaField<string>;
+  worktree?: DeltaField<string>;
   branch?: DeltaField<string>;
   head?: DeltaField<string>;
   headDivergence?: HeadDivergence;
@@ -50,8 +51,11 @@ function formatFileDelta(delta: FileDelta): string {
 export function computeDelta(previous: GitSnapshot, current: GitSnapshot): DeltaValues | null {
   const delta: DeltaValues = {};
 
-  if (current.root !== previous.root) {
-    delta.repo = { from: previous.root, to: current.root };
+  if (current.repo !== previous.repo) {
+    delta.repo = { from: previous.repo, to: current.repo };
+  }
+  if (current.worktree !== previous.worktree) {
+    delta.worktree = { from: previous.worktree, to: current.worktree };
   }
   if (current.branch !== previous.branch) {
     delta.branch = { from: previous.branch, to: current.branch };
@@ -102,6 +106,9 @@ export function formatDelta(delta: DeltaValues): string {
 
   if (delta.repo) {
     parts.push(`repo: ${delta.repo.from || '(none)'} \u2192 ${delta.repo.to || '(none)'}`);
+  }
+  if (delta.worktree) {
+    parts.push(`worktree: ${delta.worktree.from || '(none)'} \u2192 ${delta.worktree.to || '(none)'}`);
   }
   if (delta.branch) {
     parts.push(`branch: ${delta.branch.from} \u2192 ${delta.branch.to}`);

--- a/apps/claude-sdk-cli/src/gitDelta.ts
+++ b/apps/claude-sdk-cli/src/gitDelta.ts
@@ -1,4 +1,4 @@
-import type { GitSnapshot } from './gitSnapshot.js';
+import type { GitSnapshot, HeadDivergence } from './gitSnapshot.js';
 
 // ---------------------------------------------------------------------------
 // DeltaValues — structured diff between two snapshots.
@@ -13,6 +13,7 @@ export type FileDelta = { added: number; removed: number };
 export type DeltaValues = {
   branch?: DeltaField<string>;
   head?: DeltaField<string>;
+  headDivergence?: HeadDivergence;
   staged?: FileDelta;
   unstaged?: FileDelta;
   untracked?: FileDelta;
@@ -80,6 +81,18 @@ export function computeDelta(previous: GitSnapshot, current: GitSnapshot): Delta
 // Build — turns DeltaValues into the injected text line.
 // ---------------------------------------------------------------------------
 
+export function formatHeadDivergence(divergence: HeadDivergence): string {
+  const { onlyOld, onlyNew } = divergence;
+  const parts: string[] = [];
+  if (onlyOld > 0) {
+    parts.push(`${onlyOld} behind`);
+  }
+  if (onlyNew > 0) {
+    parts.push(`${onlyNew} ahead`);
+  }
+  return parts.join(', ');
+}
+
 export function formatDelta(delta: DeltaValues): string {
   const parts: string[] = [];
 
@@ -87,7 +100,8 @@ export function formatDelta(delta: DeltaValues): string {
     parts.push(`branch: ${delta.branch.from} \u2192 ${delta.branch.to}`);
   }
   if (delta.head) {
-    parts.push(`HEAD: ${delta.head.from} \u2192 ${delta.head.to}`);
+    const divergence = delta.headDivergence ? ` (${formatHeadDivergence(delta.headDivergence)})` : '';
+    parts.push(`HEAD: ${delta.head.from} \u2192 ${delta.head.to}${divergence}`);
   }
   if (delta.staged) {
     parts.push(`staged: ${formatFileDelta(delta.staged)}`);

--- a/apps/claude-sdk-cli/src/gitDelta.ts
+++ b/apps/claude-sdk-cli/src/gitDelta.ts
@@ -11,6 +11,7 @@ export type DeltaField<T> = { from: T; to: T };
 export type FileDelta = { added: number; removed: number };
 
 export type DeltaValues = {
+  repo?: DeltaField<string>;
   branch?: DeltaField<string>;
   head?: DeltaField<string>;
   headDivergence?: HeadDivergence;
@@ -49,6 +50,9 @@ function formatFileDelta(delta: FileDelta): string {
 export function computeDelta(previous: GitSnapshot, current: GitSnapshot): DeltaValues | null {
   const delta: DeltaValues = {};
 
+  if (current.root !== previous.root) {
+    delta.repo = { from: previous.root, to: current.root };
+  }
   if (current.branch !== previous.branch) {
     delta.branch = { from: previous.branch, to: current.branch };
   }
@@ -96,6 +100,9 @@ export function formatHeadDivergence(divergence: HeadDivergence): string {
 export function formatDelta(delta: DeltaValues): string {
   const parts: string[] = [];
 
+  if (delta.repo) {
+    parts.push(`repo: ${delta.repo.from || '(none)'} \u2192 ${delta.repo.to || '(none)'}`);
+  }
   if (delta.branch) {
     parts.push(`branch: ${delta.branch.from} \u2192 ${delta.branch.to}`);
   }

--- a/apps/claude-sdk-cli/src/gitSnapshot.ts
+++ b/apps/claude-sdk-cli/src/gitSnapshot.ts
@@ -61,6 +61,16 @@ export function parseStash(output: string): number {
   return output.split('\n').filter((l) => l.trim().length > 0).length;
 }
 
+export type HeadDivergence = { onlyOld: number; onlyNew: number };
+
+export function parseDivergence(output: string): HeadDivergence | null {
+  const match = output.trim().match(/^(\d+)\s+(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  return { onlyOld: Number(match[1]), onlyNew: Number(match[2]) };
+}
+
 // ---------------------------------------------------------------------------
 // Production runner — executes the four git commands in parallel.
 // ---------------------------------------------------------------------------
@@ -68,6 +78,11 @@ export function parseStash(output: string): number {
 async function runGit(args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('git', args);
   return stdout;
+}
+
+export async function gatherHeadDivergence(from: string, to: string, runner: (args: string[]) => Promise<string> = runGit): Promise<HeadDivergence | null> {
+  const output = await runner(['rev-list', '--left-right', '--count', `${from}...${to}`]).catch(() => '');
+  return parseDivergence(output);
 }
 
 export async function gatherGitSnapshot(runner: (args: string[]) => Promise<string> = runGit): Promise<GitSnapshot> {

--- a/apps/claude-sdk-cli/src/gitSnapshot.ts
+++ b/apps/claude-sdk-cli/src/gitSnapshot.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 export type GitSnapshot = {
+  root: string;
   branch: string;
   head: string;
   stagedFiles: readonly string[];
@@ -17,6 +18,10 @@ export type GitSnapshot = {
 // Exported so tests can exercise them directly with fixture strings without
 // needing a real git process.
 // ---------------------------------------------------------------------------
+
+export function parseRoot(output: string): string {
+  return output.trim();
+}
 
 export function parseBranch(output: string): string {
   return output.trim();
@@ -86,8 +91,9 @@ export async function gatherHeadDivergence(from: string, to: string, runner: (ar
 }
 
 export async function gatherGitSnapshot(runner: (args: string[]) => Promise<string> = runGit): Promise<GitSnapshot> {
-  const [branchOut, headOut, statusOut, stashOut] = await Promise.all([runner(['branch', '--show-current']).catch(() => ''), runner(['rev-parse', 'HEAD']).catch(() => ''), runner(['status', '--porcelain']).catch(() => ''), runner(['stash', 'list', '--no-decorate']).catch(() => '')]);
+  const [rootOut, branchOut, headOut, statusOut, stashOut] = await Promise.all([runner(['rev-parse', '--show-toplevel']).catch(() => ''), runner(['branch', '--show-current']).catch(() => ''), runner(['rev-parse', 'HEAD']).catch(() => ''), runner(['status', '--porcelain']).catch(() => ''), runner(['stash', 'list', '--no-decorate']).catch(() => '')]);
   return {
+    root: parseRoot(rootOut),
     branch: parseBranch(branchOut),
     head: parseHead(headOut),
     ...parseStatus(statusOut),

--- a/apps/claude-sdk-cli/src/gitSnapshot.ts
+++ b/apps/claude-sdk-cli/src/gitSnapshot.ts
@@ -4,7 +4,8 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 export type GitSnapshot = {
-  root: string;
+  repo: string;
+  worktree: string;
   branch: string;
   head: string;
   stagedFiles: readonly string[];
@@ -19,7 +20,13 @@ export type GitSnapshot = {
 // needing a real git process.
 // ---------------------------------------------------------------------------
 
-export function parseRoot(output: string): string {
+/** The repo's identity: the common git dir, shared by every worktree of the same repo. */
+export function parseRepo(output: string): string {
+  return output.trim();
+}
+
+/** Which checkout you're standing in: the working-tree root, distinct per worktree. */
+export function parseWorktree(output: string): string {
   return output.trim();
 }
 
@@ -91,9 +98,17 @@ export async function gatherHeadDivergence(from: string, to: string, runner: (ar
 }
 
 export async function gatherGitSnapshot(runner: (args: string[]) => Promise<string> = runGit): Promise<GitSnapshot> {
-  const [rootOut, branchOut, headOut, statusOut, stashOut] = await Promise.all([runner(['rev-parse', '--show-toplevel']).catch(() => ''), runner(['branch', '--show-current']).catch(() => ''), runner(['rev-parse', 'HEAD']).catch(() => ''), runner(['status', '--porcelain']).catch(() => ''), runner(['stash', 'list', '--no-decorate']).catch(() => '')]);
+  const [repoOut, worktreeOut, branchOut, headOut, statusOut, stashOut] = await Promise.all([
+    runner(['rev-parse', '--path-format=absolute', '--git-common-dir']).catch(() => ''),
+    runner(['rev-parse', '--show-toplevel']).catch(() => ''),
+    runner(['branch', '--show-current']).catch(() => ''),
+    runner(['rev-parse', 'HEAD']).catch(() => ''),
+    runner(['status', '--porcelain']).catch(() => ''),
+    runner(['stash', 'list', '--no-decorate']).catch(() => ''),
+  ]);
   return {
-    root: parseRoot(rootOut),
+    repo: parseRepo(repoOut),
+    worktree: parseWorktree(worktreeOut),
     branch: parseBranch(branchOut),
     head: parseHead(headOut),
     ...parseStatus(statusOut),

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -587,6 +587,11 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
     provider.resolve(IRulesConfigNotifier).refresh();
     statusState.setCwdBasename(basename(cwd));
     void reloadPromptsAfterMove();
+    // A move can cross into a different repo (or out of one entirely), so the previous branch/HEAD
+    // belong to a different history. Re-baseline here rather than let the next getDelta() diff across
+    // repos, which would report a meaningless branch/HEAD "change" and feed unrelated SHAs into the
+    // HEAD divergence lookup.
+    void gitMonitor.takeSnapshot();
     // The move landed: re-publish `attached` at the new cwd, last-write-wins (agent-spec, chdir). Fires
     // for both a local /cd and a `chdir` request — WorkingDirectory.change is the one authoritative path.
     agentPresence.attach(session.id, cwd);

--- a/apps/claude-sdk-cli/src/main.ts
+++ b/apps/claude-sdk-cli/src/main.ts
@@ -587,11 +587,6 @@ const runApp = async ({ configOptions, runtimeOptions, tsServerOptions, database
     provider.resolve(IRulesConfigNotifier).refresh();
     statusState.setCwdBasename(basename(cwd));
     void reloadPromptsAfterMove();
-    // A move can cross into a different repo (or out of one entirely), so the previous branch/HEAD
-    // belong to a different history. Re-baseline here rather than let the next getDelta() diff across
-    // repos, which would report a meaningless branch/HEAD "change" and feed unrelated SHAs into the
-    // HEAD divergence lookup.
-    void gitMonitor.takeSnapshot();
     // The move landed: re-publish `attached` at the new cwd, last-write-wins (agent-spec, chdir). Fires
     // for both a local /cd and a `chdir` request — WorkingDirectory.change is the one authoritative path.
     agentPresence.attach(session.id, cwd);

--- a/apps/claude-sdk-cli/test/gitDelta.spec.ts
+++ b/apps/claude-sdk-cli/test/gitDelta.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { GitStateMonitor } from '../src/GitStateMonitor.js';
-import { computeDelta, type DeltaValues, type FileDelta, formatDelta } from '../src/gitDelta.js';
+import { computeDelta, type DeltaValues, type FileDelta, formatDelta, formatHeadDivergence } from '../src/gitDelta.js';
 import type { GitSnapshot } from '../src/gitSnapshot.js';
 
 const base: GitSnapshot = {
@@ -187,6 +187,37 @@ describe('formatDelta — file counts', () => {
   });
 });
 
+describe('formatHeadDivergence', () => {
+  it('shows only ahead when nothing is behind', () => {
+    const actual = formatHeadDivergence({ onlyOld: 0, onlyNew: 21 });
+    const expected = '21 ahead';
+    expect(actual).toEqual(expected);
+  });
+
+  it('shows only behind when nothing is ahead', () => {
+    const actual = formatHeadDivergence({ onlyOld: 10, onlyNew: 0 });
+    const expected = '10 behind';
+    expect(actual).toEqual(expected);
+  });
+
+  it('shows both counts when commits sit on each side', () => {
+    const actual = formatHeadDivergence({ onlyOld: 10, onlyNew: 21 });
+    const expected = '10 behind, 21 ahead';
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('formatDelta — HEAD with divergence', () => {
+  it('appends the divergence description after the arrow', () => {
+    const actual = formatDelta({
+      head: { from: '8f9138d', to: '8c59648' },
+      headDivergence: { onlyOld: 10, onlyNew: 21 },
+    });
+    const expected = '<git-delta>HEAD: 8f9138d → 8c59648 (10 behind, 21 ahead)</git-delta>';
+    expect(actual).toEqual(expected);
+  });
+});
+
 describe('formatDelta — multiple fields joined with pipe', () => {
   it('joins multiple fields with space-pipe-space', () => {
     const actual = formatDelta({
@@ -216,6 +247,38 @@ describe('GitStateMonitor — no change between calls', () => {
     await monitor.takeSnapshot(); // establish baseline
     const actual = await monitor.getDelta();
     expect(actual).toBeUndefined();
+  });
+});
+
+describe('GitStateMonitor — HEAD change queries divergence', () => {
+  it('includes the divergence description when HEAD changes', async () => {
+    let call = 0;
+    const snapshots: GitSnapshot[] = [base, { ...base, head: 'def5678' }];
+    const monitor = new GitStateMonitor(
+      () => Promise.resolve({ ...(snapshots[call++] ?? base) }),
+      (from, to) => {
+        expect(from).toEqual('abc1234');
+        expect(to).toEqual('def5678');
+        return Promise.resolve({ onlyOld: 0, onlyNew: 1 });
+      },
+    );
+    await monitor.takeSnapshot();
+    const actual = await monitor.getDelta();
+    const expected = '<git-delta>HEAD: abc1234 \u2192 def5678 (1 ahead)</git-delta>';
+    expect(actual).toEqual(expected);
+  });
+
+  it('omits the divergence description when the divergence lookup fails', async () => {
+    let call = 0;
+    const snapshots: GitSnapshot[] = [base, { ...base, head: 'def5678' }];
+    const monitor = new GitStateMonitor(
+      () => Promise.resolve({ ...(snapshots[call++] ?? base) }),
+      () => Promise.resolve(null),
+    );
+    await monitor.takeSnapshot();
+    const actual = await monitor.getDelta();
+    const expected = '<git-delta>HEAD: abc1234 \u2192 def5678</git-delta>';
+    expect(actual).toEqual(expected);
   });
 });
 

--- a/apps/claude-sdk-cli/test/gitDelta.spec.ts
+++ b/apps/claude-sdk-cli/test/gitDelta.spec.ts
@@ -4,7 +4,8 @@ import { computeDelta, type DeltaValues, type FileDelta, formatDelta, formatHead
 import type { GitSnapshot } from '../src/gitSnapshot.js';
 
 const base: GitSnapshot = {
-  root: '/repo/one',
+  repo: '/repo/one/.git',
+  worktree: '/repo/one',
   branch: 'main',
   head: 'abc1234',
   stagedFiles: [],
@@ -30,10 +31,19 @@ describe('computeDelta — no changes', () => {
 // ---------------------------------------------------------------------------
 
 describe('computeDelta — repo change', () => {
-  it('captures repo root from/to when the working directory moves into another repo', () => {
-    const current = { ...base, root: '/repo/two' };
+  it('captures repo identity from/to when the move crosses into a different repo', () => {
+    const current = { ...base, repo: '/repo/two/.git' };
     const actual = computeDelta(base, current);
-    const expected: DeltaValues = { repo: { from: '/repo/one', to: '/repo/two' } };
+    const expected: DeltaValues = { repo: { from: '/repo/one/.git', to: '/repo/two/.git' } };
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('computeDelta — worktree change', () => {
+  it('captures worktree root from/to, independent of repo identity', () => {
+    const current = { ...base, worktree: '/repo/one-linked-worktree' };
+    const actual = computeDelta(base, current);
+    const expected: DeltaValues = { worktree: { from: '/repo/one', to: '/repo/one-linked-worktree' } };
     expect(actual).toEqual(expected);
   });
 });
@@ -146,15 +156,23 @@ describe('formatDelta — wrapper', () => {
 });
 
 describe('formatDelta — repo', () => {
-  it('formats repo root change with arrow', () => {
-    const actual = formatDelta({ repo: { from: '/repo/one', to: '/repo/two' } });
-    const expected = '<git-delta>repo: /repo/one → /repo/two</git-delta>';
+  it('formats repo identity change with arrow', () => {
+    const actual = formatDelta({ repo: { from: '/repo/one/.git', to: '/repo/two/.git' } });
+    const expected = '<git-delta>repo: /repo/one/.git → /repo/two/.git</git-delta>';
     expect(actual).toEqual(expected);
   });
 
   it('shows (none) when moving out of or into a non-repo directory', () => {
-    const actual = formatDelta({ repo: { from: '/repo/one', to: '' } });
-    const expected = '<git-delta>repo: /repo/one → (none)</git-delta>';
+    const actual = formatDelta({ repo: { from: '/repo/one/.git', to: '' } });
+    const expected = '<git-delta>repo: /repo/one/.git → (none)</git-delta>';
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('formatDelta — worktree', () => {
+  it('formats worktree root change with arrow', () => {
+    const actual = formatDelta({ worktree: { from: '/repo/one', to: '/repo/one-linked-worktree' } });
+    const expected = '<git-delta>worktree: /repo/one → /repo/one-linked-worktree</git-delta>';
     expect(actual).toEqual(expected);
   });
 });
@@ -307,7 +325,7 @@ describe('GitStateMonitor — HEAD change queries divergence', () => {
 
   it('skips the divergence lookup entirely when the move crossed into a different repo', async () => {
     let call = 0;
-    const snapshots: GitSnapshot[] = [base, { ...base, root: '/repo/two', head: 'def5678' }];
+    const snapshots: GitSnapshot[] = [base, { ...base, repo: '/repo/two/.git', worktree: '/repo/two', head: 'def5678' }];
     let divergenceCalled = false;
     const monitor = new GitStateMonitor(
       () => Promise.resolve({ ...(snapshots[call++] ?? base) }),
@@ -318,9 +336,22 @@ describe('GitStateMonitor — HEAD change queries divergence', () => {
     );
     await monitor.takeSnapshot();
     const actual = await monitor.getDelta();
-    const expected = '<git-delta>repo: /repo/one \u2192 /repo/two | HEAD: abc1234 \u2192 def5678</git-delta>';
+    const expected = '<git-delta>repo: /repo/one/.git \u2192 /repo/two/.git | worktree: /repo/one \u2192 /repo/two | HEAD: abc1234 \u2192 def5678</git-delta>';
     expect(actual).toEqual(expected);
     expect(divergenceCalled).toEqual(false);
+  });
+
+  it('still runs the divergence lookup when only the worktree changed (same repo)', async () => {
+    let call = 0;
+    const snapshots: GitSnapshot[] = [base, { ...base, worktree: '/repo/one-linked-worktree', head: 'def5678' }];
+    const monitor = new GitStateMonitor(
+      () => Promise.resolve({ ...(snapshots[call++] ?? base) }),
+      () => Promise.resolve({ onlyOld: 0, onlyNew: 1 }),
+    );
+    await monitor.takeSnapshot();
+    const actual = await monitor.getDelta();
+    const expected = '<git-delta>worktree: /repo/one \u2192 /repo/one-linked-worktree | HEAD: abc1234 \u2192 def5678 (1 ahead)</git-delta>';
+    expect(actual).toEqual(expected);
   });
 });
 

--- a/apps/claude-sdk-cli/test/gitDelta.spec.ts
+++ b/apps/claude-sdk-cli/test/gitDelta.spec.ts
@@ -4,6 +4,7 @@ import { computeDelta, type DeltaValues, type FileDelta, formatDelta, formatHead
 import type { GitSnapshot } from '../src/gitSnapshot.js';
 
 const base: GitSnapshot = {
+  root: '/repo/one',
   branch: 'main',
   head: 'abc1234',
   stagedFiles: [],
@@ -27,6 +28,15 @@ describe('computeDelta — no changes', () => {
 // ---------------------------------------------------------------------------
 // computeDelta — individual field changes
 // ---------------------------------------------------------------------------
+
+describe('computeDelta — repo change', () => {
+  it('captures repo root from/to when the working directory moves into another repo', () => {
+    const current = { ...base, root: '/repo/two' };
+    const actual = computeDelta(base, current);
+    const expected: DeltaValues = { repo: { from: '/repo/one', to: '/repo/two' } };
+    expect(actual).toEqual(expected);
+  });
+});
 
 describe('computeDelta — branch change', () => {
   it('captures branch from/to when branch differs', () => {
@@ -132,6 +142,20 @@ describe('formatDelta — wrapper', () => {
     const actual = formatDelta({ branch: { from: 'main', to: 'feature/x' } });
     const expected = true;
     expect(actual.startsWith('<git-delta>') && actual.endsWith('</git-delta>')).toEqual(expected);
+  });
+});
+
+describe('formatDelta — repo', () => {
+  it('formats repo root change with arrow', () => {
+    const actual = formatDelta({ repo: { from: '/repo/one', to: '/repo/two' } });
+    const expected = '<git-delta>repo: /repo/one → /repo/two</git-delta>';
+    expect(actual).toEqual(expected);
+  });
+
+  it('shows (none) when moving out of or into a non-repo directory', () => {
+    const actual = formatDelta({ repo: { from: '/repo/one', to: '' } });
+    const expected = '<git-delta>repo: /repo/one → (none)</git-delta>';
+    expect(actual).toEqual(expected);
   });
 });
 
@@ -279,6 +303,24 @@ describe('GitStateMonitor — HEAD change queries divergence', () => {
     const actual = await monitor.getDelta();
     const expected = '<git-delta>HEAD: abc1234 \u2192 def5678</git-delta>';
     expect(actual).toEqual(expected);
+  });
+
+  it('skips the divergence lookup entirely when the move crossed into a different repo', async () => {
+    let call = 0;
+    const snapshots: GitSnapshot[] = [base, { ...base, root: '/repo/two', head: 'def5678' }];
+    let divergenceCalled = false;
+    const monitor = new GitStateMonitor(
+      () => Promise.resolve({ ...(snapshots[call++] ?? base) }),
+      () => {
+        divergenceCalled = true;
+        return Promise.resolve({ onlyOld: 0, onlyNew: 1 });
+      },
+    );
+    await monitor.takeSnapshot();
+    const actual = await monitor.getDelta();
+    const expected = '<git-delta>repo: /repo/one \u2192 /repo/two | HEAD: abc1234 \u2192 def5678</git-delta>';
+    expect(actual).toEqual(expected);
+    expect(divergenceCalled).toEqual(false);
   });
 });
 

--- a/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
+++ b/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
@@ -1,19 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import { gatherGitSnapshot, gatherHeadDivergence, parseBranch, parseDivergence, parseHead, parseRoot, parseStash, parseStatus } from '../src/gitSnapshot.js';
+import { gatherGitSnapshot, gatherHeadDivergence, parseBranch, parseDivergence, parseHead, parseRepo, parseStash, parseStatus, parseWorktree } from '../src/gitSnapshot.js';
 
 // ---------------------------------------------------------------------------
-// parseRoot
+// parseRepo
 // ---------------------------------------------------------------------------
 
-describe('parseRoot', () => {
-  it('returns the repo root path trimmed of whitespace', () => {
-    const actual = parseRoot('/Users/stephen/repos/example\n');
+describe('parseRepo', () => {
+  it('returns the common git dir path trimmed of whitespace', () => {
+    const actual = parseRepo('/Users/stephen/repos/example/.git\n');
+    const expected = '/Users/stephen/repos/example/.git';
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns empty string outside a repo', () => {
+    const actual = parseRepo('\n');
+    const expected = '';
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWorktree
+// ---------------------------------------------------------------------------
+
+describe('parseWorktree', () => {
+  it('returns the worktree root path trimmed of whitespace', () => {
+    const actual = parseWorktree('/Users/stephen/repos/example\n');
     const expected = '/Users/stephen/repos/example';
     expect(actual).toEqual(expected);
   });
 
   it('returns empty string outside a repo', () => {
-    const actual = parseRoot('\n');
+    const actual = parseWorktree('\n');
     const expected = '';
     expect(actual).toEqual(expected);
   });
@@ -200,7 +218,7 @@ describe('gatherGitSnapshot', () => {
     expect(snapshot.head).toEqual('');
   });
 
-  it('resolves with root empty string when show-toplevel fails (not in a repo)', async () => {
+  it('resolves with worktree empty string when show-toplevel fails (not in a repo)', async () => {
     const runner = (args: string[]): Promise<string> => {
       if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
         return Promise.reject(new Error('fatal: not a git repository'));
@@ -208,7 +226,31 @@ describe('gatherGitSnapshot', () => {
       return Promise.resolve('');
     };
     const snapshot = await gatherGitSnapshot(runner);
-    expect(snapshot.root).toEqual('');
+    expect(snapshot.worktree).toEqual('');
+  });
+
+  it('resolves with repo empty string when git-common-dir fails (not in a repo)', async () => {
+    const runner = (args: string[]): Promise<string> => {
+      if (args[1] === '--git-common-dir') {
+        return Promise.reject(new Error('fatal: not a git repository'));
+      }
+      return Promise.resolve('');
+    };
+    const snapshot = await gatherGitSnapshot(runner);
+    expect(snapshot.repo).toEqual('');
+  });
+
+  it('requests the common git dir as an absolute path', async () => {
+    let capturedArgs: string[] = [];
+    const runner = (args: string[]): Promise<string> => {
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
+        capturedArgs = args;
+      }
+      return Promise.resolve('');
+    };
+    await gatherGitSnapshot(runner);
+    const expected = ['rev-parse', '--path-format=absolute', '--git-common-dir'];
+    expect(capturedArgs).toEqual(expected);
   });
 });
 

--- a/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
+++ b/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { gatherGitSnapshot, parseBranch, parseHead, parseStash, parseStatus } from '../src/gitSnapshot.js';
+import { gatherGitSnapshot, gatherHeadDivergence, parseBranch, parseDivergence, parseHead, parseStash, parseStatus } from '../src/gitSnapshot.js';
 
 // ---------------------------------------------------------------------------
 // parseBranch
@@ -180,5 +180,47 @@ describe('gatherGitSnapshot', () => {
     };
     const snapshot = await gatherGitSnapshot(runner);
     expect(snapshot.head).toEqual('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDivergence
+// ---------------------------------------------------------------------------
+
+describe('parseDivergence', () => {
+  it('parses left-right counts separated by a tab', () => {
+    const actual = parseDivergence('10\t21\n');
+    const expected = { onlyOld: 10, onlyNew: 21 };
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns null for unparsable output', () => {
+    const actual = parseDivergence('fatal: bad revision\n');
+    const expected = null;
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gatherHeadDivergence
+// ---------------------------------------------------------------------------
+
+describe('gatherHeadDivergence', () => {
+  it('runs rev-list --left-right --count over the from...to range', async () => {
+    let capturedArgs: string[] = [];
+    const runner = (args: string[]): Promise<string> => {
+      capturedArgs = args;
+      return Promise.resolve('10\t21\n');
+    };
+    await gatherHeadDivergence('8f9138d', '8c59648', runner);
+    const expected = ['rev-list', '--left-right', '--count', '8f9138d...8c59648'];
+    expect(capturedArgs).toEqual(expected);
+  });
+
+  it('returns null when the runner rejects (e.g. unknown revision)', async () => {
+    const runner = (): Promise<string> => Promise.reject(new Error('fatal: bad revision'));
+    const actual = await gatherHeadDivergence('abc1234', 'def5678', runner);
+    const expected = null;
+    expect(actual).toEqual(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
+++ b/apps/claude-sdk-cli/test/gitSnapshot.spec.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { gatherGitSnapshot, gatherHeadDivergence, parseBranch, parseDivergence, parseHead, parseStash, parseStatus } from '../src/gitSnapshot.js';
+import { gatherGitSnapshot, gatherHeadDivergence, parseBranch, parseDivergence, parseHead, parseRoot, parseStash, parseStatus } from '../src/gitSnapshot.js';
+
+// ---------------------------------------------------------------------------
+// parseRoot
+// ---------------------------------------------------------------------------
+
+describe('parseRoot', () => {
+  it('returns the repo root path trimmed of whitespace', () => {
+    const actual = parseRoot('/Users/stephen/repos/example\n');
+    const expected = '/Users/stephen/repos/example';
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns empty string outside a repo', () => {
+    const actual = parseRoot('\n');
+    const expected = '';
+    expect(actual).toEqual(expected);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // parseBranch
@@ -180,6 +198,17 @@ describe('gatherGitSnapshot', () => {
     };
     const snapshot = await gatherGitSnapshot(runner);
     expect(snapshot.head).toEqual('');
+  });
+
+  it('resolves with root empty string when show-toplevel fails (not in a repo)', async () => {
+    const runner = (args: string[]): Promise<string> => {
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+        return Promise.reject(new Error('fatal: not a git repository'));
+      }
+      return Promise.resolve('');
+    };
+    const snapshot = await gatherGitSnapshot(runner);
+    expect(snapshot.root).toEqual('');
   });
 });
 


### PR DESCRIPTION
## Summary

- The HEAD line in the `<git-delta>` reminder now shows how many commits sit only on the old side and only on the new side, e.g. `HEAD: 8f9138d → 8c59648 (10 behind, 21 ahead)`, instead of just the before/after SHA
- The reminder now tracks repo identity (the common git dir, shared across worktrees) and worktree path (the checkout you're standing in) as separate fields, so a directory move is reported accurately: moving between worktrees of the same repo shows `worktree:` (and usually `branch:`), while moving into a genuinely different repo shows `repo:`
- The ahead/behind lookup only runs when the repo is unchanged, since a cross-repo commit-count comparison would be meaningless
- Every lookup is best-effort: if it fails, the delta still shows the plain before/after values with no divergence note