### PR TITLE
GitHub PR tools no longer require a pull request number

### DIFF
--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EditFile's insert after_line accepts negative indices (-1 = after the last line) so appending no longer requires knowing the file's line count
 - Exec, ExecV2, and ExecV3 redirect writes now go through IFileSystem instead of importing node:fs directly
 - ExecV3 requires an IEnvProvider argument; createExecV3 and configureExecV3 signatures changed to accept it
+- GitHub_PullRequest_Ready/Edit/Comment/AutoMerge/Review no longer require a pull request number — omit it to target the pull request associated with the current branch, matching gh's own resolution
 - Mark every filesystem-path field on the tool schemas so the SDK normalises it, and drop the per-handler path expansion; DeleteFile and DeleteDirectory now take a files array
 - Merge PreviewEdit and EditFile into a single EditFile tool that validates, writes, and returns a diff in one call, removing the preview/confirm step and its in-memory patch store
 - ReadFile accepts image/* to read any supported image format; the format is detected from file content rather than the declared type

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -76,3 +76,4 @@
 {"description":"ReadFile returns a successful text read as plain path-and-line text instead of a JSON object, matching the Pipe Read stage's output","category":"changed"}
 {"description":"Fix version metadata","category":"fixed"}
 {"description":"ExecV3's safety rules can be overridden, removed, or added to in config, with changes taking effect immediately and no restart","category":"added"}
+{"description":"GitHub_PullRequest_Ready/Edit/Comment/AutoMerge/Review no longer require a pull request number — omit it to target the pull request associated with the current branch, matching gh's own resolution","category":"changed"}

--- a/packages/claude-sdk-tools/src/GitHub/schema.ts
+++ b/packages/claude-sdk-tools/src/GitHub/schema.ts
@@ -25,14 +25,14 @@ export const GhPrCreateInputSchema = z
 
 export const GhPrReadyInputSchema = z
   .object({
-    number: z.number().int().positive().describe('The pull request number to mark ready for review'),
+    number: z.number().int().positive().optional().describe('The pull request number to mark ready for review. Omit to use the pull request associated with the current branch.'),
     cwd: cwdSchema,
   })
   .strict();
 
 export const GhPrEditInputSchema = z
   .object({
-    number: z.number().int().positive().describe('The pull request number to edit'),
+    number: z.number().int().positive().optional().describe('The pull request number to edit. Omit to use the pull request associated with the current branch.'),
     title: z.string().optional().describe('Set the new title'),
     body: z.string().optional().describe('Set the new body'),
     addLabel: z.array(z.string()).optional().describe('Add labels by name'),
@@ -49,7 +49,7 @@ export const GhPrEditInputSchema = z
 
 export const GhPrCommentInputSchema = z
   .object({
-    number: z.number().int().positive().describe('The pull request number to comment on'),
+    number: z.number().int().positive().optional().describe('The pull request number to comment on. Omit to use the pull request associated with the current branch.'),
     body: z.string().min(1).describe('The comment body text'),
     cwd: cwdSchema,
   })
@@ -57,7 +57,7 @@ export const GhPrCommentInputSchema = z
 
 export const GhPrAutoMergeInputSchema = z
   .object({
-    number: z.number().int().positive().describe('The pull request number'),
+    number: z.number().int().positive().optional().describe('The pull request number. Omit to use the pull request associated with the current branch.'),
     enable: z.boolean().describe('true enables auto-merge (--auto), false disables it (--disable-auto). This tool never performs an immediate merge.'),
     strategy: z.enum(['merge', 'squash', 'rebase']).optional().describe('Merge strategy flag (--merge, --squash, --rebase) to pass alongside --auto. Required when enable is true; ignored when disabling.'),
     cwd: cwdSchema,
@@ -70,7 +70,7 @@ export const GhPrAutoMergeInputSchema = z
 
 export const GhPrReviewInputSchema = z
   .object({
-    number: z.number().int().positive().describe('The pull request number to review'),
+    number: z.number().int().positive().optional().describe('The pull request number to review. Omit to use the pull request associated with the current branch.'),
     type: z.enum(['comment', 'request-changes']).describe("The kind of review to leave. There is no 'approve' option — this tool cannot approve a pull request."),
     body: z.string().min(1).describe('The review body text'),
     cwd: cwdSchema,

--- a/packages/claude-sdk-tools/src/GitHub/tools.ts
+++ b/packages/claude-sdk-tools/src/GitHub/tools.ts
@@ -40,9 +40,9 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
       name: 'GitHub_PullRequest_Ready',
       description: 'Mark a draft pull request as ready for review.',
       input_schema: GhPrReadyInputSchema,
-      input_examples: [{ number: 42 }],
+      input_examples: [{ number: 42 }, {}],
       subcommand: 'ready',
-      buildArgs: (input) => [String(input.number)],
+      buildArgs: (input) => (input.number != null ? [String(input.number)] : []),
     },
     deps,
   );
@@ -55,7 +55,7 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
       input_examples: [{ number: 42, addLabel: ['bug'] }],
       subcommand: 'edit',
       buildArgs: (input) => {
-        const args: string[] = [String(input.number)];
+        const args: string[] = input.number != null ? [String(input.number)] : [];
         if (input.title != null) {
           args.push('--title', input.title);
         }
@@ -99,7 +99,7 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
       input_schema: GhPrCommentInputSchema,
       input_examples: [{ number: 42, body: 'Looks good, one small thing below.' }],
       subcommand: 'comment',
-      buildArgs: (input) => [String(input.number), '--body', input.body],
+      buildArgs: (input) => [...(input.number != null ? [String(input.number)] : []), '--body', input.body],
     },
     deps,
   );
@@ -112,10 +112,11 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
       input_examples: [{ number: 42, enable: true, strategy: 'squash' }],
       subcommand: 'merge',
       buildArgs: (input) => {
+        const numberArgs = input.number != null ? [String(input.number)] : [];
         if (!input.enable) {
-          return [String(input.number), '--disable-auto'];
+          return [...numberArgs, '--disable-auto'];
         }
-        return [String(input.number), '--auto', `--${input.strategy}`];
+        return [...numberArgs, '--auto', `--${input.strategy}`];
       },
     },
     deps,
@@ -128,7 +129,7 @@ export function createGhPrTools(deps: GhEscalatedDeps) {
       input_schema: GhPrReviewInputSchema,
       input_examples: [{ number: 42, type: 'comment', body: 'Interesting approach.' }],
       subcommand: 'review',
-      buildArgs: (input) => [String(input.number), input.type === 'comment' ? '--comment' : '--request-changes', '--body', input.body],
+      buildArgs: (input) => [...(input.number != null ? [String(input.number)] : []), input.type === 'comment' ? '--comment' : '--request-changes', '--body', input.body],
     },
     deps,
   );


### PR DESCRIPTION
## Summary

- GitHub PR tools (ready, edit, comment, auto-merge, review) now work without a PR number, resolving the current branch's PR the same way `gh pr status` does