### PR TITLE
AzureDevOps.PullRequest.* tools support multiple accounts, live config, and cached logins

### DIFF
--- a/.claude/scripts/az-keychain-cert-create.sh
+++ b/.claude/scripts/az-keychain-cert-create.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# Generates a self-signed certificate credential for an existing App Registration (created by
+# az-sp-create.sh, which deliberately creates the SP with no credential) and stores it in the
+# macOS login Keychain under the item apps/claude-sdk-cli/src/secrets/Secrets.ts reads: service
+# '@shellicar/credentials', account '<account-name>-cert'.
+#
+# Owns the certificate's entire local lifecycle in one place: generate, store, delete the temp
+# file. The PEM never leaves this script as an argument the operator has to carry between two
+# invocations — az ad app credential reset --create-cert writes it to a temp file under $HOME,
+# and this script finds that file itself the same way az-sp-create.sh's old combined form did,
+# stores its content, then deletes it. Nothing about the cert content ever touches argv or stdout.
+#
+# Deliberately its own script, separate from az-sp-create.sh: an SP/role only needs creating
+# once, but a certificate can need regenerating any number of times after that (rotation, or
+# fixing a wrong --account-name) without touching the SP or its role assignment at all.
+#
+# --account-name is the bare key from sdk-config.json's az.accounts (e.g. 'hopeventures'), and
+# --identity is reader|holder — the same two inputs az-sp-create.sh took. This script builds the
+# actual Keychain account name itself, 'az-<account-name>-<identity>', matching exactly what
+# Secrets.ts's azCert(account, identity) looks up. It is not typed in already-assembled: making
+# the operator hand-assemble 'az-hopeventures-reader' themselves is exactly the kind of manual
+# string-matching that caused the original bug this pair of scripts replaced.
+#
+# The Keychain write always overwrites (`security add-generic-password -U`) — this script's only
+# job for the Keychain side is "the current cert lives at this account name", so a second run
+# against the same --account-name/--identity must always succeed, not be blocked by refusing to
+# touch an existing item. --delete-old is unrelated to the Keychain: it only prunes stale Entra AD
+# credentials — every credential that existed on the app *before* this run, so old unused certs
+# don't pile up on the App Registration after repeated rotation. Off by default: --append (used
+# regardless) is always safe on its own, since it only ever adds; --delete-old is the deliberate,
+# explicit opt-in to also clean up what preceded it.
+#
+# Dry run by default: prints the plan, touches nothing. Pass --apply to actually generate and store.
+#
+# Usage:
+#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder
+#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --apply
+#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --delete-old --apply
+
+set -eu
+
+SERVICE='@shellicar/credentials'
+DISPLAY_NAME=''
+ACCOUNT_NAME=''
+IDENTITY=''
+APPLY=0
+DELETE_OLD=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --display-name) DISPLAY_NAME="$2"; shift 2 ;;
+    --account-name) ACCOUNT_NAME="$2"; shift 2 ;;
+    --identity) IDENTITY="$2"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    --delete-old) DELETE_OLD=1; shift ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ]; then
+  echo "usage: az-keychain-cert-create.sh --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder [--delete-old] [--apply]" >&2
+  exit 1
+fi
+
+case "$IDENTITY" in
+  reader | holder) ;;
+  *)
+    echo "error: --identity must be 'reader' or 'holder', got '$IDENTITY'" >&2
+    exit 1
+    ;;
+esac
+
+ACCOUNT="az-${ACCOUNT_NAME}-${IDENTITY}-cert"
+
+# Resolved from the display name, not typed in by hand as a GUID — the operator only ever knows
+# the app by the display name az-sp-create.sh printed at creation. Read-only, so this runs
+# unconditionally, dry run or not. An exact-match filter, and an explicit check for zero or more
+# than one match: a display name is not unique in Entra by default, and silently picking
+# whichever app came back first would risk generating a credential for the wrong SP entirely.
+MATCHES=$(az ad app list --display-name "$DISPLAY_NAME" --query "[?displayName=='$DISPLAY_NAME'].appId" -o tsv)
+MATCH_COUNT=$(printf '%s\n' "$MATCHES" | grep -c . || true)
+
+if [ "$MATCH_COUNT" -eq 0 ]; then
+  echo "error: no App Registration found with display name '$DISPLAY_NAME'" >&2
+  exit 1
+fi
+if [ "$MATCH_COUNT" -gt 1 ]; then
+  echo "error: more than one App Registration has display name '$DISPLAY_NAME' — resolve the ambiguity in Entra before running this script:" >&2
+  printf '%s\n' "$MATCHES" >&2
+  exit 1
+fi
+APP_ID="$MATCHES"
+echo "resolved: display name '$DISPLAY_NAME' -> appId $APP_ID"
+
+# Read-only, so this runs regardless of --apply: the whole point of a dry run with --delete-old
+# is to see the real, current list of what would be removed, not a generic statement that
+# something might exist. Queried once, up front, and reused for the actual deletion later so the
+# apply path acts on exactly what the plan just showed — not a second, possibly different read.
+#
+# `az ad app credential list` only ever returns password credentials (client secrets) — it always
+# comes back empty for a cert-only app, even when one is visibly attached in the portal.
+# Certificates live under the app object's own `keyCredentials` property, which only `az ad app
+# show` exposes; that's the source of truth here, not the credential-list command its name
+# suggests should cover this.
+OLD_CREDS=''
+if [ "$DELETE_OLD" -eq 1 ]; then
+  OLD_CREDS=$(az ad app show --id "$APP_ID" --query 'keyCredentials[].{keyId:keyId,displayName:displayName,startDateTime:startDateTime,endDateTime:endDateTime}' -o tsv)
+fi
+
+echo "plan: az ad app credential reset --id $APP_ID --create-cert --years 1 --append"
+echo "plan: store the resulting certificate in Keychain item service='$SERVICE' account='$ACCOUNT' (overwriting any existing value there)"
+echo "plan: delete the certificate's temp file once stored"
+if [ "$DELETE_OLD" -eq 1 ]; then
+  if [ -z "$OLD_CREDS" ]; then
+    echo "plan: --delete-old — no pre-existing Entra credentials found on $APP_ID, nothing to remove"
+  else
+    echo "plan: --delete-old — remove these pre-existing Entra credentials on $APP_ID:"
+    printf '%s\n' "$OLD_CREDS" | while IFS="$(printf '\t')" read -r KEY_ID CRED_NAME START END; do
+      echo "  keyId=$KEY_ID displayName='$CRED_NAME' start=$START end=$END"
+    done
+  fi
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "dry run only — pass --apply to generate and store"
+  exit 0
+fi
+
+OLD_KEY_IDS=''
+if [ "$DELETE_OLD" -eq 1 ] && [ -n "$OLD_CREDS" ]; then
+  OLD_KEY_IDS=$(printf '%s\n' "$OLD_CREDS" | cut -f1)
+fi
+# `az ad app credential reset --create-cert` ignores cwd and always writes the PEM under $HOME
+# (named tmp<random>.pem), regardless of where this script is invoked from. A before/after
+# snapshot of $HOME is the only reliable way to find the file it just wrote — cwd or a temp dir
+# passed in some other way will not see it.
+MARKER=$(mktemp)
+
+OUTPUT=$(az ad app credential reset --id "$APP_ID" --create-cert --years 1 --append --output json)
+
+CERT_FILE=$(find "$HOME" -maxdepth 1 -name 'tmp*.pem' -newer "$MARKER" | head -n1)
+rm -f "$MARKER"
+
+if [ -z "$CERT_FILE" ] || [ ! -f "$CERT_FILE" ]; then
+  echo "error: no certificate file found under \$HOME newer than this run — az output was:" >&2
+  printf '%s\n' "$OUTPUT" >&2
+  exit 1
+fi
+
+security add-generic-password -U -s "$SERVICE" -a "$ACCOUNT" -w "$(cat "$CERT_FILE")"
+rm -f "$CERT_FILE"
+
+if [ "$DELETE_OLD" -eq 1 ] && [ -n "$OLD_KEY_IDS" ]; then
+  for KEY_ID in $OLD_KEY_IDS; do
+    # --cert: without it this targets a password credential with this keyId, which never exists
+    # for a cert-only app — the delete would silently no-op instead of removing the old key.
+    az ad app credential delete --id "$APP_ID" --key-id "$KEY_ID" --cert >/dev/null
+    echo "OK: removed Entra credential keyId='$KEY_ID'"
+  done
+fi
+
+echo "✓ Certificate generated and stored in Keychain"
+echo "account: $ACCOUNT"

--- a/.claude/scripts/az-sp-create.sh
+++ b/.claude/scripts/az-sp-create.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
-# Creates an Entra ID App Registration + Service Principal with a self-signed certificate
-# credential (no client secret — --create-password false, so no bearer secret is ever
-# generated), assigns an RBAC role, and stores the certificate in the macOS login Keychain
-# under the item apps/claude-sdk-cli/src/secrets/Secrets.ts reads (service
-# '@shellicar/credentials', account '<name>-cert').
+# Creates an Entra ID App Registration + Service Principal with NO credential (no password, no
+# certificate — same as leaving both blank in the portal) and assigns an RBAC role. Credential
+# generation is a separate script (see az-keychain-cert-create.sh), because SP/role creation and
+# certificate lifecycle are different operations with different failure modes: recreating a whole
+# SP just to regenerate a cert (rotation, or fixing a wrong Keychain account name) is wasteful and
+# invalidates whatever else was already wired to the old SP's appId. This script runs once per SP;
+# az-keychain-cert-create.sh can run again any time against the same SP.
+#
+# --display-name is Entra's own free-text display name (--name on `az ad sp
+# create-for-rbac`), shown in the portal, read back by nothing — it is not, and is never meant to
+# be, the Keychain account name used later.
 #
 # The role is not a free-text argument. --identity reader|holder maps to a fixed role below —
 # there is deliberately nothing else to pass, so a fat-fingered role can't happen here. The
@@ -13,28 +19,26 @@
 # separate script is exactly the gap this script used to have: "unprivileged"/"no delete" must
 # be what the tooling creates, not a follow-up step an operator has to remember to run.
 #
-# `az login --service-principal --certificate <path>` is the only way this credential is ever
-# used; nothing else reads it. The certificate never touches this script's argv or stdout —
-# it goes straight from the temp dir az writes it to, into the Keychain, then is deleted.
-#
 # Dry run by default: prints the plan, touches nothing. Pass --apply to actually create.
 #
 # Usage:
-#   .claude/scripts/az-sp-create.sh --name az-holder --identity holder --scope /subscriptions/<id>
-#   .claude/scripts/az-sp-create.sh --name az-holder --identity holder --scope /subscriptions/<id> --apply
+#   .claude/scripts/az-sp-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --scope /subscriptions/<id>
+#   .claude/scripts/az-sp-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --scope /subscriptions/<id> --apply
+#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --apply
 
 set -eu
 
-SERVICE='@shellicar/credentials'
 HOLDER_ROLE_NAME='Contributor (No Delete)'
-NAME=''
+DISPLAY_NAME=''
+ACCOUNT_NAME=''
 IDENTITY=''
 SCOPE=''
 APPLY=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --name) NAME="$2"; shift 2 ;;
+    --display-name) DISPLAY_NAME="$2"; shift 2 ;;
+    --account-name) ACCOUNT_NAME="$2"; shift 2 ;;
     --identity) IDENTITY="$2"; shift 2 ;;
     --scope) SCOPE="$2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
@@ -45,8 +49,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "$NAME" ] || [ -z "$IDENTITY" ] || [ -z "$SCOPE" ]; then
-  echo "usage: az-sp-create.sh --name NAME --identity reader|holder --scope SCOPE [--apply]" >&2
+if [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ] || [ -z "$SCOPE" ]; then
+  echo "usage: az-sp-create.sh --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder --scope SCOPE [--apply]" >&2
   exit 1
 fi
 
@@ -59,23 +63,16 @@ case "$IDENTITY" in
     ;;
 esac
 
-ACCOUNT="${NAME}-cert"
-
 if [ "$IDENTITY" = 'holder' ]; then
   echo "plan: create custom role '$HOLDER_ROLE_NAME' at scope $SCOPE if it doesn't already exist — Contributor's own actions/notActions plus a */delete NotAction"
 fi
-echo "plan: az ad sp create-for-rbac --name $NAME --role '$ROLE' --scopes $SCOPE --create-cert --create-password false --years 1"
-echo "plan: store resulting certificate in Keychain item service='$SERVICE' account='$ACCOUNT'"
-echo "plan: appId/tenantId printed to stdout (non-secret) for sdk-config.json's az.accounts.<account>.* fields — nothing else is printed"
+echo "plan: az ad sp create-for-rbac --name '$DISPLAY_NAME' --role '$ROLE' --scopes $SCOPE --create-password false"
+echo "plan: print appId, tenantId to stdout (non-secret) — no credential is created here"
+echo "plan: next step (separate, by hand): az-keychain-cert-create.sh --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY --apply"
 
 if [ "$APPLY" -eq 0 ]; then
   echo "dry run only — pass --apply to create"
   exit 0
-fi
-
-if security find-generic-password -s "$SERVICE" -a "$ACCOUNT" >/dev/null 2>&1; then
-  echo "error: Keychain item service='$SERVICE' account='$ACCOUNT' already exists — remove it first if you mean to replace it" >&2
-  exit 1
 fi
 
 if [ "$IDENTITY" = 'holder' ] && ! az role definition list --name "$HOLDER_ROLE_NAME" --scope "$SCOPE" --query '[0].roleName' -o tsv | grep -q .; then
@@ -112,29 +109,22 @@ EOF
   echo "OK: custom role '$HOLDER_ROLE_NAME' created"
 fi
 
-# `az ad sp create-for-rbac --create-cert` ignores cwd and always writes the PEM under $HOME
-# (named tmp<random>.pem), regardless of where this script is invoked from. A before/after
-# snapshot of $HOME is the only reliable way to find the file it just wrote — cwd or a temp
-# dir passed in some other way will not see it.
-MARKER=$(mktemp)
-
-OUTPUT=$(az ad sp create-for-rbac --name "$NAME" --role "$ROLE" --scopes "$SCOPE" --create-cert --create-password false --years 1 --output json)
+OUTPUT=$(az ad sp create-for-rbac --name "$DISPLAY_NAME" --role "$ROLE" --scopes "$SCOPE" --create-password false --output json)
 
 APP_ID=$(printf '%s' "$OUTPUT" | jq -r '.appId')
 TENANT_ID=$(printf '%s' "$OUTPUT" | jq -r '.tenant')
-CERT_FILE=$(find "$HOME" -maxdepth 1 -name 'tmp*.pem' -newer "$MARKER" | head -n1)
-rm -f "$MARKER"
 
-if [ -z "$CERT_FILE" ] || [ ! -f "$CERT_FILE" ]; then
-  echo "error: no certificate file found under \$HOME newer than this run — az output was:" >&2
-  printf '%s\n' "$OUTPUT" >&2
-  exit 1
+if [ "$IDENTITY" = 'reader' ]; then
+  READER_FIELD="\"$APP_ID\""
+  HOLDER_FIELD='null'
+else
+  READER_FIELD='null'
+  HOLDER_FIELD="\"$APP_ID\""
 fi
 
-security add-generic-password -s "$SERVICE" -a "$ACCOUNT" -w "$(cat "$CERT_FILE")"
-rm -f "$CERT_FILE"
-
-echo "✓ Service principal created and certificate stored in Keychain"
-echo "appId:    $APP_ID"
-echo "tenantId: $TENANT_ID"
-echo "Add these (non-secret) to sdk-config.json under az.accounts.<account-name>: tenantId, and either readerClientId or holderClientId depending on which identity this is"
+echo "✓ Service principal created, no credential yet"
+echo "appId:     $APP_ID"
+echo "tenantId:  $TENANT_ID"
+echo "Merge this into sdk-config.json (it only fills the $IDENTITY field — fill the other identity's clientId when its own SP exists, or leave it null):"
+jq -n --arg account "$ACCOUNT_NAME" --arg tenantId "$TENANT_ID" --argjson reader "$READER_FIELD" --argjson holder "$HOLDER_FIELD" '{az: {accounts: {($account): {tenantId: $tenantId, readerClientId: $reader, holderClientId: $holder}}}}'
+echo "Then generate and store its certificate: az-keychain-cert-create.sh --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY --apply"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,8 @@ The CLI bundles its own SQLite schema authority. There is no server and no API t
 |--------|------|
 | `gh-holder-secret.sh` / `gh-reader-secret.sh` | Store a gh PAT (holder or reader) into Keychain |
 | `gh-purge-standard-credential.sh` | Remove a broad personal gh credential so it can't bypass the mediated tools |
-| `az-sp-create.sh` | Create an Entra App Registration + Service Principal with a self-signed certificate (no client secret), assign an RBAC role, store the certificate in Keychain |
+| `az-sp-create.sh` | Create an Entra App Registration + Service Principal with a self-signed certificate (no client secret), assign an RBAC role. Does not touch Keychain — prints the cert file path for `az-keychain-store-cert.sh` |
+| `az-keychain-store-cert.sh` | Store a cert file (from `az-sp-create.sh`) into Keychain under the exact account name `Secrets.ts` looks up (`az-<account>-<identity>`) |
 | `ado-push-group-create.sh` | Create a project-scoped Azure DevOps security group with specific Git permission bits and add a member — for shapes the built-in groups don't cover |
 | `az-holder-remove-delete.sh` | Replace an identity's Azure RBAC role assignment with a custom role that strips delete permissions |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,8 +278,8 @@ The CLI bundles its own SQLite schema authority. There is no server and no API t
 |--------|------|
 | `gh-holder-secret.sh` / `gh-reader-secret.sh` | Store a gh PAT (holder or reader) into Keychain |
 | `gh-purge-standard-credential.sh` | Remove a broad personal gh credential so it can't bypass the mediated tools |
-| `az-sp-create.sh` | Create an Entra App Registration + Service Principal with a self-signed certificate (no client secret), assign an RBAC role. Does not touch Keychain — prints the cert file path for `az-keychain-store-cert.sh` |
-| `az-keychain-store-cert.sh` | Store a cert file (from `az-sp-create.sh`) into Keychain under the exact account name `Secrets.ts` looks up (`az-<account>-<identity>`) |
+| `az-sp-create.sh` | Create an Entra App Registration + Service Principal with an RBAC role and no credential (no password, no certificate) |
+| `az-keychain-cert-create.sh` | Generate a certificate credential for an existing App Registration and store it in Keychain under the exact account name `Secrets.ts` looks up (`az-<account>-<identity>`) |
 | `ado-push-group-create.sh` | Create a project-scoped Azure DevOps security group with specific Git permission bits and add a member — for shapes the built-in groups don't cover |
 | `az-holder-remove-delete.sh` | Replace an identity's Azure RBAC role assignment with a custom role that strips delete permissions |
 

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - --config startup display now shows only the keys the payload actually named, not the full merged config
 - Add a plain-ASCII fast path to the TUI cell-grid layout, skipping Intl.Segmenter and stringWidth for rows with no ANSI styling and no wide or combining characters, cutting per-frame layout cost for plain-text rows
 - Adopt core-di-lite property injection end to end: the container resolves the whole graph eagerly, SQLite databases are created through a registered factory, and CLI startup moves into main() so the entry module's only import-time effect is invoking it
-- AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools are hidden from a turn's tool list live whenever no account currently has the matching identity configured, instead of that decision being frozen at startup
+- AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* are hidden from a turn's tools whenever no matching account is configured
 - Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up
 - claude-cli now records each session's directory to a central store and resumes the most-recent session for the current directory, so a conversation survives a restart or a machine going away
 - Command mode can now be entered, navigated, and exited while a query is streaming, not only in the editor phase

--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - --config startup display now shows only the keys the payload actually named, not the full merged config
 - Add a plain-ASCII fast path to the TUI cell-grid layout, skipping Intl.Segmenter and stringWidth for rows with no ANSI styling and no wide or combining characters, cutting per-frame layout cost for plain-text rows
 - Adopt core-di-lite property injection end to end: the container resolves the whole graph eagerly, SQLite databases are created through a registered factory, and CLI startup moves into main() so the entry module's only import-time effect is invoking it
+- AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools are hidden from a turn's tool list live whenever no account currently has the matching identity configured, instead of that decision being frozen at startup
 - Block header dividers now pad to a fixed minimum width instead of the full terminal width, so the trailing run of hyphens no longer scales with the window while short headers still line up
 - claude-cli now records each session's directory to a central store and resumes the most-recent session for the current directory, so a conversation survives a restart or a machine going away
 - Command mode can now be entered, navigated, and exited while a query is streaming, not only in the editor phase

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -158,4 +158,4 @@
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
 {"description":"Show repo and worktree changes separately in the git delta reminder: a move between worktrees of the same repo no longer reads as a different project, and the ahead/behind lookup only runs when the repo is actually the same","category":"added"}
-{"description":"AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools are hidden from a turn's tool list live whenever no account currently has the matching identity configured, instead of that decision being frozen at startup","category":"changed"}
+{"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* are hidden from a turn's tools whenever no matching account is configured","category":"changed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -158,3 +158,5 @@
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
 {"description":"Show repo and worktree changes separately in the git delta reminder: a move between worktrees of the same repo no longer reads as a different project, and the ahead/behind lookup only runs when the repo is actually the same","category":"added"}
+
+{"description":"AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools are hidden from a turn's tool list live whenever no account currently has the matching identity configured, instead of that decision being frozen at startup","category":"changed"}

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -158,5 +158,4 @@
 {"description":"Customize which commands ExecV3 will run or refuse, without a mistake in that customization ever disabling safety or breaking the rest of your settings","category":"added"}
 {"description":"Add commits-ahead/behind counts to the git delta reminder's HEAD change","category":"added"}
 {"description":"Show repo and worktree changes separately in the git delta reminder: a move between worktrees of the same repo no longer reads as a different project, and the ahead/behind lookup only runs when the repo is actually the same","category":"added"}
-
 {"description":"AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools are hidden from a turn's tool list live whenever no account currently has the matching identity configured, instead of that decision being frozen at startup","category":"changed"}

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -71,12 +71,13 @@ export type CreateAppToolsOptions = {
   secrets: ISecrets;
   /** Strips any ambient gh credential and injects the read-only reader token for every ExecV3 call. */
   envProvider: IEnvProvider;
-  /** Named Azure accounts AzCli/EscalatedAzCli can select between — the closed enum each tool's
-   *  `account` field is built from. Empty registers neither tool. */
-  azAccounts: AzAccountsConfig;
+  /** Live source for the named Azure accounts AzCli/EscalatedAzCli/AzureDevOps.PullRequest.* select
+   *  between — read fresh on every call (never captured once), so a config reload that adds,
+   *  removes, or reconfigures an account takes effect on the very next call, with no tool rebuild. */
+  getAzAccounts: () => AzAccountsConfig;
 };
 
-export function createAppTools({ fs, tsServer, toolsConfig, rulesProvider, objects, memory, history, currentSessionId, clock, tsAvailable, logger, skillDirs = [], secrets, envProvider, azAccounts }: CreateAppToolsOptions): AppTools {
+export function createAppTools({ fs, tsServer, toolsConfig, rulesProvider, objects, memory, history, currentSessionId, clock, tsAvailable, logger, skillDirs = [], secrets, envProvider, getAzAccounts }: CreateAppToolsOptions): AppTools {
   const store = new RefStore(objects);
   const ReadFile = createReadFileTool(logger);
   const EditFile = createEditFile(fs);
@@ -114,22 +115,28 @@ export function createAppTools({ fs, tsServer, toolsConfig, rulesProvider, objec
 
   // The AzureDevOps.PullRequest.* tools run as the same holder identity EscalatedAzCli uses — one
   // certificate, proven to authenticate to Azure DevOps directly (see AzCli's runAz), no separate
-  // PAT. Only registered when exactly one account has a holder identity configured; with none or
-  // more than one, there is no unambiguous holder to run as, so the tools are left unregistered
-  // rather than guessing. No org config needed: each call resolves org from its own git remote or
-  // the model's explicit input (see AzureDevOps/tools.ts's orgArgs).
-  const adoAccounts = Object.entries(azAccounts).filter(([, a]) => a.holderClientId != null);
-  if (adoAccounts.length === 1) {
-    const [accountName, account] = adoAccounts[0];
-    tools.push(
-      ...createAdoPrTools({
+  // PAT. Always registered: which account (if any) currently has a holder identity configured is
+  // live config, resolved fresh per call (see resolveAzAccount) and re-checked by the disabled-tools
+  // provider each turn — never decided once here at startup. No org config needed: each call
+  // resolves org from its own git remote or the model's explicit input (see AzureDevOps/tools.ts's
+  // orgArgs).
+  tools.push(
+    ...createAdoPrTools(
+      {
         executor: adoExecutor,
-        getCert: () => secrets.azCert(accountName, 'holder'),
-        getClientId: () => account.holderClientId as string,
-        getTenantId: () => account.tenantId,
-      }),
-    );
-  }
+        getCert: (account) => secrets.azCert(account, 'holder'),
+        getClientId: (account) => {
+          const clientId = getAzAccounts()[account]?.holderClientId;
+          if (clientId == null) {
+            throw new Error(`az account '${account}' has no holder clientId configured`);
+          }
+          return clientId;
+        },
+        getTenantId: (account) => getAzAccounts()[account].tenantId,
+      },
+      getAzAccounts,
+    ),
+  );
 
   tools.push(
     ...createAzTools(
@@ -137,15 +144,15 @@ export function createAppTools({ fs, tsServer, toolsConfig, rulesProvider, objec
         executor: azExecutor,
         getCert: (account, identity) => secrets.azCert(account, identity),
         getClientId: (account, identity) => {
-          const clientId = identity === 'reader' ? azAccounts[account]?.readerClientId : azAccounts[account]?.holderClientId;
+          const clientId = identity === 'reader' ? getAzAccounts()[account]?.readerClientId : getAzAccounts()[account]?.holderClientId;
           if (clientId == null) {
             throw new Error(`az account '${account}' has no ${identity} clientId configured`);
           }
           return clientId;
         },
-        getTenantId: (account) => azAccounts[account].tenantId,
+        getTenantId: (account) => getAzAccounts()[account].tenantId,
       },
-      azAccounts,
+      getAzAccounts,
       clock,
       logger,
     ),

--- a/apps/claude-sdk-cli/src/createAppTools.ts
+++ b/apps/claude-sdk-cli/src/createAppTools.ts
@@ -6,8 +6,8 @@ import type { IMemoryStore } from '@shellicar/claude-core/memory/interfaces';
 import type { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
 import type { AnyToolDefinition, ToolBlockLifetime } from '@shellicar/claude-sdk';
 import { AppendFile } from '@shellicar/claude-sdk-tools/AppendFile';
-import { type AzAccountsConfig, azExecutor, createAzTools } from '@shellicar/claude-sdk-tools/Az';
-import { adoExecutor, createAdoPrTools } from '@shellicar/claude-sdk-tools/AzureDevOps';
+import { type AzAccountsConfig, type AzDeps, AzSessionCache, azExecutor, createAzTools } from '@shellicar/claude-sdk-tools/Az';
+import { createAdoPrTools } from '@shellicar/claude-sdk-tools/AzureDevOps';
 import { CreateFile } from '@shellicar/claude-sdk-tools/CreateFile';
 import { toStandalone } from '@shellicar/claude-sdk-tools/composable';
 import { DeleteDirectory } from '@shellicar/claude-sdk-tools/DeleteDirectory';
@@ -114,49 +114,37 @@ export function createAppTools({ fs, tsServer, toolsConfig, rulesProvider, objec
   tools.push(...createGhPrTools({ executor: ghExecutor, getHolderToken: () => secrets.ghHolderToken() }));
 
   // The AzureDevOps.PullRequest.* tools run as the same holder identity EscalatedAzCli uses — one
-  // certificate, proven to authenticate to Azure DevOps directly (see AzCli's runAz), no separate
-  // PAT. Always registered: which account (if any) currently has a holder identity configured is
-  // live config, resolved fresh per call (see resolveAzAccount) and re-checked by the disabled-tools
-  // provider each turn — never decided once here at startup. No org config needed: each call
-  // resolves org from its own git remote or the model's explicit input (see AzureDevOps/tools.ts's
-  // orgArgs).
-  tools.push(
-    ...createAdoPrTools(
-      {
-        executor: adoExecutor,
-        getCert: (account) => secrets.azCert(account, 'holder'),
-        getClientId: (account) => {
-          const clientId = getAzAccounts()[account]?.holderClientId;
-          if (clientId == null) {
-            throw new Error(`az account '${account}' has no holder clientId configured`);
-          }
-          return clientId;
-        },
-        getTenantId: (account) => getAzAccounts()[account].tenantId,
-      },
-      getAzAccounts,
-    ),
-  );
+  // certificate, proven to authenticate to Azure DevOps directly, no separate PAT. Always
+  // registered: which account (if any) currently has a holder identity configured is live config,
+  // resolved fresh per call (see resolveAzAccount) and re-checked by the disabled-tools provider
+  // each turn — never decided once here at startup. No org config needed: each call resolves org
+  // from its own git remote or the model's explicit input (see AzureDevOps/tools.ts's orgArgs).
+  //
+  // One AzDeps object and one AzSessionCache, shared verbatim between AzCli/EscalatedAzCli and the
+  // AzureDevOps.PullRequest.* tools — they are the same credential mechanism (a holder certificate
+  // logged into az), so a PR call against an account whose EscalatedAzCli session is already warm
+  // reuses that session instead of paying its own fresh `az login`. adoExecutor and azExecutor are
+  // the same process-wide singleton (see exec-shared.ts), so there is nothing to reuse there beyond
+  // this one import.
+  const azDeps: AzDeps = {
+    executor: azExecutor,
+    getCert: (account, identity) => secrets.azCert(account, identity),
+    getClientId: (account, identity) => {
+      const clientId = identity === 'reader' ? getAzAccounts()[account]?.readerClientId : getAzAccounts()[account]?.holderClientId;
+      if (clientId == null) {
+        throw new Error(`az account '${account}' has no ${identity} clientId configured`);
+      }
+      return clientId;
+    },
+    getTenantId: (account) => getAzAccounts()[account].tenantId,
+  };
+  // A real process-lifetime singleton, not just per-call: createAppTools is only ever invoked once
+  // (see AppToolsService's factory registration in container.ts — core-di-lite memoizes by the
+  // registration itself), so this is constructed exactly once for the process's lifetime.
+  const azSessionCache = new AzSessionCache(clock, logger);
 
-  tools.push(
-    ...createAzTools(
-      {
-        executor: azExecutor,
-        getCert: (account, identity) => secrets.azCert(account, identity),
-        getClientId: (account, identity) => {
-          const clientId = identity === 'reader' ? getAzAccounts()[account]?.readerClientId : getAzAccounts()[account]?.holderClientId;
-          if (clientId == null) {
-            throw new Error(`az account '${account}' has no ${identity} clientId configured`);
-          }
-          return clientId;
-        },
-        getTenantId: (account) => getAzAccounts()[account].tenantId,
-      },
-      getAzAccounts,
-      clock,
-      logger,
-    ),
-  );
+  tools.push(...createAdoPrTools(azDeps, getAzAccounts, azSessionCache));
+  tools.push(...createAzTools(azDeps, getAzAccounts, azSessionCache));
 
   // Stages run only inside a pipe, so they are not in `tools`. The permission resolver looks every pipe
   // step up by name and reads its operation and input_schema (to locate marked paths), so it needs them

--- a/apps/claude-sdk-cli/src/setup/ConfigDisabledToolsProvider.ts
+++ b/apps/claude-sdk-cli/src/setup/ConfigDisabledToolsProvider.ts
@@ -1,12 +1,33 @@
 import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IDisabledToolsProvider } from '@shellicar/claude-sdk';
+import { AZ_CLI_TOOL_NAME, ESCALATED_AZ_CLI_TOOL_NAME } from '@shellicar/claude-sdk-tools/Az';
+import { ADO_PR_TOOL_NAMES } from '@shellicar/claude-sdk-tools/AzureDevOps';
 import { dependsOn } from '@shellicar/core-di-lite';
 
 export class ConfigDisabledToolsProvider extends IDisabledToolsProvider {
   @dependsOn(ConfigLoader)
   public configLoader!: ConfigLoader<any>;
 
+  /** Read fresh on every access (see `IDisabledToolsProvider`): whether any account currently has a
+   *  reader/holder identity configured is live config, so `AzCli`/`EscalatedAzCli`/the
+   *  AzureDevOps.PullRequest.* tools are added to the disabled set — and so left off that turn's
+   *  wire tool list — the moment the last matching account is removed, and drop back out the moment
+   *  one is (re)configured. This is what keeps `Az/tools.ts`/`AzureDevOps/tools.ts` free to always
+   *  register these tools unconditionally: registration is static, offering them to the model is not. */
   public get disabledTools(): ReadonlySet<string> {
-    return new Set(this.configLoader.config.disabledTools);
+    const disabled = new Set<string>(this.configLoader.config.disabledTools);
+    const accounts = Object.values(this.configLoader.config.az.accounts) as { readerClientId: string | null; holderClientId: string | null }[];
+    const hasReader = accounts.some((a) => a.readerClientId != null);
+    const hasHolder = accounts.some((a) => a.holderClientId != null);
+    if (!hasReader) {
+      disabled.add(AZ_CLI_TOOL_NAME);
+    }
+    if (!hasHolder) {
+      disabled.add(ESCALATED_AZ_CLI_TOOL_NAME);
+      for (const name of ADO_PR_TOOL_NAMES) {
+        disabled.add(name);
+      }
+    }
+    return disabled;
   }
 }

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -281,7 +281,23 @@ export function buildContainer(options: ContainerOptions): IServiceProvider {
     const secrets = x.resolve(ISecrets);
     const envProvider = x.resolve(IEnvProvider);
     const rulesProvider = x.resolve(IRulesConfigProvider);
-    const tools = createAppTools({ fs, tsServer, toolsConfig: loader.config.tools, rulesProvider, objects, memory, history, currentSessionId: () => session.id, clock: x.resolve(Clock), tsAvailable: runtime.tsAvailable, logger: appLogger, skillDirs, secrets, envProvider, azAccounts: loader.config.az.accounts });
+    const tools = createAppTools({
+      fs,
+      tsServer,
+      toolsConfig: loader.config.tools,
+      rulesProvider,
+      objects,
+      memory,
+      history,
+      currentSessionId: () => session.id,
+      clock: x.resolve(Clock),
+      tsAvailable: runtime.tsAvailable,
+      logger: appLogger,
+      skillDirs,
+      secrets,
+      envProvider,
+      getAzAccounts: () => loader.config.az.accounts,
+    });
     return new AppToolsService(tools);
   });
   // AppToolsService is factory-built, so its cache key is the factory; alias the

--- a/apps/claude-sdk-cli/test/ConfigDisabledToolsProvider.spec.ts
+++ b/apps/claude-sdk-cli/test/ConfigDisabledToolsProvider.spec.ts
@@ -2,8 +2,10 @@ import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { describe, expect, it } from 'vitest';
 import { ConfigDisabledToolsProvider } from '../src/setup/ConfigDisabledToolsProvider.js';
 
-function makeLoader(disabledTools: string[]): ConfigLoader<any> {
-  return new ConfigLoader({ config: { disabledTools }, sources: [], warnings: [] });
+type AzAccounts = Record<string, { tenantId: string; readerClientId: string | null; holderClientId: string | null }>;
+
+function makeLoader(disabledTools: string[], azAccounts: AzAccounts = {}): ConfigLoader<any> {
+  return new ConfigLoader({ config: { disabledTools, az: { accounts: azAccounts } }, sources: [], warnings: [] });
 }
 
 describe('ConfigDisabledToolsProvider', () => {
@@ -11,17 +13,58 @@ describe('ConfigDisabledToolsProvider', () => {
     const provider = new ConfigDisabledToolsProvider();
     provider.configLoader = makeLoader(['ExecV3']);
     const actual = provider.disabledTools;
-    const expected = new Set(['ExecV3']);
-    expect(actual).toEqual(expected);
+    expect(actual.has('ExecV3')).toBe(true);
   });
 
   it('reads the config loader live, reflecting an applied config change', () => {
     const loader = makeLoader([]);
     const provider = new ConfigDisabledToolsProvider();
     provider.configLoader = loader;
-    loader.apply({ config: { disabledTools: ['DeleteFile'] }, sources: [], warnings: [] });
+    loader.apply({ config: { disabledTools: ['DeleteFile'], az: { accounts: {} } }, sources: [], warnings: [] });
     const actual = provider.disabledTools;
-    const expected = new Set(['DeleteFile']);
-    expect(actual).toEqual(expected);
+    expect(actual.has('DeleteFile')).toBe(true);
+  });
+
+  describe('az/AzureDevOps tool availability', () => {
+    it('disables AzCli when no account has a reader identity configured', () => {
+      const provider = new ConfigDisabledToolsProvider();
+      provider.configLoader = makeLoader([]);
+      const actual = provider.disabledTools.has('AzCli');
+      expect(actual).toBe(true);
+    });
+
+    it('does not disable AzCli when an account has a reader identity configured', () => {
+      const provider = new ConfigDisabledToolsProvider();
+      provider.configLoader = makeLoader([], { shellicar: { tenantId: 't', readerClientId: 'r', holderClientId: null } });
+      const actual = provider.disabledTools.has('AzCli');
+      expect(actual).toBe(false);
+    });
+
+    it('disables EscalatedAzCli and every AzureDevOps.PullRequest.* tool when no account has a holder identity configured', () => {
+      const provider = new ConfigDisabledToolsProvider();
+      provider.configLoader = makeLoader([]);
+      const disabled = provider.disabledTools;
+      const expected = true;
+      const actual = disabled.has('EscalatedAzCli') && disabled.has('AzureDevOps_PullRequest_Create');
+      expect(actual).toBe(expected);
+    });
+
+    it('does not disable EscalatedAzCli or AzureDevOps.PullRequest.* tools when an account has a holder identity configured', () => {
+      const provider = new ConfigDisabledToolsProvider();
+      provider.configLoader = makeLoader([], { shellicar: { tenantId: 't', readerClientId: null, holderClientId: 'h' } });
+      const disabled = provider.disabledTools;
+      const expected = false;
+      const actual = disabled.has('EscalatedAzCli') || disabled.has('AzureDevOps_PullRequest_Create');
+      expect(actual).toBe(expected);
+    });
+
+    it('reflects a config reload adding a holder account, with no rebuild', () => {
+      const loader = makeLoader([]);
+      const provider = new ConfigDisabledToolsProvider();
+      provider.configLoader = loader;
+      loader.apply({ config: { disabledTools: [], az: { accounts: { shellicar: { tenantId: 't', readerClientId: null, holderClientId: 'h' } } } }, sources: [], warnings: [] });
+      const actual = provider.disabledTools.has('EscalatedAzCli');
+      expect(actual).toBe(false);
+    });
   });
 });

--- a/apps/claude-sdk-cli/test/createAppTools.spec.ts
+++ b/apps/claude-sdk-cli/test/createAppTools.spec.ts
@@ -23,7 +23,7 @@ const currentSessionId = () => 'current-session';
 const secrets: ISecrets = { ghHolderToken: () => 'test-holder-token', ghReaderToken: () => 'test-reader-token', azCert: () => 'test-cert' };
 const envProvider: IEnvProvider = { buildEnv: (cmdEnv) => ({ ...process.env, ...cmdEnv }) };
 const rulesProvider = new StaticRulesConfigProvider();
-const azAccounts = {};
+const getAzAccounts = () => ({});
 const clock = Clock.systemDefaultZone();
 
 // ITypeScriptService is a type-only export from the package entry — it has no runtime
@@ -47,7 +47,7 @@ const permMatrix: PermissionConfig = {
 
 describe('createAppTools — permission resolution for pipe stages', () => {
   it('exposes every pipe stage in permissionTools so a stage step resolves', () => {
-    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = PIPE_STAGES.every((name) => permissionTools.some((t) => t.name === name));
@@ -55,7 +55,7 @@ describe('createAppTools — permission resolution for pipe stages', () => {
   });
 
   it('does not auto-deny a pipe containing a stage', () => {
-    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { permissionTools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
     const pipe = {
       name: 'Pipe',
       input: {
@@ -75,7 +75,7 @@ describe('createAppTools — permission resolution for pipe stages', () => {
 
 describe('createAppTools — tool selection', () => {
   it('includes ExecV2 when execV2 is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -83,7 +83,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes Exec when exec is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -91,7 +91,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes Exec when exec is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -99,7 +99,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes ExecV2 when execV2 is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -107,7 +107,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes ExecV3 when execV3 is true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: true }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: true }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV3');
@@ -115,7 +115,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('excludes ExecV3 when execV3 is false', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: false, execV2: false, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'ExecV3');
@@ -123,7 +123,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes Exec when both are true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'Exec');
@@ -131,7 +131,7 @@ describe('createAppTools — tool selection', () => {
   });
 
   it('includes ExecV2 when both are true', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ExecV2');
@@ -141,7 +141,7 @@ describe('createAppTools — tool selection', () => {
 
 describe('createAppTools — TS tool availability', () => {
   it('includes TsDiagnostics when typescript is available', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: true, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'TsDiagnostics');
@@ -149,7 +149,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('excludes TsDiagnostics when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = false;
     const actual = tools.some((t) => t.name === 'TsDiagnostics');
@@ -157,7 +157,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('excludes every TS tool when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = 0;
     const actual = tools.filter((t) => ['TsDiagnostics', 'TsHover', 'TsReferences', 'TsDefinition'].includes(t.name)).length;
@@ -165,7 +165,7 @@ describe('createAppTools — TS tool availability', () => {
   });
 
   it('keeps non-TS tools when typescript is unavailable', () => {
-    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, azAccounts });
+    const { tools } = createAppTools({ fs, tsServer, toolsConfig: { exec: true, execV2: true, execV3: false }, objects: new MemoryObjectStore(), memory: new RecordingMemoryStore(), history, currentSessionId, clock, tsAvailable: false, logger: noopLogger, secrets, envProvider, rulesProvider, getAzAccounts });
 
     const expected = true;
     const actual = tools.some((t) => t.name === 'ReadFile');

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -54,8 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adopt core-di-lite property injection: TsServerService resolves its options through injection and disposes its tsserver process on scope exit
-- AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart
-- AzureDevOps.PullRequest.* tools reuse the same AzSessionCache as AzCli/EscalatedAzCli instead of logging in fresh on every call, so a PR call against an account with an already-warm holder session is near-instant instead of paying a full az login round trip
+- Az account changes take effect immediately across AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.*, with no restart
+- AzureDevOps.PullRequest.* tools reuse AzCli/EscalatedAzCli's session cache instead of logging in fresh each call
 - Composable pipe tools redesigned into atomic, single-role tools over typed streams; each takes its own input instead of the pipe's internal transport shape
 - Consolidate process spawn behind a shared exec-core interface and detach spawned commands from the controlling terminal
 - EditFile returns a plain-text, line-numbered diff instead of a JSON object, so the result is readable without unescaping
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A failed tsserver request now throws instead of returning an empty result that was indistinguishable from a clean file
-- AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli
+- AzureDevOps.PullRequest.* tools accept an account field, matching AzCli/EscalatedAzCli
 - Binary files are blocked from text reads when the format is recognised; unrecognised formats are still treated as text
 - ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph
 - Find tool follows symlinks with cycle detection

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adopt core-di-lite property injection: TsServerService resolves its options through injection and disposes its tsserver process on scope exit
+- AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart
 - Composable pipe tools redesigned into atomic, single-role tools over typed streams; each takes its own input instead of the pipe's internal transport shape
 - Consolidate process spawn behind a shared exec-core interface and detach spawned commands from the controlling terminal
 - EditFile returns a plain-text, line-numbered diff instead of a JSON object, so the result is readable without unescaping
@@ -84,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A failed tsserver request now throws instead of returning an empty result that was indistinguishable from a clean file
+- AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli
 - Binary files are blocked from text reads when the format is recognised; unrecognised formats are still treated as text
 - ExecV3 and Memory import defineTool, ToolCancelledError, ToolRefusedError, and pathSchema from their own claude-sdk subpaths instead of the barrel, so a consumer bundling this package no longer pulls in the whole SDK module graph
 - Find tool follows symlinks with cycle detection

--- a/packages/claude-sdk-tools/CHANGELOG.md
+++ b/packages/claude-sdk-tools/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adopt core-di-lite property injection: TsServerService resolves its options through injection and disposes its tsserver process on scope exit
 - AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart
+- AzureDevOps.PullRequest.* tools reuse the same AzSessionCache as AzCli/EscalatedAzCli instead of logging in fresh on every call, so a PR call against an account with an already-warm holder session is near-instant instead of paying a full az login round trip
 - Composable pipe tools redesigned into atomic, single-role tools over typed streams; each takes its own input instead of the pipe's internal transport shape
 - Consolidate process spawn behind a shared exec-core interface and detach spawned commands from the controlling terminal
 - EditFile returns a plain-text, line-numbered diff instead of a JSON object, so the result is readable without unescaping

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -80,3 +80,5 @@
 
 {"description":"AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli","category":"fixed"}
 {"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart","category":"changed"}
+
+{"description":"AzureDevOps.PullRequest.* tools reuse the same AzSessionCache as AzCli/EscalatedAzCli instead of logging in fresh on every call, so a PR call against an account with an already-warm holder session is near-instant instead of paying a full az login round trip","category":"changed"}

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -77,3 +77,6 @@
 {"description":"Fix version metadata","category":"fixed"}
 {"description":"ExecV3's safety rules can be overridden, removed, or added to in config, with changes taking effect immediately and no restart","category":"added"}
 {"description":"GitHub_PullRequest_Ready/Edit/Comment/AutoMerge/Review no longer require a pull request number — omit it to target the pull request associated with the current branch, matching gh's own resolution","category":"changed"}
+
+{"description":"AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli","category":"fixed"}
+{"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart","category":"changed"}

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -77,7 +77,6 @@
 {"description":"Fix version metadata","category":"fixed"}
 {"description":"ExecV3's safety rules can be overridden, removed, or added to in config, with changes taking effect immediately and no restart","category":"added"}
 {"description":"GitHub_PullRequest_Ready/Edit/Comment/AutoMerge/Review no longer require a pull request number — omit it to target the pull request associated with the current branch, matching gh's own resolution","category":"changed"}
-
-{"description":"AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli","category":"fixed"}
-{"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart","category":"changed"}
-{"description":"AzureDevOps.PullRequest.* tools reuse the same AzSessionCache as AzCli/EscalatedAzCli instead of logging in fresh on every call, so a PR call against an account with an already-warm holder session is near-instant instead of paying a full az login round trip","category":"changed"}
+{"description":"AzureDevOps.PullRequest.* tools accept an account field, matching AzCli/EscalatedAzCli","category":"fixed"}
+{"description":"Az account changes take effect immediately across AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.*, with no restart","category":"changed"}
+{"description":"AzureDevOps.PullRequest.* tools reuse AzCli/EscalatedAzCli's session cache instead of logging in fresh each call","category":"changed"}

--- a/packages/claude-sdk-tools/changes.jsonl
+++ b/packages/claude-sdk-tools/changes.jsonl
@@ -80,5 +80,4 @@
 
 {"description":"AzureDevOps.PullRequest.* tools accept an account field and select between every configured holder account, matching AzCli/EscalatedAzCli","category":"fixed"}
 {"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* resolve the account list live on every call instead of once at startup, so adding, removing, or reconfiguring an account takes effect immediately with no restart","category":"changed"}
-
 {"description":"AzureDevOps.PullRequest.* tools reuse the same AzSessionCache as AzCli/EscalatedAzCli instead of logging in fresh on every call, so a PR call against an account with an already-warm holder session is near-instant instead of paying a full az login round trip","category":"changed"}

--- a/packages/claude-sdk-tools/src/Az/createAzTool.ts
+++ b/packages/claude-sdk-tools/src/Az/createAzTool.ts
@@ -1,38 +1,57 @@
 import { defineTool, type ToolOperation } from '@shellicar/claude-sdk';
-import type { z } from 'zod';
 import type { AzSessionCache } from './AzSessionCache';
 import type { AzDeps } from './runAz';
 import { runAz } from './runAz';
-import { AzOutputSchema } from './schema';
+import { AzInputSchema, AzOutputSchema } from './schema';
+import type { AzAccountsConfig } from './tools';
 
-export type AzToolSpec<TSchema extends z.ZodType<{ account?: string; args: string[] }>> = {
+export type AzToolSpec = {
   name: string;
   operation: ToolOperation;
   description: string;
-  input_schema: TSchema;
   identity: 'reader' | 'holder';
-  /** The sole configured account name, set only when exactly one account exists for this
-   *  identity — the value `account` resolves to when the caller omits it. Undefined whenever
-   *  more than one account is configured, where the schema's `.refine` already guarantees
-   *  `input.account` is never omitted. */
-  defaultAccount?: string;
 };
 
+/** Resolves the account name a call actually runs as, against whichever accounts are configured
+ *  for `identity` right now — read fresh from `getAccounts()` on every call, never a list baked in
+ *  at tool-build time. Resolution order: `requested` (the explicit `account` field) always wins;
+ *  otherwise `fallback` (e.g. the org parsed from the target repo's own git remote — see
+ *  `orgNameFromRemote`) is used if it names a configured account; otherwise the sole configured
+ *  account is used if there is exactly one. Naming an account that doesn't currently qualify is
+ *  always rejected, even if it did when the tool was registered — `fallback` never bypasses that
+ *  check, it only ever supplies a candidate, the same one `requested` would have to pass. */
+export function resolveAzAccount(getAccounts: () => AzAccountsConfig, identity: 'reader' | 'holder', requested: string | undefined, fallback?: string): string {
+  const configured = Object.entries(getAccounts())
+    .filter(([, a]) => (identity === 'reader' ? a.readerClientId : a.holderClientId) != null)
+    .map(([name]) => name);
+  if (configured.length === 0) {
+    throw new Error(`no account has a ${identity} identity configured`);
+  }
+  const account = requested ?? (fallback != null && configured.includes(fallback) ? fallback : undefined) ?? (configured.length === 1 ? configured[0] : undefined);
+  if (account == null) {
+    throw new Error('account is required when more than one Azure account is configured');
+  }
+  if (!configured.includes(account)) {
+    throw new Error(`account '${account}' has no ${identity} identity configured`);
+  }
+  return account;
+}
+
 /** `cache` is one `AzSessionCache` shared across every Az tool built by `createAzTools`. Its
- *  lifetime is the process, not a tool-execution block — see `AzSessionCache` for why. */
-export function createAzTool<TSchema extends z.ZodType<{ account?: string; args: string[] }>>(spec: AzToolSpec<TSchema>, deps: AzDeps, cache: AzSessionCache) {
+ *  lifetime is the process, not a tool-execution block — see `AzSessionCache` for why.
+ *
+ *  `getAccounts` is read fresh on every call (see `resolveAzAccount`) rather than captured once, so
+ *  a config reload that adds/removes an account takes effect on the very next call. */
+export function createAzTool(spec: AzToolSpec, deps: AzDeps, cache: AzSessionCache, getAccounts: () => AzAccountsConfig) {
   return defineTool({
     name: spec.name,
     operation: spec.operation,
     description: spec.description,
-    input_schema: spec.input_schema,
+    input_schema: AzInputSchema,
     output_schema: AzOutputSchema,
     input_examples: [],
     handler: async (input) => {
-      const account = input.account ?? spec.defaultAccount;
-      if (account == null) {
-        throw new Error('account is required when more than one Azure account is configured');
-      }
+      const account = resolveAzAccount(getAccounts, spec.identity, input.account);
       const result = await runAz(deps, cache, spec.identity, account, input.args, process.cwd());
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },

--- a/packages/claude-sdk-tools/src/Az/schema.ts
+++ b/packages/claude-sdk-tools/src/Az/schema.ts
@@ -6,27 +6,16 @@ export const AzOutputSchema = z.object({
   exitCode: z.number().int().nullable(),
 });
 
-/** Built per-registration from whichever account names are actually configured for a given
- *  identity (reader/holder), so the model can only ever request an account whose service
- *  principal actually exists — the enum is the structural guarantee, not a runtime check.
- *
- *  `account` is always optional in the schema's output type — with exactly one configured account
- *  there is nothing to disambiguate, so the caller may omit it. With more than one, omitting it is
- *  rejected by the `.refine` below: a default can only ever be unambiguous, never a guess among
- *  several real choices. */
-export function createAzInputSchema(accounts: [string, ...string[]]) {
-  const single = accounts.length === 1;
-  return z
-    .object({
-      account: z
-        .enum(accounts)
-        .optional()
-        .describe(single ? `Which configured Azure account to run this command against. Optional — omit to use the only configured account ('${accounts[0]}').` : 'Which configured Azure account to run this command against. Required — more than one account is configured.'),
-      args: z.array(z.string()).min(1).describe('Arguments to `az`, e.g. ["group", "list"] for `az group list`. No shell — no quoting, no globbing, no operators'),
-    })
-    .strict()
-    .refine((input) => single || input.account != null, {
-      message: 'account is required when more than one Azure account is configured',
-      path: ['account'],
-    });
-}
+/** `account` is a plain string, not an enum of currently-configured accounts: which accounts exist
+ *  is live config (see `AzAccountsConfig`, read fresh per call in `createAzTool`'s handler), and a
+ *  config reload must take effect on the very next call with no tool/schema rebuild. Baking today's
+ *  account names into the wire schema as an enum would freeze them at whenever the tool was built.
+ *  So the schema only shapes the input; whether a given name is actually configured, and whether
+ *  omitting it is allowed (exactly one account configured for this identity), is validated live in
+ *  the handler against the current account list. */
+export const AzInputSchema = z
+  .object({
+    account: z.string().optional().describe('Which configured Azure account to run this command against. Optional when exactly one account is configured for this identity; required when more than one is configured.'),
+    args: z.array(z.string()).min(1).describe('Arguments to `az`, e.g. ["group", "list"] for `az group list`. No shell — no quoting, no globbing, no operators'),
+  })
+  .strict();

--- a/packages/claude-sdk-tools/src/Az/tools.ts
+++ b/packages/claude-sdk-tools/src/Az/tools.ts
@@ -1,6 +1,4 @@
-import type { Clock } from '@js-joda/core';
-import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
-import { AzSessionCache } from './AzSessionCache';
+import type { AzSessionCache } from './AzSessionCache';
 import { createAzTool } from './createAzTool';
 import type { AzDeps } from './runAz';
 
@@ -25,21 +23,15 @@ export const ESCALATED_AZ_CLI_TOOL_NAME = 'EscalatedAzCli';
  *  `resolveAzAccount`), and whether the tool is even offered to the model on a given turn is decided
  *  live too, by the disabled-tools provider (see `ConfigDisabledToolsProvider` in the CLI app),
  *  which hides `AzCli`/`EscalatedAzCli` from that turn's tool list whenever no account currently has
- *  the matching identity configured. */
-export function createAzTools(deps: AzDeps, getAccounts: () => AzAccountsConfig, clock: Clock, logger?: ILogger) {
-  // One cache shared by every Az tool this call builds, so a reader and holder call against the
-  // same account in one block still share nothing (different identities → different cache keys),
-  // but repeated calls under the same identity/account do.
-  //
-  // This is a real process-lifetime singleton, not just per-call: `createAzTools` is only ever
-  // invoked once, inside the DI container's `AppToolsService` factory registration
-  // (apps/claude-sdk-cli/src/setup/container.ts) — `core-di-lite` memoizes a factory registration by
-  // the registration itself, so `AppToolsService.resolve()` constructs it once and every later
-  // resolve returns the same cached instance for the container's (i.e. the process's) lifetime. If
-  // that factory wiring ever changes to construct `AppToolsService` more than once, this cache stops
-  // being a singleton and the "process lifetime" claim above breaks silently.
-  const cache = new AzSessionCache(clock, logger);
-
+ *  the matching identity configured.
+ *
+ *  `cache` is constructed by the caller, not here, and shared with `AzureDevOps.PullRequest.*` (see
+ *  `AzureDevOps/tools.ts`'s `createAdoPrTools`) — one `AzSessionCache` for every escalated `az`
+ *  surface in the process, so a login warmed by one tool is reused by the others rather than each
+ *  keeping its own. It is still a process-lifetime singleton in practice: the caller
+ *  (`createAppTools`, invoked once — see its own docs) constructs it exactly once and passes the
+ *  same instance to every consumer. */
+export function createAzTools(deps: AzDeps, getAccounts: () => AzAccountsConfig, cache: AzSessionCache) {
   return [
     createAzTool(
       {

--- a/packages/claude-sdk-tools/src/Az/tools.ts
+++ b/packages/claude-sdk-tools/src/Az/tools.ts
@@ -3,31 +3,30 @@ import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { AzSessionCache } from './AzSessionCache';
 import { createAzTool } from './createAzTool';
 import type { AzDeps } from './runAz';
-import { createAzInputSchema } from './schema';
 
 /** One entry per account the operator has configured, each independently optional per identity:
- *  an account with no reader service principal simply doesn't appear in AzCli's enum, one with no
- *  holder doesn't appear in EscalatedAzCli's. */
+ *  an account with no reader service principal simply doesn't appear as a valid `account` for
+ *  AzCli, one with no holder doesn't for EscalatedAzCli — checked live per call (see
+ *  `resolveAzAccount`), not baked into either tool's schema. */
 export type AzAccountsConfig = Record<string, { tenantId: string; readerClientId: string | null; holderClientId: string | null }>;
 
-function isNonEmpty(names: string[]): names is [string, ...string[]] {
-  return names.length > 0;
-}
+export const AZ_CLI_TOOL_NAME = 'AzCli';
+export const ESCALATED_AZ_CLI_TOOL_NAME = 'EscalatedAzCli';
 
 /** AzCli and EscalatedAzCli are the same shape, differing only in which identity (and so which
  *  RBAC role) they run under and which permission bucket they sit in. Unlike GitHub/AzureDevOps,
  *  `az` has no single bounded surface to enumerate into named per-verb tools, so the credential
  *  itself is the enforcement point: each account gets its own reader/holder service principal,
- *  scoped by RBAC, and the tool stays a free-text proposer. Neither tool is registered at all if
- *  no account has that identity configured. */
-export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, clock: Clock, logger?: ILogger) {
-  const readerAccounts = Object.entries(accounts)
-    .filter(([, a]) => a.readerClientId != null)
-    .map(([name]) => name);
-  const holderAccounts = Object.entries(accounts)
-    .filter(([, a]) => a.holderClientId != null)
-    .map(([name]) => name);
-
+ *  scoped by RBAC, and the tool stays a free-text proposer.
+ *
+ *  Both tools are always registered, unconditionally — whether either identity currently has any
+ *  account configured is live config, and can change on a reload; gating registration here would
+ *  freeze that decision at process start. Instead, `getAccounts` is read fresh on every call (see
+ *  `resolveAzAccount`), and whether the tool is even offered to the model on a given turn is decided
+ *  live too, by the disabled-tools provider (see `ConfigDisabledToolsProvider` in the CLI app),
+ *  which hides `AzCli`/`EscalatedAzCli` from that turn's tool list whenever no account currently has
+ *  the matching identity configured. */
+export function createAzTools(deps: AzDeps, getAccounts: () => AzAccountsConfig, clock: Clock, logger?: ILogger) {
   // One cache shared by every Az tool this call builds, so a reader and holder call against the
   // same account in one block still share nothing (different identities → different cache keys),
   // but repeated calls under the same identity/account do.
@@ -40,41 +39,29 @@ export function createAzTools(deps: AzDeps, accounts: AzAccountsConfig, clock: C
   // that factory wiring ever changes to construct `AppToolsService` more than once, this cache stops
   // being a singleton and the "process lifetime" claim above breaks silently.
   const cache = new AzSessionCache(clock, logger);
-  const tools = [];
 
-  if (isNonEmpty(readerAccounts)) {
-    tools.push(
-      createAzTool(
-        {
-          name: 'AzCli',
-          operation: 'write',
-          description: 'Run an Azure CLI (`az`) command under the unprivileged reader identity of a configured account.',
-          input_schema: createAzInputSchema(readerAccounts),
-          identity: 'reader',
-          defaultAccount: readerAccounts.length === 1 ? readerAccounts[0] : undefined,
-        },
-        deps,
-        cache,
-      ),
-    );
-  }
-
-  if (isNonEmpty(holderAccounts)) {
-    tools.push(
-      createAzTool(
-        {
-          name: 'EscalatedAzCli',
-          operation: 'escalate',
-          description: 'Run an Azure CLI (`az`) command under the privileged holder identity of a configured account. Always asks for approval first.',
-          input_schema: createAzInputSchema(holderAccounts),
-          identity: 'holder',
-          defaultAccount: holderAccounts.length === 1 ? holderAccounts[0] : undefined,
-        },
-        deps,
-        cache,
-      ),
-    );
-  }
-
-  return tools;
+  return [
+    createAzTool(
+      {
+        name: AZ_CLI_TOOL_NAME,
+        operation: 'write',
+        description: 'Run an Azure CLI (`az`) command under the unprivileged reader identity of a configured account.',
+        identity: 'reader',
+      },
+      deps,
+      cache,
+      getAccounts,
+    ),
+    createAzTool(
+      {
+        name: ESCALATED_AZ_CLI_TOOL_NAME,
+        operation: 'escalate',
+        description: 'Run an Azure CLI (`az`) command under the privileged holder identity of a configured account. Always asks for approval first.',
+        identity: 'holder',
+      },
+      deps,
+      cache,
+      getAccounts,
+    ),
+  ];
 }

--- a/packages/claude-sdk-tools/src/AzureDevOps/createAdoAutoMergeTool.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/createAdoAutoMergeTool.ts
@@ -1,6 +1,8 @@
 import { defineTool } from '@shellicar/claude-sdk';
+import { resolveAzAccount } from '../Az/createAzTool';
+import type { AzAccountsConfig } from '../Az/tools';
 import { getGitRemoteUrl } from './gitRemote';
-import { parseAdoRemote } from './parseAdoRemote';
+import { orgNameFromRemote, parseAdoRemote } from './parseAdoRemote';
 import type { AdoEscalatedDeps } from './runAdoEscalated';
 import { runAdoEscalated } from './runAdoEscalated';
 import { AdoPrAutoMergeInputSchema, AdoPrOutputSchema } from './schema';
@@ -17,8 +19,11 @@ export function buildMergeCommitMessage(id: number, title: string, description: 
 /** AzureDevOps_PullRequest_AutoMerge: enable/disable auto-complete. Unlike the other named tools,
  *  enabling requires two `az repos pr` calls — a `show` to read the PR's own title/description, then
  *  an `update` carrying the merge commit message built from them — so it does not fit the single
- *  fixed-subcommand `createAdoPrTool` shape and is built directly. */
-export function createAdoAutoMergeTool(deps: AdoEscalatedDeps) {
+ *  fixed-subcommand `createAdoPrTool` shape and is built directly.
+ *
+ *  `getAccounts` is read fresh on every call (see `resolveAzAccount`), never a list captured once at
+ *  tool-build time — the same live-config shape every other AzureDevOps.PullRequest.* tool uses. */
+export function createAdoAutoMergeTool(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
   return defineTool({
     name: 'AzureDevOps_PullRequest_AutoMerge',
     operation: 'escalate',
@@ -31,15 +36,16 @@ export function createAdoAutoMergeTool(deps: AdoEscalatedDeps) {
       const cwd = input.cwd ?? process.cwd();
       const remoteUrl = await getGitRemoteUrl(cwd);
       const remote = remoteUrl != null ? parseAdoRemote(remoteUrl) : null;
+      const account = resolveAzAccount(getAccounts, 'holder', input.account, orgNameFromRemote(remote));
       const resolvedOrg = input.org ?? remote?.orgUrl;
       const orgArgs = resolvedOrg != null ? ['--org', resolvedOrg] : [];
 
       if (!input.enable) {
-        const result = await runAdoEscalated(deps, ['update'], ['--id', String(input.id), '--auto-complete', 'false', ...orgArgs], cwd);
+        const result = await runAdoEscalated(deps, account, ['update'], ['--id', String(input.id), '--auto-complete', 'false', ...orgArgs], cwd);
         return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
       }
 
-      const show = await runAdoEscalated(deps, ['show'], ['--id', String(input.id), '--query', '{title:title,description:description}', '-o', 'json', ...orgArgs], cwd);
+      const show = await runAdoEscalated(deps, account, ['show'], ['--id', String(input.id), '--query', '{title:title,description:description}', '-o', 'json', ...orgArgs], cwd);
       if (show.exitCode !== 0) {
         return { textContent: { stdout: show.stdout.trim(), stderr: show.stderr.trim(), exitCode: show.exitCode } };
       }
@@ -53,7 +59,7 @@ export function createAdoAutoMergeTool(deps: AdoEscalatedDeps) {
       if (input.deleteSourceBranch != null) {
         args.push('--delete-source-branch', String(input.deleteSourceBranch));
       }
-      const result = await runAdoEscalated(deps, ['update'], args, cwd);
+      const result = await runAdoEscalated(deps, account, ['update'], args, cwd);
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },
   });

--- a/packages/claude-sdk-tools/src/AzureDevOps/createAdoAutoMergeTool.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/createAdoAutoMergeTool.ts
@@ -1,4 +1,5 @@
 import { defineTool } from '@shellicar/claude-sdk';
+import type { AzSessionCache } from '../Az/AzSessionCache';
 import { resolveAzAccount } from '../Az/createAzTool';
 import type { AzAccountsConfig } from '../Az/tools';
 import { getGitRemoteUrl } from './gitRemote';
@@ -22,8 +23,11 @@ export function buildMergeCommitMessage(id: number, title: string, description: 
  *  fixed-subcommand `createAdoPrTool` shape and is built directly.
  *
  *  `getAccounts` is read fresh on every call (see `resolveAzAccount`), never a list captured once at
- *  tool-build time — the same live-config shape every other AzureDevOps.PullRequest.* tool uses. */
-export function createAdoAutoMergeTool(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
+ *  tool-build time — the same live-config shape every other AzureDevOps.PullRequest.* tool uses.
+ *  `cache` is the same `AzSessionCache` instance `AzCli`/`EscalatedAzCli` share (see
+ *  `runAdoEscalated`), so both `az repos pr` calls this tool can make reuse an already-warm holder
+ *  session instead of each paying its own fresh login. */
+export function createAdoAutoMergeTool(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig, cache: AzSessionCache) {
   return defineTool({
     name: 'AzureDevOps_PullRequest_AutoMerge',
     operation: 'escalate',
@@ -41,11 +45,11 @@ export function createAdoAutoMergeTool(deps: AdoEscalatedDeps, getAccounts: () =
       const orgArgs = resolvedOrg != null ? ['--org', resolvedOrg] : [];
 
       if (!input.enable) {
-        const result = await runAdoEscalated(deps, account, ['update'], ['--id', String(input.id), '--auto-complete', 'false', ...orgArgs], cwd);
+        const result = await runAdoEscalated(deps, cache, account, ['update'], ['--id', String(input.id), '--auto-complete', 'false', ...orgArgs], cwd);
         return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
       }
 
-      const show = await runAdoEscalated(deps, account, ['show'], ['--id', String(input.id), '--query', '{title:title,description:description}', '-o', 'json', ...orgArgs], cwd);
+      const show = await runAdoEscalated(deps, cache, account, ['show'], ['--id', String(input.id), '--query', '{title:title,description:description}', '-o', 'json', ...orgArgs], cwd);
       if (show.exitCode !== 0) {
         return { textContent: { stdout: show.stdout.trim(), stderr: show.stderr.trim(), exitCode: show.exitCode } };
       }
@@ -59,7 +63,7 @@ export function createAdoAutoMergeTool(deps: AdoEscalatedDeps, getAccounts: () =
       if (input.deleteSourceBranch != null) {
         args.push('--delete-source-branch', String(input.deleteSourceBranch));
       }
-      const result = await runAdoEscalated(deps, account, ['update'], args, cwd);
+      const result = await runAdoEscalated(deps, cache, account, ['update'], args, cwd);
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },
   });

--- a/packages/claude-sdk-tools/src/AzureDevOps/createAdoPrTool.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/createAdoPrTool.ts
@@ -1,5 +1,6 @@
 import { defineTool } from '@shellicar/claude-sdk';
 import type { z } from 'zod';
+import type { AzSessionCache } from '../Az/AzSessionCache';
 import { resolveAzAccount } from '../Az/createAzTool';
 import type { AzAccountsConfig } from '../Az/tools';
 import { getGitRemoteUrl } from './gitRemote';
@@ -28,8 +29,12 @@ export type AdoPrToolSpec<TSchema extends z.ZodType<{ account?: string; cwd?: st
 
 /** `getAccounts` is read fresh on every call (see `resolveAzAccount`), never a list captured once
  *  at tool-build time — the same live-config shape `Az/createAzTool.ts` uses, so a config reload
- *  that adds/removes a holder account takes effect on the very next call, with no tool rebuild. */
-export function createAdoPrTool<TSchema extends z.ZodType<{ account?: string; cwd?: string }>>(spec: AdoPrToolSpec<TSchema>, deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
+ *  that adds/removes a holder account takes effect on the very next call, with no tool rebuild.
+ *
+ *  `cache` is the same `AzSessionCache` instance `AzCli`/`EscalatedAzCli` share (see
+ *  `runAdoEscalated`), so a PR call reuses an already-warm holder session instead of paying a fresh
+ *  login every time. */
+export function createAdoPrTool<TSchema extends z.ZodType<{ account?: string; cwd?: string }>>(spec: AdoPrToolSpec<TSchema>, deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig, cache: AzSessionCache) {
   return defineTool({
     name: spec.name,
     // 'escalate', not 'write': this crosses a privilege boundary (the holder PAT) that must always
@@ -45,7 +50,7 @@ export function createAdoPrTool<TSchema extends z.ZodType<{ account?: string; cw
       const remoteUrl = await getGitRemoteUrl(cwd);
       const remote = remoteUrl != null ? parseAdoRemote(remoteUrl) : null;
       const account = resolveAzAccount(getAccounts, 'holder', input.account, orgNameFromRemote(remote));
-      const result = await runAdoEscalated(deps, account, spec.subcommand, spec.buildArgs(input, remote), cwd);
+      const result = await runAdoEscalated(deps, cache, account, spec.subcommand, spec.buildArgs(input, remote), cwd);
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },
   });

--- a/packages/claude-sdk-tools/src/AzureDevOps/createAdoPrTool.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/createAdoPrTool.ts
@@ -1,8 +1,10 @@
 import { defineTool } from '@shellicar/claude-sdk';
 import type { z } from 'zod';
+import { resolveAzAccount } from '../Az/createAzTool';
+import type { AzAccountsConfig } from '../Az/tools';
 import { getGitRemoteUrl } from './gitRemote';
 import type { AdoRemoteContext } from './parseAdoRemote';
-import { parseAdoRemote } from './parseAdoRemote';
+import { orgNameFromRemote, parseAdoRemote } from './parseAdoRemote';
 import type { AdoEscalatedDeps } from './runAdoEscalated';
 import { runAdoEscalated } from './runAdoEscalated';
 import { AdoPrOutputSchema } from './schema';
@@ -15,7 +17,7 @@ export type { AdoEscalatedDeps };
  *  the org/project/repository parsed from the target repo's own git remote when one exists — `az`'s
  *  own `--detect` only ever resolves organization, never project, so parsing it here is what
  *  actually closes that gap; explicit input fields still win over it. */
-export type AdoPrToolSpec<TSchema extends z.ZodType> = {
+export type AdoPrToolSpec<TSchema extends z.ZodType<{ account?: string; cwd?: string }>> = {
   name: string;
   description: string;
   input_schema: TSchema;
@@ -24,7 +26,10 @@ export type AdoPrToolSpec<TSchema extends z.ZodType> = {
   buildArgs: (input: z.output<TSchema>, remote: AdoRemoteContext | null) => string[];
 };
 
-export function createAdoPrTool<TSchema extends z.ZodType>(spec: AdoPrToolSpec<TSchema>, deps: AdoEscalatedDeps) {
+/** `getAccounts` is read fresh on every call (see `resolveAzAccount`), never a list captured once
+ *  at tool-build time — the same live-config shape `Az/createAzTool.ts` uses, so a config reload
+ *  that adds/removes a holder account takes effect on the very next call, with no tool rebuild. */
+export function createAdoPrTool<TSchema extends z.ZodType<{ account?: string; cwd?: string }>>(spec: AdoPrToolSpec<TSchema>, deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
   return defineTool({
     name: spec.name,
     // 'escalate', not 'write': this crosses a privilege boundary (the holder PAT) that must always
@@ -36,10 +41,11 @@ export function createAdoPrTool<TSchema extends z.ZodType>(spec: AdoPrToolSpec<T
     output_schema: AdoPrOutputSchema,
     input_examples: spec.input_examples ?? [],
     handler: async (input) => {
-      const cwd = (input as { cwd?: string }).cwd ?? process.cwd();
+      const cwd = input.cwd ?? process.cwd();
       const remoteUrl = await getGitRemoteUrl(cwd);
       const remote = remoteUrl != null ? parseAdoRemote(remoteUrl) : null;
-      const result = await runAdoEscalated(deps, spec.subcommand, spec.buildArgs(input, remote), cwd);
+      const account = resolveAzAccount(getAccounts, 'holder', input.account, orgNameFromRemote(remote));
+      const result = await runAdoEscalated(deps, account, spec.subcommand, spec.buildArgs(input, remote), cwd);
       return { textContent: { stdout: result.stdout.trim(), stderr: result.stderr.trim(), exitCode: result.exitCode } };
     },
   });

--- a/packages/claude-sdk-tools/src/AzureDevOps/parseAdoRemote.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/parseAdoRemote.ts
@@ -27,3 +27,18 @@ export function parseAdoRemote(url: string): AdoRemoteContext | null {
 
   return null;
 }
+
+/** The org segment out of an already-parsed remote's `orgUrl` ('https://dev.azure.com/<org>/' →
+ *  '<org>'), used as the account-name fallback when a PR tool's `account` field is omitted — see
+ *  `resolveAzAccount`'s `fallback` parameter. Not a guess: it is the same org the tool call is
+ *  already targeting, so a repo whose remote's org matches a configured account name runs as that
+ *  account with no explicit `account` needed, and falls through to the ordinary single-account/
+ *  ambiguous-error rules whenever it doesn't match anything configured. */
+export function orgNameFromRemote(remote: AdoRemoteContext | null): string | undefined {
+  if (remote == null) {
+    return undefined;
+  }
+  const match = remote.orgUrl.match(/dev\.azure\.com\/([^/]+)\/$/);
+  return match?.[1];
+}
+

--- a/packages/claude-sdk-tools/src/AzureDevOps/parseAdoRemote.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/parseAdoRemote.ts
@@ -41,4 +41,3 @@ export function orgNameFromRemote(remote: AdoRemoteContext | null): string | und
   const match = remote.orgUrl.match(/dev\.azure\.com\/([^/]+)\/$/);
   return match?.[1];
 }
-

--- a/packages/claude-sdk-tools/src/AzureDevOps/runAdoEscalated.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/runAdoEscalated.ts
@@ -1,51 +1,26 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import type { IExecutor } from '@shellicar/exec-core';
-import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '../az-shared';
+import type { AzSessionCache } from '../Az/AzSessionCache';
+import type { AzDeps } from '../Az/runAz';
+import { type RunResult, runOnce } from '../az-shared';
 
-/** Deps every escalated `az repos pr` call needs: the same certificate-login mechanism the Az
- *  package's holder identity already uses for ordinary `az` commands — one identity, one
- *  credential, proven to authenticate to Azure DevOps directly (no separate PAT). Nothing here is
- *  cached beyond one call's lifetime; a rotated certificate takes effect on the very next call.
- *
- *  Shaped like `AzDeps` (see `Az/runAz.ts`): every getter takes the account name, so more than one
- *  configured holder account can be selected between rather than only ever running as a single,
- *  implicit one. */
-export type AdoEscalatedDeps = {
-  executor: IExecutor;
-  /** PEM (cert + private key) content for one account's holder identity. */
-  getCert: (account: string) => string;
-  /** The account's holder service principal's Application (client) ID. */
-  getClientId: (account: string) => string;
-  /** The Entra tenant ID the account's holder service principal belongs to. */
-  getTenantId: (account: string) => string;
-};
+/** ADO PR tool calls always run as the holder identity — same deps shape `AzCli`/`EscalatedAzCli`
+ *  use (`AzDeps`), since it's the same credential mechanism: one certificate, proven to
+ *  authenticate to Azure DevOps directly, no separate PAT. A plain alias, not a narrower type: the
+ *  same `AzDeps` object the app builds for `EscalatedAzCli` is reused verbatim here, so there is
+ *  only ever one place that reads a certificate/clientId/tenantId out of config or Keychain. */
+export type AdoEscalatedDeps = AzDeps;
 
-/** Runs one `az repos pr <subcommand> <args>` as the named account's holder identity: writes the
- *  certificate to a throwaway temp dir, `az login --service-principal --certificate` into an
- *  isolated AZURE_CONFIG_DIR scoped to that dir (never the caller's own logged-in session), runs
- *  the real command against that same config dir, then deletes the temp dir — certificate and
- *  session both gone once the call returns.
- *
- *  AZURE_EXTENSION_DIR points at a persistent, shared directory (see az-shared.ts) rather than the
- *  throwaway config dir: the `azure-devops` extension is not a credential, and re-downloading it
- *  on every single call is what made every call slow. Only the login/token cache is ephemeral. */
-export async function runAdoEscalated(deps: AdoEscalatedDeps, account: string, subcommand: string[], args: string[], cwd: string): Promise<RunResult> {
-  const configDir = await mkdtemp(join(tmpdir(), 'az-ado-'));
-  const extensionDir = await ensureAzExtensionDir();
-  try {
-    const certPath = join(configDir, 'cert.pem');
-    await writeFile(certPath, deps.getCert(account), { mode: 0o600 });
-    const env = { ...process.env, AZURE_CONFIG_DIR: configDir, AZURE_EXTENSION_DIR: extensionDir };
-
-    const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', deps.getClientId(account), '--tenant', deps.getTenantId(account), '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
-    if (login.exitCode !== 0) {
-      return login;
-    }
-
-    return await runOnce(deps.executor, 'az', ['repos', 'pr', ...subcommand, ...args], cwd, env);
-  } finally {
-    await removeConfigDir(configDir);
+/** Runs one `az repos pr <subcommand> <args>` as the given account's holder identity, through the
+ *  same `AzSessionCache` `AzCli`/`EscalatedAzCli` use — not a fresh `az login` per call. Because
+ *  the cache keys on `${identity}:${account}` and ADO PR calls always use `identity: 'holder'`, a
+ *  PR call against an account whose `EscalatedAzCli` session is already warm reuses that exact
+ *  session; there is no separate, ADO-only login path to pay for. This is what turns a repeated
+ *  ADO PR call from a ~12s round trip (fresh login every time) into the same near-instant cache hit
+ *  `EscalatedAzCli` already gets. */
+export async function runAdoEscalated(deps: AzDeps, cache: AzSessionCache, account: string, subcommand: string[], args: string[], cwd: string): Promise<RunResult> {
+  const session = await cache.getSession(deps, 'holder', account, cwd);
+  if ('loginFailed' in session) {
+    return session.loginFailed;
   }
+  const env = { ...process.env, AZURE_CONFIG_DIR: session.configDir, AZURE_EXTENSION_DIR: session.extensionDir };
+  return await runOnce(deps.executor, 'az', ['repos', 'pr', ...subcommand, ...args], cwd, env);
 }

--- a/packages/claude-sdk-tools/src/AzureDevOps/runAdoEscalated.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/runAdoEscalated.ts
@@ -7,35 +7,39 @@ import { ensureAzExtensionDir, type RunResult, removeConfigDir, runOnce } from '
 /** Deps every escalated `az repos pr` call needs: the same certificate-login mechanism the Az
  *  package's holder identity already uses for ordinary `az` commands — one identity, one
  *  credential, proven to authenticate to Azure DevOps directly (no separate PAT). Nothing here is
- *  cached beyond one call's lifetime; a rotated certificate takes effect on the very next call. */
+ *  cached beyond one call's lifetime; a rotated certificate takes effect on the very next call.
+ *
+ *  Shaped like `AzDeps` (see `Az/runAz.ts`): every getter takes the account name, so more than one
+ *  configured holder account can be selected between rather than only ever running as a single,
+ *  implicit one. */
 export type AdoEscalatedDeps = {
   executor: IExecutor;
-  /** PEM (cert + private key) content for the holder identity backing the ADO PR tools. */
-  getCert: () => string;
-  /** The holder service principal's Application (client) ID. */
-  getClientId: () => string;
-  /** The Entra tenant ID the holder service principal belongs to. */
-  getTenantId: () => string;
+  /** PEM (cert + private key) content for one account's holder identity. */
+  getCert: (account: string) => string;
+  /** The account's holder service principal's Application (client) ID. */
+  getClientId: (account: string) => string;
+  /** The Entra tenant ID the account's holder service principal belongs to. */
+  getTenantId: (account: string) => string;
 };
 
-/** Runs one `az repos pr <subcommand> <args>` as the holder identity: writes the certificate to a
- *  throwaway temp dir, `az login --service-principal --certificate` into an isolated
- *  AZURE_CONFIG_DIR scoped to that dir (never the caller's own logged-in session), runs the real
- *  command against that same config dir, then deletes the temp dir — certificate and session both
- *  gone once the call returns.
+/** Runs one `az repos pr <subcommand> <args>` as the named account's holder identity: writes the
+ *  certificate to a throwaway temp dir, `az login --service-principal --certificate` into an
+ *  isolated AZURE_CONFIG_DIR scoped to that dir (never the caller's own logged-in session), runs
+ *  the real command against that same config dir, then deletes the temp dir — certificate and
+ *  session both gone once the call returns.
  *
  *  AZURE_EXTENSION_DIR points at a persistent, shared directory (see az-shared.ts) rather than the
  *  throwaway config dir: the `azure-devops` extension is not a credential, and re-downloading it
  *  on every single call is what made every call slow. Only the login/token cache is ephemeral. */
-export async function runAdoEscalated(deps: AdoEscalatedDeps, subcommand: string[], args: string[], cwd: string): Promise<RunResult> {
+export async function runAdoEscalated(deps: AdoEscalatedDeps, account: string, subcommand: string[], args: string[], cwd: string): Promise<RunResult> {
   const configDir = await mkdtemp(join(tmpdir(), 'az-ado-'));
   const extensionDir = await ensureAzExtensionDir();
   try {
     const certPath = join(configDir, 'cert.pem');
-    await writeFile(certPath, deps.getCert(), { mode: 0o600 });
+    await writeFile(certPath, deps.getCert(account), { mode: 0o600 });
     const env = { ...process.env, AZURE_CONFIG_DIR: configDir, AZURE_EXTENSION_DIR: extensionDir };
 
-    const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', deps.getClientId(), '--tenant', deps.getTenantId(), '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
+    const login = await runOnce(deps.executor, 'az', ['login', '--service-principal', '-u', deps.getClientId(account), '--tenant', deps.getTenantId(account), '--certificate', certPath, '--allow-no-subscriptions'], cwd, env);
     if (login.exitCode !== 0) {
       return login;
     }

--- a/packages/claude-sdk-tools/src/AzureDevOps/schema.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/schema.ts
@@ -5,6 +5,14 @@ const cwdSchema = pathSchema
   .optional()
   .describe("Directory to run `az` in. Supports ~ and $VAR expansion. Determines which repo the command targets (via its git remote) when org/project/repository are omitted — required whenever the CLI's own working directory is not the target repo. Defaults to the CLI's own working directory when omitted.");
 
+/** A plain string, not an enum of currently-configured holder accounts: which accounts exist is
+ *  live config (see `AzAccountsConfig`), read fresh per call in the handler (see `createAdoPrTool`),
+ *  so a config reload takes effect on the very next call with no tool/schema rebuild. Whether a
+ *  given name is actually configured, and whether omitting it is allowed (exactly one holder
+ *  account configured), is validated live in the handler, the same shape as `Az/schema.ts`'s
+ *  `AzInputSchema`. */
+const accountSchema = z.string().optional().describe('Which configured Azure account to run this pull request command against. Optional when exactly one account has a holder identity configured; required when more than one does.');
+
 export const AdoPrOutputSchema = z.object({
   stdout: z.string(),
   stderr: z.string(),
@@ -24,6 +32,7 @@ export const AdoPrCreateInputSchema = z
     org: z.string().optional().describe('Azure DevOps organization URL, e.g. https://dev.azure.com/MyOrg/. Falls back to git config / az devops defaults if omitted'),
     project: z.string().optional().describe('Name or ID of the project. Falls back to git config / az devops defaults if omitted'),
     repository: z.string().optional().describe('Name or ID of the repository to create the pull request in'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -32,6 +41,7 @@ export const AdoPrReadyInputSchema = z
   .object({
     id: z.number().int().positive().describe('ID of the pull request to publish out of draft'),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -43,6 +53,7 @@ export const AdoPrEditInputSchema = z
     description: z.string().optional().describe('New description for the pull request. Can include markdown'),
     status: z.enum(['active', 'abandoned']).optional().describe("New state of the pull request. There is no 'completed' option — this tool cannot merge a pull request; use AzureDevOps_PullRequest_AutoMerge to queue a merge"),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -54,6 +65,7 @@ export const AdoPrAutoMergeInputSchema = z
     squash: z.boolean().optional().describe('Squash the commits in the source branch when merging into the target branch'),
     deleteSourceBranch: z.boolean().optional().describe('Delete the source branch after the pull request completes'),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -64,6 +76,7 @@ export const AdoPrReviewerAddInputSchema = z
     reviewers: z.array(z.string()).min(1).describe('Users or groups to include as reviewers, space separated'),
     required: z.boolean().optional().describe('Make the added reviewers required'),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -73,6 +86,7 @@ export const AdoPrReviewerRemoveInputSchema = z
     id: z.number().int().positive().describe('ID of the pull request'),
     reviewers: z.array(z.string()).min(1).describe('Users or groups to remove as reviewers'),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();
@@ -82,6 +96,7 @@ export const AdoPrVoteInputSchema = z
     id: z.number().int().positive().describe('ID of the pull request to vote on'),
     vote: z.enum(['approve-with-suggestions', 'reject', 'reset', 'wait-for-author']).describe("New vote value for the pull request. There is no 'approve' option — this tool cannot approve a pull request"),
     org: z.string().optional().describe('Azure DevOps organization URL'),
+    account: accountSchema,
     cwd: cwdSchema,
   })
   .strict();

--- a/packages/claude-sdk-tools/src/AzureDevOps/tools.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/tools.ts
@@ -1,3 +1,4 @@
+import type { AzSessionCache } from '../Az/AzSessionCache';
 import type { AzAccountsConfig } from '../Az/tools';
 import { createAdoAutoMergeTool } from './createAdoAutoMergeTool';
 import { type AdoEscalatedDeps, createAdoPrTool } from './createAdoPrTool';
@@ -28,8 +29,13 @@ export const ADO_PR_TOOL_NAMES = ['AzureDevOps_PullRequest_Create', 'AzureDevOps
  *  `getAccounts` is read fresh on every call (see `resolveAzAccount`), and whether these tools are
  *  even offered to the model on a given turn is decided live too, by the disabled-tools provider
  *  (see `ConfigDisabledToolsProvider` in the CLI app), which hides every name in `ADO_PR_TOOL_NAMES`
- *  whenever no account currently has a holder identity configured. */
-export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
+ *  whenever no account currently has a holder identity configured.
+ *
+ *  `cache` is the same `AzSessionCache` `AzCli`/`EscalatedAzCli` are built with — the caller
+ *  constructs it once and passes the same instance to both `createAzTools` and this function, so a
+ *  PR call and an `EscalatedAzCli` call against the same account share one warm login instead of
+ *  each keeping its own. */
+export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig, cache: AzSessionCache) {
   const Create = createAdoPrTool(
     {
       name: 'AzureDevOps_PullRequest_Create',
@@ -75,6 +81,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
   const Ready = createAdoPrTool(
@@ -88,6 +95,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
   const Edit = createAdoPrTool(
@@ -113,9 +121,10 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
-  const AutoMerge = createAdoAutoMergeTool(deps, getAccounts);
+  const AutoMerge = createAdoAutoMergeTool(deps, getAccounts, cache);
 
   const ReviewerAdd = createAdoPrTool(
     {
@@ -134,6 +143,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
   const ReviewerRemove = createAdoPrTool(
@@ -147,6 +157,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
   const Vote = createAdoPrTool(
@@ -160,6 +171,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAc
     },
     deps,
     getAccounts,
+    cache,
   );
 
   return [Create, Ready, Edit, AutoMerge, ReviewerAdd, ReviewerRemove, Vote] as const;

--- a/packages/claude-sdk-tools/src/AzureDevOps/tools.ts
+++ b/packages/claude-sdk-tools/src/AzureDevOps/tools.ts
@@ -1,3 +1,4 @@
+import type { AzAccountsConfig } from '../Az/tools';
 import { createAdoAutoMergeTool } from './createAdoAutoMergeTool';
 import { type AdoEscalatedDeps, createAdoPrTool } from './createAdoPrTool';
 import type { AdoRemoteContext } from './parseAdoRemote';
@@ -13,12 +14,22 @@ export function orgArgs(org: string | undefined, remote: AdoRemoteContext | null
   return resolved != null ? ['--org', resolved] : [];
 }
 
+export const ADO_PR_TOOL_NAMES = ['AzureDevOps_PullRequest_Create', 'AzureDevOps_PullRequest_Ready', 'AzureDevOps_PullRequest_Edit', 'AzureDevOps_PullRequest_AutoMerge', 'AzureDevOps_PullRequest_ReviewerAdd', 'AzureDevOps_PullRequest_ReviewerRemove', 'AzureDevOps_PullRequest_Vote'] as const;
+
 /** The named, typed AzureDevOps.PullRequest.* tools. Each hardcodes which `az repos pr` subcommand
  *  and flags it ever emits — the same structural guarantee the GitHub.PullRequest.* tools give (see
  *  the GitHub package), applied to Azure DevOps instead of GitHub. There is no comment tool: az cli
  *  has no `az repos pr comment` subcommand (thread comments require a raw REST call via `az devops
- *  invoke`, which cannot carry a fixed-subcommand guarantee), so it is left out rather than faked. */
-export function createAdoPrTools(deps: AdoEscalatedDeps) {
+ *  invoke`, which cannot carry a fixed-subcommand guarantee), so it is left out rather than faked.
+ *
+ *  Always registered, unconditionally — whether any account currently has a holder identity
+ *  configured is live config and can change on a reload; gating registration here would freeze
+ *  that decision at process start (see `Az/tools.ts`'s `createAzTools` for the same reasoning).
+ *  `getAccounts` is read fresh on every call (see `resolveAzAccount`), and whether these tools are
+ *  even offered to the model on a given turn is decided live too, by the disabled-tools provider
+ *  (see `ConfigDisabledToolsProvider` in the CLI app), which hides every name in `ADO_PR_TOOL_NAMES`
+ *  whenever no account currently has a holder identity configured. */
+export function createAdoPrTools(deps: AdoEscalatedDeps, getAccounts: () => AzAccountsConfig) {
   const Create = createAdoPrTool(
     {
       name: 'AzureDevOps_PullRequest_Create',
@@ -63,6 +74,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       },
     },
     deps,
+    getAccounts,
   );
 
   const Ready = createAdoPrTool(
@@ -75,6 +87,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       buildArgs: (input, remote) => ['--id', String(input.id), '--draft', 'false', ...orgArgs(input.org, remote)],
     },
     deps,
+    getAccounts,
   );
 
   const Edit = createAdoPrTool(
@@ -99,9 +112,10 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       },
     },
     deps,
+    getAccounts,
   );
 
-  const AutoMerge = createAdoAutoMergeTool(deps);
+  const AutoMerge = createAdoAutoMergeTool(deps, getAccounts);
 
   const ReviewerAdd = createAdoPrTool(
     {
@@ -119,6 +133,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       },
     },
     deps,
+    getAccounts,
   );
 
   const ReviewerRemove = createAdoPrTool(
@@ -131,6 +146,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       buildArgs: (input, remote) => ['--id', String(input.id), '--reviewers', ...input.reviewers, ...orgArgs(input.org, remote)],
     },
     deps,
+    getAccounts,
   );
 
   const Vote = createAdoPrTool(
@@ -143,6 +159,7 @@ export function createAdoPrTools(deps: AdoEscalatedDeps) {
       buildArgs: (input, remote) => ['--id', String(input.id), '--vote', input.vote, ...orgArgs(input.org, remote)],
     },
     deps,
+    getAccounts,
   );
 
   return [Create, Ready, Edit, AutoMerge, ReviewerAdd, ReviewerRemove, Vote] as const;

--- a/packages/claude-sdk-tools/src/entry/Az.ts
+++ b/packages/claude-sdk-tools/src/entry/Az.ts
@@ -1,9 +1,8 @@
 import type { AzDeps } from '../Az/runAz';
-import type { AzAccountsConfig } from '../Az/tools';
-import { createAzTools } from '../Az/tools';
+import { AZ_CLI_TOOL_NAME, type AzAccountsConfig, createAzTools, ESCALATED_AZ_CLI_TOOL_NAME } from '../Az/tools';
 import { executor } from '../exec-shared';
 
 export type { AzAccountsConfig, AzDeps };
 // Shares the process-wide Executor with ExecV3/GitHub/AzureDevOps (see their entry files), so az
 // calls are tracked and reaped by the same exit-sweep handler as every other exec child.
-export { createAzTools, executor as azExecutor };
+export { AZ_CLI_TOOL_NAME, createAzTools, ESCALATED_AZ_CLI_TOOL_NAME, executor as azExecutor };

--- a/packages/claude-sdk-tools/src/entry/Az.ts
+++ b/packages/claude-sdk-tools/src/entry/Az.ts
@@ -1,3 +1,4 @@
+import { AzSessionCache } from '../Az/AzSessionCache';
 import type { AzDeps } from '../Az/runAz';
 import { AZ_CLI_TOOL_NAME, type AzAccountsConfig, createAzTools, ESCALATED_AZ_CLI_TOOL_NAME } from '../Az/tools';
 import { executor } from '../exec-shared';
@@ -5,4 +6,8 @@ import { executor } from '../exec-shared';
 export type { AzAccountsConfig, AzDeps };
 // Shares the process-wide Executor with ExecV3/GitHub/AzureDevOps (see their entry files), so az
 // calls are tracked and reaped by the same exit-sweep handler as every other exec child.
-export { AZ_CLI_TOOL_NAME, createAzTools, ESCALATED_AZ_CLI_TOOL_NAME, executor as azExecutor };
+//
+// AzSessionCache is a value export, not just a type: the composition root constructs exactly one
+// instance and shares it between createAzTools and AzureDevOps's createAdoPrTools (see
+// createAppTools.ts), so a login warmed by one is reused by the other.
+export { AZ_CLI_TOOL_NAME, AzSessionCache, createAzTools, ESCALATED_AZ_CLI_TOOL_NAME, executor as azExecutor };

--- a/packages/claude-sdk-tools/src/entry/AzureDevOps.ts
+++ b/packages/claude-sdk-tools/src/entry/AzureDevOps.ts
@@ -1,8 +1,8 @@
 import type { AdoEscalatedDeps } from '../AzureDevOps/createAdoPrTool';
-import { createAdoPrTools } from '../AzureDevOps/tools';
+import { ADO_PR_TOOL_NAMES, createAdoPrTools } from '../AzureDevOps/tools';
 import { executor } from '../exec-shared';
 
 export type { AdoEscalatedDeps };
 // Shares the process-wide Executor with ExecV3 (see entry/ExecV3.ts) and GitHub (see entry/GitHub.ts),
 // so ado escalated calls are tracked and reaped by the same exit-sweep handler as every other exec child.
-export { createAdoPrTools, executor as adoExecutor };
+export { ADO_PR_TOOL_NAMES, createAdoPrTools, executor as adoExecutor };

--- a/packages/claude-sdk-tools/test/Az/createAzTool.spec.ts
+++ b/packages/claude-sdk-tools/test/Az/createAzTool.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAzAccount } from '../../src/Az/createAzTool';
+import type { AzAccountsConfig } from '../../src/Az/tools';
+
+const single: AzAccountsConfig = { shellicar: { tenantId: 't', readerClientId: 'r', holderClientId: null } };
+const multiple: AzAccountsConfig = {
+  shellicar: { tenantId: 't1', readerClientId: 'r1', holderClientId: 'h1' },
+  hopeventures: { tenantId: 't2', readerClientId: 'r2', holderClientId: 'h2' },
+};
+
+describe('resolveAzAccount', () => {
+  describe('with exactly one account configured for the identity', () => {
+    it('resolves to that account when none is requested', () => {
+      const expected = 'shellicar';
+      const actual = resolveAzAccount(() => single, 'reader', undefined);
+      expect(actual).toBe(expected);
+    });
+
+    it('resolves to the requested account when it matches', () => {
+      const expected = 'shellicar';
+      const actual = resolveAzAccount(() => single, 'reader', 'shellicar');
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('with more than one account configured for the identity', () => {
+    it('throws when no account is requested', () => {
+      const expected = 'account is required when more than one Azure account is configured';
+      expect(() => resolveAzAccount(() => multiple, 'reader', undefined)).toThrow(expected);
+    });
+
+    it('resolves to the requested account when it matches', () => {
+      const expected = 'hopeventures';
+      const actual = resolveAzAccount(() => multiple, 'holder', 'hopeventures');
+      expect(actual).toBe(expected);
+    });
+  });
+
+  it('throws when the requested account has no identity of that kind configured', () => {
+    const expected = "account 'other' has no holder identity configured";
+    expect(() => resolveAzAccount(() => multiple, 'holder', 'other')).toThrow(expected);
+  });
+
+  it('throws when no account has the identity configured at all', () => {
+    const expected = 'no account has a holder identity configured';
+    expect(() => resolveAzAccount(() => single, 'holder', undefined)).toThrow(expected);
+  });
+
+  describe('with a fallback', () => {
+    it('uses the fallback when no account is requested and it matches a configured account', () => {
+      const expected = 'hopeventures';
+      const actual = resolveAzAccount(() => multiple, 'holder', undefined, 'hopeventures');
+      expect(actual).toBe(expected);
+    });
+
+    it('prefers the explicit request over the fallback', () => {
+      const expected = 'shellicar';
+      const actual = resolveAzAccount(() => multiple, 'holder', 'shellicar', 'hopeventures');
+      expect(actual).toBe(expected);
+    });
+
+    it('throws when the fallback does not match any configured account and more than one is configured', () => {
+      const expected = 'account is required when more than one Azure account is configured';
+      expect(() => resolveAzAccount(() => multiple, 'holder', undefined, 'unrelated-org')).toThrow(expected);
+    });
+  });
+});

--- a/packages/claude-sdk-tools/test/Az/schema.spec.ts
+++ b/packages/claude-sdk-tools/test/Az/schema.spec.ts
@@ -1,62 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { createAzInputSchema } from '../../src/Az/schema';
+import { AzInputSchema } from '../../src/Az/schema';
 
-describe('createAzInputSchema', () => {
-  describe('with exactly one configured account', () => {
-    const schema = createAzInputSchema(['shellicar']);
-
-    it('accepts input with account omitted', () => {
-      const expected = true;
-      const actual = schema.safeParse({ args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
-
-    it('accepts input with the account explicitly given', () => {
-      const expected = true;
-      const actual = schema.safeParse({ account: 'shellicar', args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
-
-    it('rejects an account name outside the configured enum', () => {
-      const expected = false;
-      const actual = schema.safeParse({ account: 'other', args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
+describe('AzInputSchema', () => {
+  it('accepts input with account omitted', () => {
+    const expected = true;
+    const actual = AzInputSchema.safeParse({ args: ['group', 'list'] }).success;
+    expect(actual).toBe(expected);
   });
 
-  describe('with more than one configured account', () => {
-    const schema = createAzInputSchema(['shellicar', 'hopeventures']);
-
-    it('rejects input with account omitted', () => {
-      const expected = false;
-      const actual = schema.safeParse({ args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
-
-    it('accepts input naming one of the configured accounts', () => {
-      const expected = true;
-      const actual = schema.safeParse({ account: 'hopeventures', args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
-
-    it('rejects an account name outside the configured enum', () => {
-      const expected = false;
-      const actual = schema.safeParse({ account: 'other', args: ['group', 'list'] }).success;
-      expect(actual).toBe(expected);
-    });
+  it('accepts input with an account name given', () => {
+    const expected = true;
+    const actual = AzInputSchema.safeParse({ account: 'shellicar', args: ['group', 'list'] }).success;
+    expect(actual).toBe(expected);
   });
 
   it('rejects an empty args array', () => {
-    const schema = createAzInputSchema(['shellicar']);
     const expected = false;
-    const actual = schema.safeParse({ args: [] }).success;
+    const actual = AzInputSchema.safeParse({ args: [] }).success;
     expect(actual).toBe(expected);
   });
 
   it('rejects unknown fields (strict schema)', () => {
-    const schema = createAzInputSchema(['shellicar']);
     const expected = false;
-    const actual = schema.safeParse({ args: ['group', 'list'], unexpected: true }).success;
+    const actual = AzInputSchema.safeParse({ args: ['group', 'list'], unexpected: true }).success;
     expect(actual).toBe(expected);
   });
 });

--- a/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
+++ b/packages/claude-sdk-tools/test/AzSessionCache.spec.ts
@@ -95,6 +95,39 @@ describe('AzSessionCache — background refresh vs hard-expiry relogin race', ()
     await Promise.all(configDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})));
   });
 
+  // The cache entry is written to the map synchronously, inside #login, before its own first
+  // await — so two calls issued back-to-back (as Promise.all does: each runs to its first await
+  // before the next starts) can never both observe a cold miss. The second always finds the
+  // in-flight entry the first just wrote and joins its promise rather than starting a second
+  // login. This is the guarantee two parallel tool calls against the same account rely on.
+  it('joins a single in-flight login instead of starting a second one for concurrent cold-start callers', async () => {
+    const clock = new MutableClock(0);
+    const executor = new ControllableExecutor();
+    const deps = makeDeps(executor);
+    const cache = new AzSessionCache(clock);
+
+    const [promiseA, promiseB] = [cache.getSession(deps, 'reader', 'acct', '/cwd'), cache.getSession(deps, 'reader', 'acct', '/cwd')];
+
+    await waitForCallCount(executor, 1);
+    const expectedCallsAfterBothStart = 1;
+    const actualCallsAfterBothStart = executor.calls.length;
+    expect(actualCallsAfterBothStart).toBe(expectedCallsAfterBothStart);
+
+    await executor.resolve(0);
+    await waitForCallCount(executor, 2);
+    await executor.resolve(1, tokenJson(1000));
+
+    const [sessionA, sessionB] = await Promise.all([promiseA, promiseB]);
+    if ('loginFailed' in sessionA || 'loginFailed' in sessionB) {
+      throw new Error('unreachable');
+    }
+    configDirs.push(sessionA.configDir);
+
+    const expected = sessionA.configDir;
+    const actual = sessionB.configDir;
+    expect(actual).toBe(expected);
+  });
+
   // A background refresh started at the 50% mark is meant to be a non-blocking courtesy: if a
   // caller crosses hardExpireAt before it finishes, that caller synchronously relogs in and its
   // session is the one that should be current. AzSessionCache#backgroundRefresh instead lands its

--- a/packages/claude-sdk-tools/test/parseAdoRemote.spec.ts
+++ b/packages/claude-sdk-tools/test/parseAdoRemote.spec.ts
@@ -65,7 +65,6 @@ describe('parseAdoRemote', () => {
   });
 });
 
-
 describe('orgNameFromRemote', () => {
   it('extracts the org segment from a parsed remote', () => {
     const expected = 'hopeventures';

--- a/packages/claude-sdk-tools/test/parseAdoRemote.spec.ts
+++ b/packages/claude-sdk-tools/test/parseAdoRemote.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseAdoRemote } from '../src/AzureDevOps/parseAdoRemote';
+import { orgNameFromRemote, parseAdoRemote } from '../src/AzureDevOps/parseAdoRemote';
 
 describe('parseAdoRemote', () => {
   describe('https remotes', () => {
@@ -62,5 +62,20 @@ describe('parseAdoRemote', () => {
       const actual = parseAdoRemote('not a url at all');
       expect(actual).toBe(expected);
     });
+  });
+});
+
+
+describe('orgNameFromRemote', () => {
+  it('extracts the org segment from a parsed remote', () => {
+    const expected = 'hopeventures';
+    const actual = orgNameFromRemote({ orgUrl: 'https://dev.azure.com/hopeventures/', project: 'p', repository: 'r' });
+    expect(actual).toBe(expected);
+  });
+
+  it('returns undefined when there is no remote', () => {
+    const expected = undefined;
+    const actual = orgNameFromRemote(null);
+    expect(actual).toBe(expected);
   });
 });

--- a/scripts/src/tool-schema-sizes.ts
+++ b/scripts/src/tool-schema-sizes.ts
@@ -96,7 +96,7 @@ const { tools } = createAppTools({
   logger: new StubLogger(),
   secrets: new StubSecrets(),
   envProvider: new StubEnvProvider(),
-  azAccounts: {},
+  getAzAccounts: () => ({}),
 });
 
 const sizes = tools.map((tool) => ({


### PR DESCRIPTION
## Summary

- AzureDevOps.PullRequest.* tools can now target any configured Azure account, not just a single implicit one, defaulting to the git remote's own org when it matches one.
- Account configuration changes take effect immediately across AzCli, EscalatedAzCli, and the AzureDevOps.PullRequest.* tools, with no restart.
- Each of those tools is hidden from a turn's tool list whenever no account has the matching identity configured.
- AzureDevOps.PullRequest.* calls reuse an already-warm az login instead of paying a fresh one every time.
- Provisioning an Azure service principal's certificate is now a separate step from creating the service principal, so fixing a misnamed Keychain entry doesn't require recreating it.