### PR TITLE
Flush sealed conversation blocks to scrollback as they seal

### DIFF
--- a/apps/claude-sdk-cli/src/model/ConversationState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationState.ts
@@ -99,11 +99,16 @@ export class ConversationState extends IConversationState {
     return this.#promptStartedAt;
   }
 
-  /** Push one or more pre-built blocks (e.g. from history replay or startup banner). */
+  /**
+   * Push one or more pre-built blocks (e.g. from history replay or startup banner). Marks them as
+   * already flushed: these are re-displays of past content or boot-time notices, not new turn
+   * content, so they must not be re-written to scrollback.
+   */
   public addBlocks(blocks: ReadonlyArray<Block>): void {
     for (const block of blocks) {
       this.#sealedBlocks.push(block);
     }
+    this.#flushedCount = this.#sealedBlocks.length;
     this.#emitter.emit('change');
   }
 

--- a/apps/claude-sdk-cli/src/model/ConversationState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationState.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'node:events';
 import { Clock, Instant } from '@js-joda/core';
 import { sanitiseLoneSurrogates } from '@shellicar/claude-core/sanitise';
 import { dependsOn } from '@shellicar/core-di';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { ToolEntry } from './ToolObject.js';
 
 type ConversationStateEvents = {
@@ -55,7 +56,7 @@ export abstract class IConversationState {
   public abstract setLastContent(type: BlockType, text: string): void;
   public abstract setLastTools(type: 'tools' | 'execution', content: string, tools: ToolEntry[]): void;
   public abstract completeActive(): void;
-  public abstract appendToLastSealed(type: BlockType, text: string): 'active' | number | 'miss';
+  public abstract appendToLastSealed(type: BlockType, text: string): 'active' | 'miss';
   public abstract advanceFlushedCount(to: number): void;
   public abstract clear(): void;
 }
@@ -63,6 +64,7 @@ export abstract class IConversationState {
 export class ConversationState extends IConversationState {
   #sealedBlocks: Block[] = [];
   #flushedCount = 0;
+  @dependsOn(ILogger) private readonly logger!: ILogger;
   #activeBlock: Block | null = null;
   @dependsOn(Clock) private readonly clock!: Clock;
   #promptStartedAt: Instant | null = null;
@@ -213,10 +215,9 @@ export class ConversationState extends IConversationState {
   }
 
   /**
-   * Replace the content of the most recent block of the given type, checking
-   * the active block first then searching sealed blocks in reverse.
-   * Used by AgentMessageHandler to update tool renders after the tools block
-   * has been sealed (e.g. during the approval phase).
+   * Replace the content of the active block if its type matches. A sealed block is never
+   * modified — once sealed, a block's content is final, so a mismatch (or no active block)
+   * is a no-op, logged as a warning since it means a caller targeted a block that already closed.
    */
   public setLastContent(type: BlockType, text: string): void {
     const sanitised = sanitiseLoneSurrogates(text);
@@ -225,22 +226,14 @@ export class ConversationState extends IConversationState {
       this.#emitter.emit('change');
       return;
     }
-    for (let i = this.#sealedBlocks.length - 1; i >= 0; i--) {
-      if (this.#sealedBlocks[i]?.type === type) {
-        // biome-ignore lint/style/noNonNullAssertion: checked above
-        this.#sealedBlocks[i]!.content = sanitised;
-        this.#emitter.emit('change');
-        return;
-      }
-    }
+    this.logger.warn('setLastContent: no active block of matching type; sealed blocks are never modified', { type });
   }
 
   /**
-   * Set the rendered content and the structured tool entries of the most recent
-   * `tools` block (active first, then sealed in reverse). Mirrors setLastContent's
-   * targeting so results arriving after the block is sealed still update it. The
-   * content string is byte-identical to what setLastContent wrote, so the Primary
-   * view's tools rendering is unchanged; `tools` is additive, read only by history.
+   * Set the rendered content and the structured tool entries of the active `tools`/`execution`
+   * block if its type matches. A sealed block is never modified — a mismatch (or no active
+   * block) is a no-op, logged as a warning since it means a caller targeted a block that
+   * already closed.
    */
   public setLastTools(type: 'tools' | 'execution', content: string, tools: ToolEntry[]): void {
     const sanitised = sanitiseLoneSurrogates(content);
@@ -250,16 +243,7 @@ export class ConversationState extends IConversationState {
       this.#emitter.emit('change');
       return;
     }
-    for (let i = this.#sealedBlocks.length - 1; i >= 0; i--) {
-      if (this.#sealedBlocks[i]?.type === type) {
-        // biome-ignore lint/style/noNonNullAssertion: checked above
-        this.#sealedBlocks[i]!.content = sanitised;
-        // biome-ignore lint/style/noNonNullAssertion: checked above
-        this.#sealedBlocks[i]!.tools = tools;
-        this.#emitter.emit('change');
-        return;
-      }
-    }
+    this.logger.warn('setLastTools: no active block of matching type; sealed blocks are never modified', { type });
   }
 
   /** Seal the active block if it has content, then clear it. */
@@ -273,28 +257,20 @@ export class ConversationState extends IConversationState {
   }
 
   /**
-   * Append text to the most recent block of the given type, checking the active block
-   * first then searching sealed blocks in reverse. Used for retroactive annotations.
+   * Append text to the active block if its type matches. A sealed block is never modified —
+   * once sealed, a block's content is final.
    *
    * Returns:
-   * - `'active'`    — text was appended to the active block
-   * - a number      — text was appended to the sealed block at that index
-   * - `'miss'`      — no matching block found, text was not appended
+   * - `'active'` — text was appended to the active block
+   * - `'miss'`   — no matching active block, text was not appended (logged as a warning)
    */
-  public appendToLastSealed(type: BlockType, text: string): 'active' | number | 'miss' {
+  public appendToLastSealed(type: BlockType, text: string): 'active' | 'miss' {
     if (this.#activeBlock?.type === type) {
       this.#activeBlock.content += text;
       this.#emitter.emit('change');
       return 'active';
     }
-    for (let i = this.#sealedBlocks.length - 1; i >= 0; i--) {
-      if (this.#sealedBlocks[i]?.type === type) {
-        // biome-ignore lint/style/noNonNullAssertion: checked above
-        this.#sealedBlocks[i]!.content += text;
-        this.#emitter.emit('change');
-        return i;
-      }
-    }
+    this.logger.warn('appendToLastSealed: no active block of matching type; sealed blocks are never modified', { type });
     return 'miss';
   }
 

--- a/apps/claude-sdk-cli/src/model/ConversationState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationState.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'node:events';
 import { Clock, Instant } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { sanitiseLoneSurrogates } from '@shellicar/claude-core/sanitise';
 import { dependsOn } from '@shellicar/core-di';
-import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { ToolEntry } from './ToolObject.js';
 
 type ConversationStateEvents = {

--- a/apps/claude-sdk-cli/src/runAgent.ts
+++ b/apps/claude-sdk-cli/src/runAgent.ts
@@ -77,7 +77,7 @@ export type RunAgentStores = {
   primaryViewState: IPrimaryViewState;
 };
 
-export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, stores: RunAgentStores, flushToScroll: () => void, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string, skillDelta?: string | null, cwdDelta?: string | null): Promise<void> {
+export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, stores: RunAgentStores, transformToolResult: TransformToolResult, abortController: AbortController, gitDelta?: string, skillDelta?: string | null, cwdDelta?: string | null): Promise<void> {
   const { conversationState, toolApprovalState, editorState, primaryViewState } = stores;
 
   // On resume there is no new user message: don't open a prompt block.
@@ -87,7 +87,6 @@ export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, s
     conversationState.completeActive();
   }
   primaryViewState.setPhase('streaming');
-  flushToScroll();
 
   // The skill and cwd deltas are persisted-leading (frozen in history, cached); the git delta is
   // ephemeral-trailing (re-added per turn, uncached).
@@ -122,6 +121,5 @@ export async function runAgent(queryRunner: QueryRunner, input: RunAgentInput, s
     toolApprovalState.resetExpanded();
     editorState.reset();
     primaryViewState.setPhase('editor');
-    flushToScroll();
   }
 }

--- a/apps/claude-sdk-cli/src/setup/Application.ts
+++ b/apps/claude-sdk-cli/src/setup/Application.ts
@@ -120,6 +120,7 @@ export class Application extends IApplication {
     this.configChangeCoordinator.wire();
     this.shutdownSequence.wire();
     this.consumerMessageRouter.wire();
+    this.turnCoordinator.wire();
 
     await this.agentBusActivator.activate();
 

--- a/apps/claude-sdk-cli/src/setup/TurnCoordinator.ts
+++ b/apps/claude-sdk-cli/src/setup/TurnCoordinator.ts
@@ -25,6 +25,9 @@ import { SkillCatalogueTracker } from './SkillCatalogueTracker.js';
 
 /** The coordinator's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class ITurnCoordinator {
+  /** Subscribes the scroll flush to conversation changes: any block sealing at any time (not just
+   *  turn boundaries) is written to scrollback. Call once at startup, before any turn runs. */
+  public abstract wire(): void;
   /** Run one turn: git/skill/cwd delta collection, save-before-send, the agent call, save-after,
    *  and query-close bookkeeping. Never throws — a failure is logged and swallowed, matching the
    *  main loop's original contract (one bad turn must not crash the process). */
@@ -85,6 +88,14 @@ export class TurnCoordinator extends ITurnCoordinator {
     this.#currentAbortController?.abort();
   }
 
+  #flushToScroll = (): void => {
+    flushSealedToScroll(this.conversationState, this.terminalState, this.renderer, this.configLoader.config.markdown);
+  };
+
+  public wire(): void {
+    this.conversationState.on('change', this.#flushToScroll);
+  }
+
   #transformToolResult = (toolName: string, output: unknown): unknown => {
     const result = this.appTools.refTransform(toolName, output);
     if (toolName !== 'Ref') {
@@ -129,7 +140,6 @@ export class TurnCoordinator extends ITurnCoordinator {
           editorState: this.editorState,
           primaryViewState: this.primaryViewState,
         },
-        () => flushSealedToScroll(this.conversationState, this.terminalState, this.renderer, this.configLoader.config.markdown),
         this.#transformToolResult,
         abortController,
         gitDelta,

--- a/apps/claude-sdk-cli/src/view/flushSealedToScroll.ts
+++ b/apps/claude-sdk-cli/src/view/flushSealedToScroll.ts
@@ -7,7 +7,8 @@ import type { TerminalRenderer } from './TerminalRenderer.js';
 /**
  * Write any newly sealed blocks to the terminal scrollback so conversation
  * history survives leaving the alt buffer. Replaces AppLayout.#flushToScroll;
- * called at turn boundaries by runAgent.
+ * called on every conversation change (TurnCoordinator.wire), so a block reaches
+ * scrollback the moment it seals rather than batched at turn boundaries.
  */
 export function flushSealedToScroll(state: IConversationState, terminalState: ITerminalState, renderer: TerminalRenderer, markdown?: MarkdownConfig): void {
   const sealedBlocks = state.sealedBlocks;

--- a/apps/claude-sdk-cli/src/view/renderConversation.ts
+++ b/apps/claude-sdk-cli/src/view/renderConversation.ts
@@ -181,9 +181,9 @@ function renderStreamingMarkdown(block: Block, cols: number, indent: string, now
  * discard all but a handful of lines. `content` is passed explicitly (not read off `block.content`)
  * because a tools/execution block's collapsed preview renders its tool-name summary, not the block's
  * own content — a single cache slot per block is safe because a given block only ever renders one of
- * the two (see HistoryView's dispatch to #toolsCard vs #blockCard). Sealed blocks are immutable except
- * appendToLastSealed, which reassigns `content` to a new string, so the content-reference check catches
- * it. Keyed by block identity; the WeakMap drops entries when a block is gc'd (e.g.
+ * the two (see HistoryView's dispatch to #toolsCard vs #blockCard). Sealed blocks are immutable, so the
+ * content-reference check is a cheap identity comparison, not a defence against mutation. Keyed by
+ * block identity; the WeakMap drops entries when a block is gc'd (e.g.
  * ConversationState.clear()). The active streaming block is never cached.
  */
 export function renderBlockContentCached(block: Block, content: string, cols: number, markdown: boolean): string[] {

--- a/apps/claude-sdk-cli/test/AccountLimitNotice.spec.ts
+++ b/apps/claude-sdk-cli/test/AccountLimitNotice.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { AccountLimitNotice } from '../src/model/AccountLimitNotice.js';
@@ -6,6 +7,14 @@ import { ConversationState, IConversationState } from '../src/model/Conversation
 
 const RETRYING = '⏳ Account limit — retrying';
 const STOPPED = '🛑 Account limit — stopped';
+
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
 
 // Fake ConversationState that records the notices spliced into it, so the
 // gating logic can be verified without the real append-only state.
@@ -18,13 +27,18 @@ class RecordingConversationState extends ConversationState {
 }
 
 // AccountLimitNotice injects ConversationState, so build it through a container
-// holding the provided (recording) state.
+// holding the provided (recording) state. ConversationState's own declared
+// dependencies (Clock, ILogger) still need registrations for the container's
+// dependency plan, even though this factory supplies a pre-built instance.
 function buildAccountLimitNotice(conversation: ConversationState): AccountLimitNotice {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
-  // ConversationState @dependsOn(Clock); buildProvider injects it eagerly.
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services
     .register(ConversationState)

--- a/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/AgentMessageHandler.spec.ts
@@ -99,12 +99,16 @@ class FakeDurableConfigProvider extends IDurableConfigProvider {
   }
 }
 
-// ConversationState injects Clock; build it through a container.
+// ConversationState injects Clock and ILogger; build it through a container.
 function buildConversationState(): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => logger)
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);

--- a/apps/claude-sdk-cli/test/Application.spec.ts
+++ b/apps/claude-sdk-cli/test/Application.spec.ts
@@ -146,7 +146,7 @@ function buildApplication(drain: DrainWire, overrides: ApplicationOverrides = {}
     .asSelf();
   services
     .register(ITurnCoordinator)
-    .using(() => ({ runTurn: async () => {} }) as unknown as ITurnCoordinator)
+    .using(() => ({ wire: () => {}, runTurn: async () => {} }) as unknown as ITurnCoordinator)
     .asSelf();
   services
     .register(IConfigChangeCoordinator)

--- a/apps/claude-sdk-cli/test/ConversationState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationState.spec.ts
@@ -619,7 +619,7 @@ describe('ConversationState — setLastTools', () => {
     expect(actual).toBe(expected);
   });
 
-  it('does not modify the sealed block\'s entries', () => {
+  it("does not modify the sealed block's entries", () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
     state.appendToActive('tool content');

--- a/apps/claude-sdk-cli/test/ConversationState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationState.spec.ts
@@ -1,15 +1,28 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 
-// ConversationState injects Clock; build it through a container wrapping the
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// ConversationState injects Clock and ILogger; build it through a container wrapping the
 // supplied clock (defaulting to a fixed clock).
 function buildConversationState(clock: Clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC)): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => clock)
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);
@@ -371,24 +384,24 @@ describe('ConversationState — appendToLastSealed', () => {
     expect(actual).toBe(expected);
   });
 
-  it('returns the sealed block index when found in sealed blocks', () => {
+  it('returns "miss" when the matching block has already been sealed', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
     state.appendToActive('tool content');
-    state.transitionBlock('response'); // seals tools block at index 0
+    state.transitionBlock('response'); // seals the tools block at index 0
     const result = state.appendToLastSealed('tools', ' annotation');
-    const expected = 0;
+    const expected = 'miss';
     const actual = result;
     expect(actual).toBe(expected);
   });
 
-  it('content is updated on the sealed block', () => {
+  it('does not modify the sealed block', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
     state.appendToActive('tool content');
     state.transitionBlock('response');
     state.appendToLastSealed('tools', ' annotation');
-    const expected = 'tool content annotation';
+    const expected = 'tool content';
     const actual = state.sealedBlocks[0]?.content;
     expect(actual).toBe(expected);
   });
@@ -401,7 +414,7 @@ describe('ConversationState — appendToLastSealed', () => {
     expect(actual).toBe(expected);
   });
 
-  it('finds the most recent sealed block when multiple exist', () => {
+  it('does not modify a sealed block even when it is the most recent of its type', () => {
     const state = buildConversationState();
     state.addBlocks([
       { type: 'tools', content: 'first' },
@@ -409,8 +422,7 @@ describe('ConversationState — appendToLastSealed', () => {
       { type: 'tools', content: 'second' },
     ]);
     state.appendToLastSealed('tools', ' extra');
-    // Most recent tools block is index 2
-    const expected = 'second extra';
+    const expected = 'second';
     const actual = state.sealedBlocks[2]?.content;
     expect(actual).toBe(expected);
   });
@@ -595,26 +607,26 @@ describe('ConversationState — setLastTools', () => {
     expect(actual).toBe(expected);
   });
 
-  it('targets the most recent sealed tools block after it has been sealed', () => {
+  it('does not modify a sealed tools block after it has been sealed', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
     state.appendToActive('tool content');
     state.transitionBlock('response'); // seals the tools block at index 0
     state.appendToActive('reply');
     state.setLastTools('tools', 'updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
-    const expected = 'updated';
+    const expected = 'tool content';
     const actual = state.sealedBlocks[0]?.content;
     expect(actual).toBe(expected);
   });
 
-  it('stores the entries on the sealed tools block', () => {
+  it('does not modify the sealed block\'s entries', () => {
     const state = buildConversationState();
     state.transitionBlock('tools');
     state.appendToActive('tool content');
     state.transitionBlock('response');
     state.setLastTools('tools', 'updated', [{ name: 'Exec', kind: 'client', input: { cmd: 'ls' }, output: 'out', phase: 'done' }]);
-    const expected = 'Exec';
-    const actual = state.sealedBlocks[0]?.tools?.[0]?.name;
+    const expected = undefined;
+    const actual = state.sealedBlocks[0]?.tools;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/HistoryNavHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryNavHandler.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { HistoryNavHandler } from '../src/controller/HistoryNavHandler.js';
@@ -6,12 +7,27 @@ import { ConversationState, IConversationState } from '../src/model/Conversation
 import { HistoryViewState, IHistoryViewState } from '../src/model/HistoryViewState.js';
 import { ITerminalState, TerminalState } from '../src/model/TerminalState.js';
 
-// HistoryNavHandler injects HistoryViewState/ConversationState/TerminalState; build it through a container.
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// HistoryNavHandler injects HistoryViewState/ConversationState/TerminalState; build it through a
+// container. ConversationState's own declared dependencies (Clock, ILogger) still need
+// registrations for the container's dependency plan, even though this factory supplies a
+// pre-built instance.
 function buildHistoryNavHandler(state: HistoryViewState, conversation: ConversationState, terminal: TerminalState): HistoryNavHandler {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services
     .register(HistoryViewState)

--- a/apps/claude-sdk-cli/test/PermissionsNoticeGate.spec.ts
+++ b/apps/claude-sdk-cli/test/PermissionsNoticeGate.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import type { PermissionsConfigInput } from '../src/cli-config/formatPermissionsDisplay.js';
@@ -6,12 +7,24 @@ import { ConversationState, IConversationState } from '../src/model/Conversation
 import { PermissionsNoticeGate } from '../src/model/PermissionsNoticeGate.js';
 import { renderConversation } from '../src/view/renderConversation.js';
 
-// ConversationState injects Clock; build it through a container.
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// ConversationState injects Clock and ILogger; build it through a container.
 function buildConversationState(): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { AppModeState } from '../src/model/AppModeState.js';
@@ -17,11 +18,23 @@ import { TurnClock } from '../src/model/TurnClock.js';
 import { PrimaryView } from '../src/view/PrimaryView.js';
 import type { ViewModel } from '../src/view/View.js';
 
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
 function makeConversationState(clock: Clock): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => clock)
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);

--- a/apps/claude-sdk-cli/test/StoreEmissions.spec.ts
+++ b/apps/claude-sdk-cli/test/StoreEmissions.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import type { SdkMessageUsage } from '@shellicar/claude-sdk';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
@@ -8,12 +9,24 @@ import { EditorState } from '../src/model/EditorState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { ToolApprovalState } from '../src/model/ToolApprovalState.js';
 
-// ConversationState injects Clock; build it through a container.
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// ConversationState injects Clock and ILogger; build it through a container.
 function buildConversationState(): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);

--- a/apps/claude-sdk-cli/test/StreamInterruptNotice.spec.ts
+++ b/apps/claude-sdk-cli/test/StreamInterruptNotice.spec.ts
@@ -1,17 +1,30 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { StreamInterruptNotice } from '../src/model/StreamInterruptNotice.js';
 import type { ToolEntry } from '../src/model/ToolObject.js';
 
-// StreamInterruptNotice injects ConversationState (which injects Clock); build the
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// StreamInterruptNotice injects ConversationState (which injects Clock and ILogger); build the
 // whole graph through a container so the real seal/splice behaviour is exercised.
 function build(): { notice: StreamInterruptNotice; conversation: ConversationState } {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   services.register(StreamInterruptNotice).asSelf();

--- a/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { ViewSelectHandler } from '../src/controller/ViewSelectHandler.js';
@@ -6,12 +7,27 @@ import { AppModeState, IAppModeState } from '../src/model/AppModeState.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { HistoryViewState, IHistoryViewState } from '../src/model/HistoryViewState.js';
 
-// ViewSelectHandler injects AppModeState/HistoryViewState/ConversationState; build it through a container.
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// ViewSelectHandler injects AppModeState/HistoryViewState/ConversationState; build it through a
+// container. ConversationState's own declared dependencies (Clock, ILogger) still need
+// registrations for the container's dependency plan, even though this factory supplies a
+// pre-built instance.
 function buildViewSelectHandler(appModeState: AppModeState, historyViewState: HistoryViewState, conversation: ConversationState): ViewSelectHandler {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services
     .register(AppModeState)

--- a/apps/claude-sdk-cli/test/renderConversation.spec.ts
+++ b/apps/claude-sdk-cli/test/renderConversation.spec.ts
@@ -1,16 +1,29 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import stringWidth from 'string-width';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { buildDivider, type DividerTimestamps, renderBlockContentCached, renderConversation } from '../src/view/renderConversation.js';
 
-// ConversationState injects Clock; build it through a container.
+class NoopLogger extends ILogger {
+  public trace(): void {}
+  public debug(): void {}
+  public info(): void {}
+  public warn(): void {}
+  public error(): void {}
+}
+
+// ConversationState injects Clock and ILogger; build it through a container.
 function buildConversationState(): ConversationState {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
     .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => new NoopLogger())
     .asSelf();
   services.register(ConversationState).asSelf().as(IConversationState);
   return services.buildProvider().resolve(ConversationState);


### PR DESCRIPTION
## Summary

- A sealed conversation block can no longer be modified; a caller targeting an already-sealed block is a no-op, logged as a warning.
- History-replayed and boot-time blocks are marked already flushed, so restarting no longer re-writes the whole conversation to scrollback.
- A block is written to scrollback the moment it seals, instead of batched at the start and end of a turn.
