### PR TITLE
Fix dropped tool_results when cancelling a multi-tool approval batch

### DIFF
--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -67,12 +67,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Carry structured API error detail (status, type, message) to consumers, not only the status
 - Clock stamp now leads the user's message in history instead of trailing every request
 - defineTool validates a tool's name against Anthropic's required pattern (letters, digits, underscore, hyphen; 1-128 characters) at definition time instead of surfacing as an API error on first use
+- Fix a cancel during a multi-tool approval batch dropping tool_results for tools still awaiting approval, including the case where the cancel lands before any approval request for the batch was even made
 - Fix a concurrent tool batch abandoning every still-running tool when one tool's run closure threw, instead of resolving that one tool as failed
 - Fix a retried turn stacking a duplicate clock stamp onto the resent message instead of replacing the stale one from the discarded attempt
 - Fix context window size for Opus 4.6, Opus 4.7, and Sonnet 4.6 (200k to 1M)
 - Fix context window size for Sonnet 4 (200k to 1M)
 - Fix the clock stamp landing before a tool_result or reminder instead of the user's message
 - Fix version metadata
+- Generalise the dangling tool_use self-heal to cover a partially-answered multi-tool batch, prepending the synthetic result so it still leads the reply as the API requires
 - Keep CLAUDE.md context present in every request after compaction (it previously dropped out)
 - Package now publishes CJS alongside ESM with working sourcemaps
 - Preserve redacted_thinking blocks in conversation history

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -60,3 +60,5 @@
 {"description":"Fix the clock stamp landing before a tool_result or reminder instead of the user's message","category":"fixed"}
 {"description":"Fix version metadata","category":"fixed"}
 {"description":"Depend on @shellicar/core-di instead of @shellicar/core-di-lite","category":"changed"}
+{"description":"Fix a cancel during a multi-tool approval batch dropping tool_results for tools still awaiting approval, including the case where the cancel lands before any approval request for the batch was even made","category":"fixed"}
+{"description":"Generalise the dangling tool_use self-heal to cover a partially-answered multi-tool batch, prepending the synthetic result so it still leads the reply as the API requires","category":"fixed"}

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -145,26 +145,55 @@ export class Conversation extends IConversation {
   }
 
   /**
-   * Self-heal a tip left on a dangling tool_use: a prior process died after committing the
-   * assistant's tool_use blocks but before their tool_result (crash, kill signal, hung tool).
-   * The API rejects any request whose history ends on an unanswered tool_use, so an honest
-   * synthetic result is appended for each one — never a claim about what the tool did, only
-   * that it never got an answer. Uses `push`, so a real user message pushed right after merges
-   * into the same row rather than sitting as its own leading message.
-   * Returns `true` if a heal was applied.
+   * Self-heal any tool_use left without a matching tool_result: a prior process died after
+   * committing the assistant's tool_use blocks but before all their tool_results (crash, kill
+   * signal, hung tool), or a batch was cut short mid-approval. The API rejects any request
+   * whose history contains a tool_use with no matching tool_result anywhere after it, so an
+   * honest synthetic result is appended for each still-missing id — never a claim about what
+   * the tool did, only that it never got an answer.
+   *
+   * Two shapes, both anchored on the last assistant message with tool_use blocks:
+   * - it is the tip itself (no reply landed at all), or
+   * - it is followed by exactly one user message that already answers some but not all of
+   *   its tool_use ids (a partially-drained cancelled batch).
+   * Anything else (a fully-answered batch, or no tool_use at all) needs no heal.
+   *
+   * Uses `push`, so a real user message pushed right after merges into the same row rather
+   * than sitting as its own leading message. Returns `true` if a heal was applied.
    */
   public healDanglingToolUse(): boolean {
     const last = this.#items.at(-1);
-    if (last?.msg.role !== 'assistant' || !Array.isArray(last.msg.content)) {
+    if (last == null) {
       return false;
     }
-    const toolUseIds = last.msg.content.filter((b) => b.type === 'tool_use').map((b) => b.id);
-    if (toolUseIds.length === 0) {
+    if (last.msg.role === 'assistant') {
+      return this.#healMissingToolResults(last, []);
+    }
+    if (last.msg.role === 'user') {
+      const prev = this.#items.at(-2);
+      if (prev?.msg.role === 'assistant') {
+        const covered = Array.isArray(last.msg.content) ? last.msg.content.filter((b) => b.type === 'tool_result').map((b) => b.tool_use_id) : [];
+        return this.#healMissingToolResults(prev, covered);
+      }
+    }
+    return false;
+  }
+
+  /** Append a synthetic tool_result for every tool_use id on `assistantItem` not already in `coveredIds`. */
+  #healMissingToolResults(assistantItem: HistoryItem, coveredIds: string[]): boolean {
+    if (!Array.isArray(assistantItem.msg.content)) {
+      return false;
+    }
+    const missingIds = assistantItem.msg.content
+      .filter((b): b is Extract<typeof b, { type: 'tool_use' }> => b.type === 'tool_use')
+      .map((b) => b.id)
+      .filter((id) => !coveredIds.includes(id));
+    if (missingIds.length === 0) {
       return false;
     }
     this.push({
       role: 'user',
-      content: toolUseIds.map((id) => ({
+      content: missingIds.map((id) => ({
         type: 'tool_result' as const,
         tool_use_id: id,
         is_error: true,

--- a/packages/claude-sdk/src/private/Conversation.ts
+++ b/packages/claude-sdk/src/private/Conversation.ts
@@ -147,10 +147,10 @@ export class Conversation extends IConversation {
   /**
    * Self-heal any tool_use left without a matching tool_result: a prior process died after
    * committing the assistant's tool_use blocks but before all their tool_results (crash, kill
-   * signal, hung tool), or a batch was cut short mid-approval. The API rejects any request
-   * whose history contains a tool_use with no matching tool_result anywhere after it, so an
-   * honest synthetic result is appended for each still-missing id — never a claim about what
-   * the tool did, only that it never got an answer.
+   * signal, hung tool), or a batch was cut short mid-approval. The API requires every tool_use
+   * in an assistant message to be answered by a tool_result in the very next user message, so an
+   * honest synthetic result is added for each still-missing id — never a claim about what the
+   * tool did, only that it never got an answer.
    *
    * Two shapes, both anchored on the last assistant message with tool_use blocks:
    * - it is the tip itself (no reply landed at all), or
@@ -158,8 +158,10 @@ export class Conversation extends IConversation {
    *   its tool_use ids (a partially-drained cancelled batch).
    * Anything else (a fully-answered batch, or no tool_use at all) needs no heal.
    *
-   * Uses `push`, so a real user message pushed right after merges into the same row rather
-   * than sitting as its own leading message. Returns `true` if a heal was applied.
+   * The synthetic blocks are prepended, never appended: the API requires every tool_result to
+   * lead the user message it's part of, and the existing reply may carry other content after its
+   * tool_results (a merged typed message, a clock-stamp reminder) that an append would land after.
+   * Returns `true` if a heal was applied.
    */
   public healDanglingToolUse(): boolean {
     const last = this.#items.at(-1);
@@ -167,23 +169,25 @@ export class Conversation extends IConversation {
       return false;
     }
     if (last.msg.role === 'assistant') {
-      return this.#healMissingToolResults(last, []);
+      return this.#healMissingToolResults(last, undefined);
     }
     if (last.msg.role === 'user') {
       const prev = this.#items.at(-2);
       if (prev?.msg.role === 'assistant') {
-        const covered = Array.isArray(last.msg.content) ? last.msg.content.filter((b) => b.type === 'tool_result').map((b) => b.tool_use_id) : [];
-        return this.#healMissingToolResults(prev, covered);
+        return this.#healMissingToolResults(prev, last);
       }
     }
     return false;
   }
 
-  /** Append a synthetic tool_result for every tool_use id on `assistantItem` not already in `coveredIds`. */
-  #healMissingToolResults(assistantItem: HistoryItem, coveredIds: string[]): boolean {
+  /** Prepend a synthetic tool_result for every tool_use id on `assistantItem` not already answered
+   *  in `replyItem` (or append a brand-new reply row when there is none). */
+  #healMissingToolResults(assistantItem: HistoryItem, replyItem: HistoryItem | undefined): boolean {
     if (!Array.isArray(assistantItem.msg.content)) {
       return false;
     }
+    const existingContent = replyItem != null && Array.isArray(replyItem.msg.content) ? replyItem.msg.content : [];
+    const coveredIds = existingContent.filter((b): b is Extract<(typeof existingContent)[number], { type: 'tool_result' }> => b.type === 'tool_result').map((b) => b.tool_use_id);
     const missingIds = assistantItem.msg.content
       .filter((b): b is Extract<typeof b, { type: 'tool_use' }> => b.type === 'tool_use')
       .map((b) => b.id)
@@ -191,15 +195,17 @@ export class Conversation extends IConversation {
     if (missingIds.length === 0) {
       return false;
     }
-    this.push({
-      role: 'user',
-      content: missingIds.map((id) => ({
-        type: 'tool_result' as const,
-        tool_use_id: id,
-        is_error: true,
-        content: [{ type: 'text' as const, text: 'Abandoned: the CLI was restarted or crashed before this tool completed. The outcome is unknown.' }],
-      })),
-    });
+    const synthetic = missingIds.map((id) => ({
+      type: 'tool_result' as const,
+      tool_use_id: id,
+      is_error: true,
+      content: [{ type: 'text' as const, text: 'Abandoned: the CLI was restarted or crashed before this tool completed. The outcome is unknown.' }],
+    }));
+    if (replyItem == null) {
+      this.push({ role: 'user', content: synthetic });
+    } else {
+      replyItem.msg = { ...replyItem.msg, content: [...synthetic, ...existingContent] };
+    }
     return true;
   }
 }

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -276,61 +276,69 @@ export class QueryRunner extends IQueryRunner {
 
     // Phase 2: execute the ready list.
     if (requireApproval) {
-      const pending = ready.map(({ toolUse, run }) => {
-        // The consumer addresses each streaming tool by its tool_use id and relinks
-        // the approval to that object by requestId. Use the tool_use id as the requestId
-        // so the relink succeeds (ids are unique within a batch; the id round-trips
-        // through tool_approval_response unchanged).
-        const requestId = toolUse.id;
-        return {
-          toolUse,
-          run,
-          promise: this.approval.request(requestId, () => {
-            this.publisher.send({ type: 'tool_approval_request', requestId, name: toolUse.name, input: toolUse.input } satisfies SdkMessage);
-          }),
-        };
-      });
+      // A cancel that lands before any approval is requested has already resolved and cleared the
+      // coordinator's pending map (ApprovalCoordinator.handle only resolves whatever is pending *at
+      // that moment*). Requesting approval now would register fresh promises the coordinator has no
+      // reason to ever settle, so every ready tool is short-circuited straight to a cancelled
+      // tool_result instead of entering the approval wait and hanging on Promise.race forever.
+      if (this.approval.cancelled) {
+        for (const { toolUse } of ready) {
+          toolResults.push(this.#emitApprovalRejection(toolUse, 'cancelled'));
+        }
+      } else {
+        const pending = ready.map(({ toolUse, run }) => {
+          // The consumer addresses each streaming tool by its tool_use id and relinks
+          // the approval to that object by requestId. Use the tool_use id as the requestId
+          // so the relink succeeds (ids are unique within a batch; the id round-trips
+          // through tool_approval_response unchanged).
+          const requestId = toolUse.id;
+          return {
+            toolUse,
+            run,
+            promise: this.approval.request(requestId, () => {
+              this.publisher.send({ type: 'tool_approval_request', requestId, name: toolUse.name, input: toolUse.input } satisfies SdkMessage);
+            }),
+          };
+        });
 
-      // Approved runs are started immediately and collected here; they are never awaited one
-      // at a time, so an early approval's tool does not block a later approval from starting.
-      const running: Promise<ToolResultBlock>[] = [];
-      // `toolRunStarted` registers the batch's one shared `toolController` and resets the coordinator's
-      // cancel-escalation state for it. That reset must happen exactly once per batch, not once per
-      // approved tool: since every tool in the batch shares the same controller, calling it again for
-      // a later approval while an earlier tool is still running would clear `#toolCancelled` on an
-      // already-cancelled controller, silently downgrading what should be a second (escalating) cancel
-      // back into a no-op abort of a dead controller. `batchStarted` guards against that.
-      let batchStarted = false;
+        // Approved runs are started immediately and collected here; they are never awaited one
+        // at a time, so an early approval's tool does not block a later approval from starting.
+        const running: Promise<ToolResultBlock>[] = [];
+        // `toolRunStarted` registers the batch's one shared `toolController` and resets the coordinator's
+        // cancel-escalation state for it. That reset must happen exactly once per batch, not once per
+        // approved tool: since every tool in the batch shares the same controller, calling it again for
+        // a later approval while an earlier tool is still running would clear `#toolCancelled` on an
+        // already-cancelled controller, silently downgrading what should be a second (escalating) cancel
+        // back into a no-op abort of a dead controller. `batchStarted` guards against that.
+        let batchStarted = false;
 
-      // Every pending approval that is still resolved with 'cancelled' after a query-cancel
-      // (ApprovalCoordinator.handle resolves them all at once) is drained here rather than
-      // abandoned: each iteration races whatever has already settled, so a cancel with several
-      // tools still awaiting approval converts every one of them into a tool_result, not just
-      // whichever happened to win the race first.
-      while (pending.length > 0) {
-        const { toolUse, run, response, index } = await Promise.race(pending.map((item, idx) => item.promise.then((response) => ({ toolUse: item.toolUse, run: item.run, response, index: idx }))));
-        pending.splice(index, 1);
+        // Every pending approval that is still resolved with 'cancelled' after a query-cancel
+        // (ApprovalCoordinator.handle resolves them all at once) is drained here rather than
+        // abandoned: each iteration races whatever has already settled, so a cancel with several
+        // tools still awaiting approval converts every one of them into a tool_result, not just
+        // whichever happened to win the race first.
+        while (pending.length > 0) {
+          const { toolUse, run, response, index } = await Promise.race(pending.map((item, idx) => item.promise.then((response) => ({ toolUse: item.toolUse, run: item.run, response, index: idx }))));
+          pending.splice(index, 1);
 
-        if (!response.approved) {
-          const content = response.reason ?? 'Rejected by user, do not reattempt';
-          this.logger.debug('tool_rejected', { name: toolUse.name, reason: content });
-          this.publisher.send({ type: 'tool_result', id: toolUse.id, content, isError: true, cancelled: false });
-          toolResults.push({ type: 'tool_result', tool_use_id: toolUse.id, is_error: true, content: [{ type: 'text' as const, text: content }] });
-          continue;
+          if (!response.approved) {
+            toolResults.push(this.#emitApprovalRejection(toolUse, response.reason));
+            continue;
+          }
+
+          if (!batchStarted) {
+            this.approval.toolRunStarted(toolController);
+            batchStarted = true;
+          }
+          running.push(run(transformToolResult));
         }
 
-        if (!batchStarted) {
-          this.approval.toolRunStarted(toolController);
-          batchStarted = true;
-        }
-        running.push(run(transformToolResult));
-      }
-
-      if (running.length > 0) {
-        try {
-          toolResults.push(...(await Promise.all(running)));
-        } finally {
-          this.approval.toolRunFinished();
+        if (running.length > 0) {
+          try {
+            toolResults.push(...(await Promise.all(running)));
+          } finally {
+            this.approval.toolRunFinished();
+          }
         }
       }
     } else if (!this.approval.cancelled && ready.length > 0) {
@@ -342,6 +350,19 @@ export class QueryRunner extends IQueryRunner {
       }
     }
     return toolResults;
+  }
+
+  /** Map an approval-phase rejection to its channel event and tool_result block. Two callers: a real
+   * user rejection (`reason` is whatever the consumer sent), and an already-cancelled query short-
+   * circuiting a tool that was never even offered for approval (`reason === 'cancelled'`, the
+   * coordinator's own marker, not a human's words) — which gets the richer cancelled wording and
+   * `cancelled: true` instead of being echoed back to the model verbatim. */
+  #emitApprovalRejection(toolUse: ToolUseResult, reason: string | undefined): ToolResultBlock {
+    const cancelled = reason === 'cancelled';
+    const content = cancelled ? 'Tool execution cancelled by user before it could run' : (reason ?? 'Rejected by user, do not reattempt');
+    this.logger.debug(cancelled ? 'tool_cancelled' : 'tool_rejected', { name: toolUse.name, reason: content });
+    this.publisher.send({ type: 'tool_result', id: toolUse.id, content, isError: true, cancelled });
+    return { type: 'tool_result', tool_use_id: toolUse.id, is_error: true, content: [{ type: 'text' as const, text: content }] };
   }
 
   /** Map a tool outcome to its channel events and the tool_result block. The one place an

--- a/packages/claude-sdk/src/private/QueryRunner.ts
+++ b/packages/claude-sdk/src/private/QueryRunner.ts
@@ -302,10 +302,12 @@ export class QueryRunner extends IQueryRunner {
       // back into a no-op abort of a dead controller. `batchStarted` guards against that.
       let batchStarted = false;
 
+      // Every pending approval that is still resolved with 'cancelled' after a query-cancel
+      // (ApprovalCoordinator.handle resolves them all at once) is drained here rather than
+      // abandoned: each iteration races whatever has already settled, so a cancel with several
+      // tools still awaiting approval converts every one of them into a tool_result, not just
+      // whichever happened to win the race first.
       while (pending.length > 0) {
-        if (this.approval.cancelled) {
-          break;
-        }
         const { toolUse, run, response, index } = await Promise.race(pending.map((item, idx) => item.promise.then((response) => ({ toolUse: item.toolUse, run: item.run, response, index: idx }))));
         pending.splice(index, 1);
 

--- a/packages/claude-sdk/test/Conversation.spec.ts
+++ b/packages/claude-sdk/test/Conversation.spec.ts
@@ -369,6 +369,51 @@ describe('Conversation.healDanglingToolUse', () => {
     expect(actual).toBe(expected);
   });
 
+  it('returns true when the tip partially answers a multi-tool batch', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1', 'toolu_2'));
+    c.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }] });
+    const expected = true;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
+  it('heals only the tool_use id missing from a partial reply', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1', 'toolu_2'));
+    c.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }] });
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { tool_use_id: string }[];
+    const expected = ['toolu_1', 'toolu_2'];
+    const actual = content.map((b) => b.tool_use_id);
+    expect(actual).toEqual(expected);
+  });
+
+  it('merges the healed result into the same row as the partial reply, not a new row', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1', 'toolu_2'));
+    c.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }] });
+    c.healDanglingToolUse();
+    const expected = 2;
+    const actual = c.messages.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not heal when the reply already answers every tool_use id in the batch', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1', 'toolu_2'));
+    c.push({
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' },
+        { type: 'tool_result', tool_use_id: 'toolu_2', content: 'ok' },
+      ],
+    });
+    const expected = false;
+    const actual = c.healDanglingToolUse();
+    expect(actual).toBe(expected);
+  });
+
   it('a real user message pushed after the heal merges into the same row', () => {
     const c = new Conversation();
     c.push(toolUseMsg('toolu_1'));

--- a/packages/claude-sdk/test/Conversation.spec.ts
+++ b/packages/claude-sdk/test/Conversation.spec.ts
@@ -378,15 +378,37 @@ describe('Conversation.healDanglingToolUse', () => {
     expect(actual).toBe(expected);
   });
 
-  it('heals only the tool_use id missing from a partial reply', () => {
+  it('prepends the missing tool_result ahead of the partial reply, not after it', () => {
     const c = new Conversation();
     c.push(toolUseMsg('toolu_1', 'toolu_2'));
     c.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }] });
     c.healDanglingToolUse();
     const content = c.messages.at(-1)?.content as { tool_use_id: string }[];
-    const expected = ['toolu_1', 'toolu_2'];
+    const expected = ['toolu_2', 'toolu_1'];
     const actual = content.map((b) => b.tool_use_id);
     expect(actual).toEqual(expected);
+  });
+
+  it('prepends the missing tool_result ahead of a reply that also carries typed text', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.push({ role: 'user', content: [{ type: 'text', text: 'a fresh message merged onto the same tip' }] });
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { type: string }[];
+    const expected = 'tool_result';
+    const actual = content[0]?.type;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not drop the typed text when prepending a missing tool_result', () => {
+    const c = new Conversation();
+    c.push(toolUseMsg('toolu_1'));
+    c.push({ role: 'user', content: [{ type: 'text', text: 'a fresh message merged onto the same tip' }] });
+    c.healDanglingToolUse();
+    const content = c.messages.at(-1)?.content as { type: string; text?: string }[];
+    const expected = 'a fresh message merged onto the same tip';
+    const actual = content.at(-1)?.text;
+    expect(actual).toBe(expected);
   });
 
   it('merges the healed result into the same row as the partial reply, not a new row', () => {

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -893,6 +893,70 @@ describe('QueryRunner — concurrent tool execution', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cancel while several approvals are still pending (regression).
+//
+// ApprovalCoordinator.handle resolves every pending approval at once on a query-cancel, but
+// the dispatch loop only converts whichever one Promise.race happens to pick up first into a
+// tool_result before re-checking `approval.cancelled` and bailing out — abandoning the rest
+// with no tool_result at all, even though their promises had already settled.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — cancel while several approvals are pending (regression)', () => {
+  it('covers every pending tool_use id when cancelled before any approval is answered', async () => {
+    const a = makeTool('a', async (input) => `got: ${input.value}`);
+    const b = makeTool('b', async (input) => `got: ${input.value}`);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+      ],
+      [a, b],
+      { requireToolApproval: true },
+    );
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    w.approval.handle({ type: 'cancel' });
+    await runPromise;
+
+    const last = w.conversation.messages.at(-1);
+    const content = Array.isArray(last?.content) ? last.content : [];
+    const expected = ['tu_1', 'tu_2'];
+    const actual = content.filter((block): block is ToolResultBlock => typeof block === 'object' && 'type' in block && block.type === 'tool_result').map((block) => block.tool_use_id).sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('marks every drained tool_result as an error', async () => {
+    const a = makeTool('a', async (input) => `got: ${input.value}`);
+    const b = makeTool('b', async (input) => `got: ${input.value}`);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+      ],
+      [a, b],
+      { requireToolApproval: true },
+    );
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    w.approval.handle({ type: 'cancel' });
+    await runPromise;
+
+    const last = w.conversation.messages.at(-1);
+    const content = Array.isArray(last?.content) ? last.content : [];
+    const results = content.filter((block): block is ToolResultBlock => typeof block === 'object' && 'type' in block && block.type === 'tool_result');
+    const expected = [true, true];
+    const actual = results.map((r) => r.is_error);
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cancel escalation across concurrent approvals (regression).
 //
 // A second cancel is supposed to escalate to a full query-cancel once a tool is already

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -924,7 +924,10 @@ describe('QueryRunner — cancel while several approvals are pending (regression
     const last = w.conversation.messages.at(-1);
     const content = Array.isArray(last?.content) ? last.content : [];
     const expected = ['tu_1', 'tu_2'];
-    const actual = content.filter((block): block is ToolResultBlock => typeof block === 'object' && 'type' in block && block.type === 'tool_result').map((block) => block.tool_use_id).sort();
+    const actual = content
+      .filter((block): block is ToolResultBlock => typeof block === 'object' && 'type' in block && block.type === 'tool_result')
+      .map((block) => block.tool_use_id)
+      .sort();
     expect(actual).toEqual(expected);
   });
 

--- a/packages/claude-sdk/test/QueryRunner.spec.ts
+++ b/packages/claude-sdk/test/QueryRunner.spec.ts
@@ -957,6 +957,123 @@ describe('QueryRunner — cancel while several approvals are pending (regression
     const actual = results.map((r) => r.is_error);
     expect(actual).toEqual(expected);
   });
+
+  it('marks the drained cancel events with cancelled: true on the channel, not a raw rejection', async () => {
+    const a = makeTool('a', async (input) => `got: ${input.value}`);
+    const b = makeTool('b', async (input) => `got: ${input.value}`);
+    const w = makeWiring(
+      [
+        multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]),
+      ],
+      [a, b],
+      { requireToolApproval: true },
+    );
+
+    const runPromise = w.queryRunner.run(makeInput());
+    await new Promise((resolve) => setImmediate(resolve));
+    w.approval.handle({ type: 'cancel' });
+    await runPromise;
+
+    const events = w.channel.messages.filter((m): m is Extract<SdkMessage, { type: 'tool_result' }> => m.type === 'tool_result');
+    const expected = [true, true];
+    const actual = events.map((e) => e.cancelled);
+    expect(actual).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancel already settled before any approval request for the batch was created
+// (regression). A query-cancel resolves and clears the coordinator's whole
+// pending map at the moment it fires (ApprovalCoordinator.handle). If the cancel
+// lands in the gap between the assistant turn resolving and this batch's own
+// approval requests being built, those requests are registered *after* the
+// coordinator already cleared everything — nothing will ever resolve them, and
+// naively awaiting Promise.race on them would hang forever.
+// ---------------------------------------------------------------------------
+
+describe('QueryRunner — cancel already settled before approval requests are created (regression)', () => {
+  it('completes without hanging and covers every tool_use id with a cancelled tool_result', async () => {
+    const approval = new ApprovalCoordinator();
+    const conversation = new Conversation();
+    const channel = new FakeSdkPublisher();
+    const durableProvider = new FakeDurableConfigProvider(makeDurable({ requireToolApproval: true }));
+    const registry = new ToolRegistry([makeTool('a', async (input) => `got: ${input.value}`), makeTool('b', async (input) => `got: ${input.value}`)], new NoopLogger());
+
+    // Stands in for ITurnRunner: pushes the assistant tool_use turn itself (mirroring the real
+    // TurnRunner's contract), then fires the cancel — simulating it landing in the gap before
+    // #runTools has built any approval request for this batch.
+    class CancelBeforeDispatchTurnRunner extends ITurnRunner {
+      #used = false;
+      public async run(conv: Conversation): Promise<MessageStreamResult> {
+        if (this.#used) {
+          throw new Error('scripted for a single call only');
+        }
+        this.#used = true;
+        const result = multiToolUseResult([
+          { id: 'tu_1', name: 'a', input: { value: 'x' } },
+          { id: 'tu_2', name: 'b', input: { value: 'y' } },
+        ]);
+        conv.push({ role: 'assistant', content: result.blocks.map(toParam) });
+        approval.handle({ type: 'cancel' });
+        return result;
+      }
+    }
+
+    const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
+    services
+      .register(ITurnRunner)
+      .using(() => new CancelBeforeDispatchTurnRunner())
+      .asSelf();
+    services
+      .register(Conversation)
+      .using(() => conversation)
+      .asSelf()
+      .as(IConversation);
+    services
+      .register(IToolRegistry)
+      .using(() => registry)
+      .asSelf();
+    services
+      .register(ApprovalCoordinator)
+      .using(() => approval)
+      .asSelf();
+    services
+      .register(ISdkMessagePublisher)
+      .using(() => channel)
+      .asSelf();
+    services
+      .register(IDurableConfigProvider)
+      .using(() => durableProvider)
+      .asSelf();
+    services
+      .register(ILogger)
+      .using(() => new NoopLogger())
+      .asSelf();
+    services
+      .register(IToolsClockListener)
+      .using(() => new NoopToolsClock())
+      .asSelf();
+    services
+      .register(IToolBlockNotifier)
+      .using(() => new ToolBlockNotifier([]))
+      .asSelf();
+    services.register(QueryRunner).asSelf();
+    const queryRunner = services.buildProvider().resolve(QueryRunner);
+
+    await queryRunner.run(makeInput());
+
+    const last = conversation.messages.at(-1);
+    const content = Array.isArray(last?.content) ? last.content : [];
+    const expected = ['tu_1', 'tu_2'];
+    const actual = content
+      .filter((block): block is ToolResultBlock => typeof block === 'object' && 'type' in block && block.type === 'tool_result')
+      .map((block) => block.tool_use_id)
+      .sort();
+    expect(actual).toEqual(expected);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Cancelling while several tool calls are awaiting approval no longer drops the ones still pending.
- A cancel that lands before any approval request for a batch is made no longer hangs the query.
- The dangling tool_use self-heal now covers a partially-answered batch.
- A healed synthetic tool_result now leads the reply instead of trailing it.
- A tool cancelled before it started running now reports `cancelled: true` on the channel.