### PR TITLE
Gate tools behind a config-driven required Skill load

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add image paste from clipboard via command mode
 - Add maxTokens to config (default 32000)
 - Add per-source CLAUDE.md loading control
+- Add requiredSkills config: certain tools can be made to require a named Skill be loaded earlier in the conversation before they're callable
 - Add secrets.ghScoping config (default false): opt-in gh token scoping for exec calls, since it requires macOS arm64 and a Keychain reader item created out of band by the operator
 - Add the --system-identity flag: bind a system prompt to a conversation from a file, persisted and restored on resume
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -161,3 +161,4 @@
 {"description":"AzCli, EscalatedAzCli, and AzureDevOps.PullRequest.* are hidden from a turn's tools whenever no matching account is configured","category":"changed"}
 {"description":"A broken dependency wiring now fails the build or startup","category":"changed"}
 {"description":"Pressing escape during a pending tool approval no longer leaves Y/N permanently swallowed for the rest of the session","category":"fixed"}
+{"description":"Add requiredSkills config: certain tools can be made to require a named Skill be loaded earlier in the conversation before they're callable","category":"added"}

--- a/apps/claude-sdk-cli/src/cli-config/schema.ts
+++ b/apps/claude-sdk-cli/src/cli-config/schema.ts
@@ -362,6 +362,12 @@ export const sdkConfigSchema = z
     tools: toolsSchema.describe('Execution tool selection'),
     input: inputSchema.describe('Raw keyboard input handling configuration'),
     disabledTools: z.array(z.string()).optional().default([]).catch([]).describe('Names of loaded tools to hide from the model and refuse as unavailable. Read live: takes effect on the next turn without a restart.'),
+    requiredSkills: z
+      .record(z.string(), z.array(z.string()))
+      .optional()
+      .default({})
+      .catch({})
+      .describe('Tool name to the skill name(s) that must have been successfully loaded via the Skill tool earlier in this conversation before that tool may be called. A tool absent from this map is unrestricted. Read live: takes effect on the very next tool_use without a restart.'),
     statusBar: statusBarSchema.describe('Status bar configuration'),
     permissions: permissionsSchema.describe('Tool approval permission matrix'),
     preventSleep: preventSleepSchema.describe('Sleep prevention during in-flight network requests'),

--- a/apps/claude-sdk-cli/src/setup/SkillGateProvider.ts
+++ b/apps/claude-sdk-cli/src/setup/SkillGateProvider.ts
@@ -2,11 +2,36 @@ import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IConversation, ISkillGateProvider, type SkillGateResult } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
 
+/** A `tool_result` block's `content` is the un-transformed `Skill` output verbatim (`{ found,
+ *  skill, ... }`) unless the ref-swap transform intervened for an oversized body; either way, an
+ *  unparsable or ref-swapped body carries no `found: true` and is correctly treated as not loaded
+ *  (fail closed, never fail open). `is_error` alone is not enough to prove success: the `Skill`
+ *  tool reports a missing/typo'd skill name as an ordinary, non-error result with `found: false`
+ *  (see Skill.ts), so a name that never resolved must not open the gate. */
+function skillLoadSucceeded(block: { is_error?: boolean; content?: unknown }): boolean {
+  if (block.is_error) {
+    return false;
+  }
+  const content = block.content;
+  const text = Array.isArray(content) ? (content.find((b): b is { type: string; text: string } => (b as { type?: string }).type === 'text')?.text ?? null) : typeof content === 'string' ? content : null;
+  if (text === null) {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return (parsed as { found?: unknown } | null)?.found === true;
+  } catch {
+    return false;
+  }
+}
+
 /** Every `Skill` tool_use whose input names a skill, keyed by that call's tool_use id, paired
- *  with whether a same-named tool_result later reported success — built fresh per check from
- *  `conversation.items`, never cached. This is what makes a restart free: `items` already holds
- *  the full replayed history by the time `setHistory` returns, live pushes append to the same
- *  array, and this function does not care which produced any given entry. */
+ *  with whether a same-named tool_result later reported `found: true` — built fresh per check
+ *  from `conversation.items`, never cached. This is what makes a restart free: `items` already
+ *  holds the full replayed history by the time `setHistory` returns, live pushes append to the
+ *  same array, and this function does not care which produced any given entry. `items` also holds
+ *  every message forever regardless of compaction (see `Conversation`), so a skill loaded before a
+ *  compaction still counts even though the compacted request sent to the API no longer carries it. */
 function loadedSkillNames(conversation: IConversation): Set<string> {
   const attempted = new Map<string, string>();
   const loaded = new Set<string>();
@@ -30,7 +55,7 @@ function loadedSkillNames(conversation: IConversation): Set<string> {
           continue;
         }
         const skill = attempted.get(block.tool_use_id);
-        if (skill !== undefined && !block.is_error) {
+        if (skill !== undefined && skillLoadSucceeded(block)) {
           loaded.add(skill);
         }
       }
@@ -51,6 +76,13 @@ export class SkillGateProvider extends ISkillGateProvider {
   @dependsOn(IConversation) public conversation!: IConversation;
 
   public check(toolName: string): SkillGateResult {
+    // The Skill tool can never be required to unlock itself: a requiredSkills entry naming
+    // 'Skill' would deadlock it permanently (nothing can call Skill to satisfy the requirement,
+    // since the call to do so is itself blocked). Configuring it that way is a config mistake,
+    // not a real requirement, so it is ignored rather than honoured.
+    if (toolName === 'Skill') {
+      return { allowed: true };
+    }
     const required = this.configLoader.config.requiredSkills[toolName] as string[] | undefined;
     if (required === undefined || required.length === 0) {
       return { allowed: true };

--- a/apps/claude-sdk-cli/src/setup/SkillGateProvider.ts
+++ b/apps/claude-sdk-cli/src/setup/SkillGateProvider.ts
@@ -1,0 +1,62 @@
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { IConversation, ISkillGateProvider, type SkillGateResult } from '@shellicar/claude-sdk';
+import { dependsOn } from '@shellicar/core-di';
+
+/** Every `Skill` tool_use whose input names a skill, keyed by that call's tool_use id, paired
+ *  with whether a same-named tool_result later reported success — built fresh per check from
+ *  `conversation.items`, never cached. This is what makes a restart free: `items` already holds
+ *  the full replayed history by the time `setHistory` returns, live pushes append to the same
+ *  array, and this function does not care which produced any given entry. */
+function loadedSkillNames(conversation: IConversation): Set<string> {
+  const attempted = new Map<string, string>();
+  const loaded = new Set<string>();
+  for (const { msg } of conversation.items) {
+    if (!Array.isArray(msg.content)) {
+      continue;
+    }
+    if (msg.role === 'assistant') {
+      for (const block of msg.content) {
+        if (block.type !== 'tool_use' || block.name !== 'Skill') {
+          continue;
+        }
+        const skill = (block.input as { skill?: unknown }).skill;
+        if (typeof skill === 'string') {
+          attempted.set(block.id, skill);
+        }
+      }
+    } else if (msg.role === 'user') {
+      for (const block of msg.content) {
+        if (block.type !== 'tool_result') {
+          continue;
+        }
+        const skill = attempted.get(block.tool_use_id);
+        if (skill !== undefined && !block.is_error) {
+          loaded.add(skill);
+        }
+      }
+    }
+  }
+  return loaded;
+}
+
+/** Config-driven, conversation-aware `ISkillGateProvider`: certain tools (named in
+ *  `config.requiredSkills`) may only be called once every skill listed for them has been
+ *  successfully loaded via the `Skill` tool earlier in this conversation. Both halves are read
+ *  fresh on every `check` call — the required-skills map off the live `ConfigLoader` (so an
+ *  edit takes effect on the very next tool_use, matching `ConfigDisabledToolsProvider`'s
+ *  live-read contract) and which skills have loaded off the live `Conversation` (so a `Skill`
+ *  load earlier in the same turn already counts). */
+export class SkillGateProvider extends ISkillGateProvider {
+  @dependsOn(ConfigLoader) public configLoader!: ConfigLoader<any>;
+  @dependsOn(IConversation) public conversation!: IConversation;
+
+  public check(toolName: string): SkillGateResult {
+    const required = this.configLoader.config.requiredSkills[toolName] as string[] | undefined;
+    if (required === undefined || required.length === 0) {
+      return { allowed: true };
+    }
+    const loaded = loadedSkillNames(this.conversation);
+    const missing = required.filter((skill: string) => !loaded.has(skill));
+    return missing.length === 0 ? { allowed: true } : { allowed: false, missing };
+  }
+}

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -36,6 +36,7 @@ import {
   IQueryRunner,
   IRequestClockListener,
   ISdkMessagePublisher,
+  ISkillGateProvider,
   IStreamProcessor,
   IToolBlockNotifier,
   IToolProvider,
@@ -154,6 +155,7 @@ import { ISessionActivator, SessionActivator } from './SessionActivator.js';
 import { IShutdownCoordinator, ShutdownCoordinator } from './ShutdownCoordinator.js';
 import { IShutdownSequence, ShutdownSequence } from './ShutdownSequence.js';
 import { SkillCatalogueTracker } from './SkillCatalogueTracker.js';
+import { SkillGateProvider } from './SkillGateProvider.js';
 import { ITurnCoordinator, TurnCoordinator } from './TurnCoordinator.js';
 import { IWorkingDirectoryMoveHandler, WorkingDirectoryMoveHandler } from './WorkingDirectoryMoveHandler.js';
 
@@ -339,14 +341,15 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
   // StreamProcessor and IStreamProcessor share identity from this one register() call.
   services.register(StreamProcessor).asSelf().as(IStreamProcessor);
   services.register(ConfigDisabledToolsProvider).as(IDisabledToolsProvider);
+  services.register(SkillGateProvider).as(ISkillGateProvider);
   services
     .register(ToolRegistry)
-    .using([IFileSystem, IToolProvider, ILogger, IDisabledToolsProvider], (fs, toolProvider, log, disabledToolsProvider) => {
+    .using([IFileSystem, IToolProvider, ILogger, IDisabledToolsProvider, ISkillGateProvider], (fs, toolProvider, log, disabledToolsProvider, skillGate) => {
       // Canonicalise a marked path to a single absolute form all three consumers read: expand ~/$VAR,
       // then resolve against cwd so a relative path (test1.txt) and dot segments (../a) collapse to one
       // path. Symlinks are not resolved (realpath is async and throws on not-yet-existing paths).
       const expand = (p: string) => path.resolve(fs.cwd(), expandPath(p, fs));
-      return new ToolRegistry(toolProvider.tools, log, expand, disabledToolsProvider);
+      return new ToolRegistry(toolProvider.tools, log, expand, disabledToolsProvider, skillGate);
     })
     .as(IToolRegistry);
   // Build-tools step: collect every distinct block lifetime the tools declared,

--- a/apps/claude-sdk-cli/test/SkillGateProvider.spec.ts
+++ b/apps/claude-sdk-cli/test/SkillGateProvider.spec.ts
@@ -8,11 +8,14 @@ function makeLoader(requiredSkills: Record<string, string[]>): ConfigLoader<any>
   return new ConfigLoader({ config: { requiredSkills }, sources: [], warnings: [] });
 }
 
-function pushSkillCall(conversation: Conversation, id: string, skill: string, isError: boolean): void {
+type SkillCallOutcome = 'found' | 'not-found' | 'error';
+
+function pushSkillCall(conversation: Conversation, id: string, skill: string, outcome: SkillCallOutcome): void {
   conversation.push({ role: 'assistant', content: [{ type: 'tool_use', id, name: 'Skill', input: { skill } }] } as Anthropic.Beta.Messages.BetaMessageParam);
+  const text = outcome === 'found' ? JSON.stringify({ found: true, skill, body: 'instructions' }) : JSON.stringify({ found: false, skill, available: [] });
   conversation.push({
     role: 'user',
-    content: [{ type: 'tool_result', tool_use_id: id, is_error: isError, content: [{ type: 'text', text: '{}' }] }],
+    content: [{ type: 'tool_result', tool_use_id: id, is_error: outcome === 'error', content: [{ type: 'text', text }] }],
   } as Anthropic.Beta.Messages.BetaMessageParam);
 }
 
@@ -37,7 +40,7 @@ describe('SkillGateProvider', () => {
     const provider = new SkillGateProvider();
     provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
     const conversation = new Conversation();
-    pushSkillCall(conversation, 'tool_1', 'pr', false);
+    pushSkillCall(conversation, 'tool_1', 'pr', 'found');
     provider.conversation = conversation;
     const actual = provider.check('GitHub_PullRequest_Create');
     expect(actual).toEqual({ allowed: true });
@@ -47,17 +50,35 @@ describe('SkillGateProvider', () => {
     const provider = new SkillGateProvider();
     provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
     const conversation = new Conversation();
-    pushSkillCall(conversation, 'tool_1', 'pr', true);
+    pushSkillCall(conversation, 'tool_1', 'pr', 'error');
     provider.conversation = conversation;
     const actual = provider.check('GitHub_PullRequest_Create');
     expect(actual).toEqual({ allowed: false, missing: ['pr'] });
+  });
+
+  it('does not count a Skill call that resolved but reported found: false', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
+    const conversation = new Conversation();
+    pushSkillCall(conversation, 'tool_1', 'pr', 'not-found');
+    provider.conversation = conversation;
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: false, missing: ['pr'] });
+  });
+
+  it('never blocks the Skill tool itself, even if misconfigured to require a skill', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ Skill: ['pr'] });
+    provider.conversation = new Conversation();
+    const actual = provider.check('Skill');
+    expect(actual).toEqual({ allowed: true });
   });
 
   it('requires every listed skill, not just one', () => {
     const provider = new SkillGateProvider();
     provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr', 'commit'] });
     const conversation = new Conversation();
-    pushSkillCall(conversation, 'tool_1', 'pr', false);
+    pushSkillCall(conversation, 'tool_1', 'pr', 'found');
     provider.conversation = conversation;
     const actual = provider.check('GitHub_PullRequest_Create');
     expect(actual).toEqual({ allowed: false, missing: ['commit'] });

--- a/apps/claude-sdk-cli/test/SkillGateProvider.spec.ts
+++ b/apps/claude-sdk-cli/test/SkillGateProvider.spec.ts
@@ -1,0 +1,75 @@
+import type { Anthropic } from '@anthropic-ai/sdk';
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
+import { Conversation } from '@shellicar/claude-sdk';
+import { describe, expect, it } from 'vitest';
+import { SkillGateProvider } from '../src/setup/SkillGateProvider.js';
+
+function makeLoader(requiredSkills: Record<string, string[]>): ConfigLoader<any> {
+  return new ConfigLoader({ config: { requiredSkills }, sources: [], warnings: [] });
+}
+
+function pushSkillCall(conversation: Conversation, id: string, skill: string, isError: boolean): void {
+  conversation.push({ role: 'assistant', content: [{ type: 'tool_use', id, name: 'Skill', input: { skill } }] } as Anthropic.Beta.Messages.BetaMessageParam);
+  conversation.push({
+    role: 'user',
+    content: [{ type: 'tool_result', tool_use_id: id, is_error: isError, content: [{ type: 'text', text: '{}' }] }],
+  } as Anthropic.Beta.Messages.BetaMessageParam);
+}
+
+describe('SkillGateProvider', () => {
+  it('allows a tool absent from the requiredSkills map', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({});
+    provider.conversation = new Conversation();
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: true });
+  });
+
+  it('blocks a required tool when its skill has never been loaded', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
+    provider.conversation = new Conversation();
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: false, missing: ['pr'] });
+  });
+
+  it('allows a required tool once its skill has loaded successfully', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
+    const conversation = new Conversation();
+    pushSkillCall(conversation, 'tool_1', 'pr', false);
+    provider.conversation = conversation;
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: true });
+  });
+
+  it('does not count a Skill call that came back as an error', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr'] });
+    const conversation = new Conversation();
+    pushSkillCall(conversation, 'tool_1', 'pr', true);
+    provider.conversation = conversation;
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: false, missing: ['pr'] });
+  });
+
+  it('requires every listed skill, not just one', () => {
+    const provider = new SkillGateProvider();
+    provider.configLoader = makeLoader({ GitHub_PullRequest_Create: ['pr', 'commit'] });
+    const conversation = new Conversation();
+    pushSkillCall(conversation, 'tool_1', 'pr', false);
+    provider.conversation = conversation;
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: false, missing: ['commit'] });
+  });
+
+  it('reads the config loader live, reflecting an applied requiredSkills change', () => {
+    const loader = makeLoader({});
+    const provider = new SkillGateProvider();
+    provider.configLoader = loader;
+    provider.conversation = new Conversation();
+    loader.apply({ config: { requiredSkills: { GitHub_PullRequest_Create: ['pr'] } }, sources: [], warnings: [] });
+    const actual = provider.check('GitHub_PullRequest_Create');
+    expect(actual).toEqual({ allowed: false, missing: ['pr'] });
+  });
+});

--- a/apps/claude-sdk-cli/test/cli-config.spec.ts
+++ b/apps/claude-sdk-cli/test/cli-config.spec.ts
@@ -29,6 +29,7 @@ describe('sdkConfigSchema', () => {
         tools: { exec: false, execV2: false, execV3: true, blockedCommands: [], rules: {} },
         input: { escFastPath: true },
         disabledTools: [],
+        requiredSkills: {},
         statusBar: { showConversationId: true },
         permissions: {
           default: { read: 'approve', write: 'approve', delete: 'ask' },

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support tool search for on-demand tool discovery
 - Support tool use examples in tool definitions
 - ToolRegistry accepts an IDisabledToolsProvider so a consumer can hide named tools from the model and refuse them as unavailable, read live on every call
+- ToolRegistry can be configured to require a named skill be loaded before a tool is callable, via a new ISkillGateProvider hook
 
 ### Changed
 

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -62,3 +62,4 @@
 {"description":"Depend on @shellicar/core-di instead of @shellicar/core-di-lite","category":"changed"}
 {"description":"Fix a cancel during a multi-tool approval batch dropping tool_results for tools still awaiting approval, including the case where the cancel lands before any approval request for the batch was even made","category":"fixed"}
 {"description":"Generalise the dangling tool_use self-heal to cover a partially-answered multi-tool batch, prepending the synthetic result so it still leads the reply as the API requires","category":"fixed"}
+{"description":"ToolRegistry can be configured to require a named skill be loaded before a tool is callable, via a new ISkillGateProvider hook","category":"added"}

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -19,6 +19,7 @@ import { AnthropicBeta, CacheTtl, COMPACT_BETA } from './public/enums';
 import { IDisabledToolsProvider } from './public/IDisabledToolsProvider';
 import { IDurableConfigProvider } from './public/IDurableConfigProvider';
 import { ISdkMessagePublisher } from './public/ISdkMessagePublisher';
+import { ISkillGateProvider, type SkillGateResult } from './public/ISkillGateProvider';
 import { IToolProvider } from './public/IToolProvider';
 import { IQueryRunner, IStreamProcessor, IToolRegistry, ITurnRunner, IWakeLock } from './public/interfaces';
 import { annotatePathDescriptions, collectPaths, IS_PATH, normalisePaths, pathSchema, TOOL_INPUT_KEYED_BY } from './public/pathSchema';
@@ -91,6 +92,7 @@ export type {
   SdkServerToolUse,
   SdkToolApprovalRequest,
   SdkTurnContent,
+  SkillGateResult,
   SystemReminder,
   TextBlock,
   ThinkingEffort,
@@ -130,6 +132,7 @@ export {
   IRequestClockListener,
   IS_PATH,
   ISdkMessagePublisher,
+  ISkillGateProvider,
   IStreamProcessor,
   IToolBlockNotifier,
   IToolProvider,

--- a/packages/claude-sdk/src/private/ToolRegistry.ts
+++ b/packages/claude-sdk/src/private/ToolRegistry.ts
@@ -2,6 +2,7 @@ import type { Anthropic } from '@anthropic-ai/sdk';
 import type { BetaTool } from '@anthropic-ai/sdk/resources/beta.mjs';
 import type { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { IDisabledToolsProvider } from '../public/IDisabledToolsProvider';
+import type { ISkillGateProvider } from '../public/ISkillGateProvider';
 import { IToolRegistry } from '../public/interfaces';
 import { normalisePaths } from '../public/pathSchema';
 import { ToolCancelledError } from '../public/ToolCancelledError';
@@ -52,17 +53,19 @@ export class ToolRegistry extends IToolRegistry {
   // behave unchanged; the composition root injects the real fs-bound expander.
   readonly #expand: (p: string) => string;
   readonly #disabledToolsProvider: IDisabledToolsProvider;
+  readonly #skillGate: ISkillGateProvider;
 
   // The wire-map is built eagerly in the constructor, so a bad tool schema
   // fails at composition (buildProvider) rather than on first use. The app's
   // composition root supplies the tools and logger through the factory.
   // disabledToolsProvider defaults to an always-empty set so the many
   // `new ToolRegistry(tools, logger)` call sites (SDK tests) keep compiling.
-  public constructor(tools: readonly AnyToolDefinition[], logger: ILogger, expand: (p: string) => string = (p) => p, disabledToolsProvider: IDisabledToolsProvider = { disabledTools: new Set() }) {
+  public constructor(tools: readonly AnyToolDefinition[], logger: ILogger, expand: (p: string) => string = (p) => p, disabledToolsProvider: IDisabledToolsProvider = { disabledTools: new Set() }, skillGate: ISkillGateProvider = { check: () => ({ allowed: true }) }) {
     super();
     this.#logger = logger;
     this.#expand = expand;
     this.#disabledToolsProvider = disabledToolsProvider;
+    this.#skillGate = skillGate;
     this.#map = new Map();
     for (const tool of tools) {
       const wire: BetaTool = {
@@ -98,6 +101,13 @@ export class ToolRegistry extends IToolRegistry {
     if (entry == null || this.#disabledToolsProvider.disabledTools.has(name)) {
       this.#logger.debug('tool_not_found', { name });
       return { kind: 'unavailable', name };
+    }
+
+    const gate = this.#skillGate.check(name);
+    if (!gate.allowed) {
+      this.#logger.debug('tool_skill_gate_blocked', { name, missing: gate.missing });
+      const skills = gate.missing.join(', ');
+      return { kind: 'rejected', reason: `This tool requires loading the following skill(s) first via the Skill tool: ${skills}` };
     }
 
     const parseResult = entry.definition.input_schema.safeParse(input);

--- a/packages/claude-sdk/src/public/ISkillGateProvider.ts
+++ b/packages/claude-sdk/src/public/ISkillGateProvider.ts
@@ -1,0 +1,15 @@
+/**
+ * The live skill-gate contract `ToolRegistry` consults before resolving a `tool_use`, so it
+ * can require certain tools to be preceded by a named `Skill` load without importing the
+ * consumer's concrete config or conversation-history source.
+ *
+ * Read fresh on every `resolve` call, never cached: both halves of the answer — the
+ * required-skills mapping (config, hot-reloaded) and which skills have already loaded
+ * (conversation history, which grows between calls) — can change between one tool_use and
+ * the next, exactly like `IDisabledToolsProvider`.
+ */
+export type SkillGateResult = { allowed: true } | { allowed: false; missing: readonly string[] };
+
+export abstract class ISkillGateProvider {
+  public abstract check(toolName: string): SkillGateResult;
+}

--- a/packages/claude-sdk/test/ToolRegistry.spec.ts
+++ b/packages/claude-sdk/test/ToolRegistry.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { ToolRegistry } from '../src/private/ToolRegistry.js';
 import type { IDisabledToolsProvider } from '../src/public/IDisabledToolsProvider.js';
+import type { ISkillGateProvider, SkillGateResult } from '../src/public/ISkillGateProvider.js';
 import { ToolRefusedError } from '../src/public/ToolRefusedError.js';
 import type { AnyToolDefinition, ToolAttachmentBlock } from '../src/public/types.js';
 
@@ -17,6 +18,10 @@ const logger = new NoopLogger();
 
 function disabledToolsProviderOf(names: string[]): IDisabledToolsProvider {
   return { disabledTools: new Set(names) };
+}
+
+function skillGateProviderOf(result: SkillGateResult): ISkillGateProvider {
+  return { check: () => result };
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +198,29 @@ describe('ToolRegistry — disabled tools', () => {
     const registry = new ToolRegistry([tool], logger, (p) => p, provider);
     provider.disabledTools = new Set(['echo']);
     expect(registry.wireTools).toHaveLength(0);
+  });
+});
+
+describe('ToolRegistry — skill gate', () => {
+  it('resolve returns rejected naming the missing skill when the gate blocks the tool', () => {
+    const tool = makeTool('echo', async (input) => input.value);
+    const registry = new ToolRegistry([tool], logger, (p) => p, disabledToolsProviderOf([]), skillGateProviderOf({ allowed: false, missing: ['pr'] }));
+    const resolved = registry.resolve('echo', { value: 'hi' });
+    expect(resolved).toEqual({ kind: 'rejected', reason: 'This tool requires loading the following skill(s) first via the Skill tool: pr' });
+  });
+
+  it('resolve still returns ready when the gate allows the tool', () => {
+    const tool = makeTool('echo', async (input) => input.value);
+    const registry = new ToolRegistry([tool], logger, (p) => p, disabledToolsProviderOf([]), skillGateProviderOf({ allowed: true }));
+    const resolved = registry.resolve('echo', { value: 'hi' });
+    expect(resolved.kind).toBe('ready');
+  });
+
+  it('defaults to allowing every tool when no gate is supplied', () => {
+    const tool = makeTool('echo', async (input) => input.value);
+    const registry = new ToolRegistry([tool], logger);
+    const resolved = registry.resolve('echo', { value: 'hi' });
+    expect(resolved.kind).toBe('ready');
   });
 });
 

--- a/schema/sdk-config.schema.json
+++ b/schema/sdk-config.schema.json
@@ -548,6 +548,20 @@
         "type": "string"
       }
     },
+    "requiredSkills": {
+      "default": {},
+      "description": "Tool name to the skill name(s) that must have been successfully loaded via the Skill tool earlier in this conversation before that tool may be called. A tool absent from this map is unrestricted. Read live: takes effect on the very next tool_use without a restart.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
     "statusBar": {
       "default": {
         "showConversationId": true


### PR DESCRIPTION
## Summary
- A tool can now be configured to require a named Skill to have loaded earlier in the conversation before it's callable.
- The requirement is checked live, so a config change or a fresh Skill load takes effect on the next call, no restart needed.
- The check survives a CLI restart, since it reads the same replayed conversation history.
- A blocked call is rejected with the name of the missing skill, so the model can load it and retry.