### PR TITLE
Add an F3 conversation view that lists and switches conversations for the current directory

### DIFF
--- a/apps/claude-sdk-cli/CHANGELOG.md
+++ b/apps/claude-sdk-cli/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decode escape sequences in --prompt values: \n, \r, \t, \\
 - Display server tool use as its own block in the conversation
 - ESC while a tool is running cancels the tool instead of the query, so Claude receives the cancellation and can continue
+- F3 opens a conversation view listing every conversation held in the current directory, with its model, cost, query and turn counts, context use, span, opening ask and last reply; space peeks at the tail of a conversation and enter switches to it in place, without restarting the CLI
 - Flash tool approval prompt with inverted colours when awaiting Y/N
 - Format 1M+ token counts with M suffix in the status bar
 - Index every committed turn to a searchable history store, with a migration for old audit files, a rebuild script, and a background sweep that collapses near-duplicates

--- a/apps/claude-sdk-cli/changes.jsonl
+++ b/apps/claude-sdk-cli/changes.jsonl
@@ -166,3 +166,4 @@
 {"description":"ExecV3 now overrides AZURE_CONFIG_DIR and strips ambient Azure credential env vars, so a model-driven az command can never inherit a real ambient session or SDK credential","category":"security"}
 {"description":"Az account config: reader/holder identities are now configured with a type (cert or interactive) and optional subscriptionIds, replacing readerClientId/holderClientId","category":"changed"}
 {"description":"A notice now prints in the conversation whenever a tool's disabled/enabled state actually flips on a config reload (e.g. AzCli/EscalatedAzCli becoming available as an account is configured)","category":"added"}
+{"description":"F3 opens a conversation view listing every conversation held in the current directory, with its model, cost, query and turn counts, context use, span, opening ask and last reply; space peeks at the tail of a conversation and enter switches to it in place, without restarting the CLI","category":"added"}

--- a/apps/claude-sdk-cli/src/AuditStats.ts
+++ b/apps/claude-sdk-cli/src/AuditStats.ts
@@ -2,6 +2,7 @@ import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages/mess
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { type CacheTtl, calculateCost, calculateCostSplit, getContextWindow, reconstructCacheSplit } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
+import { auditPathFor } from './conversations/auditPath.js';
 import type { StatusTotals } from './model/StatusState.js';
 
 /** An audit line: the stored BetaMessage plus the fields the audit now adds —
@@ -45,10 +46,6 @@ const EMPTY: StatusTotals = {
 export class AuditStats {
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
 
-  get #auditDir(): string {
-    return `${this.fs.homedir()}/.claude/audit`;
-  }
-
   /**
    * Derive the status totals for a conversation id from its audit file. Returns
    * the zero snapshot when the id has no audit data, so a fresh id reads as
@@ -56,7 +53,7 @@ export class AuditStats {
    * legacy fallback in #lineCost.
    */
   public async derive(id: string, cacheTtl: CacheTtl): Promise<StatusTotals> {
-    const path = `${this.#auditDir}/${id}.jsonl`;
+    const path = auditPathFor(this.fs, id);
     if (!(await this.fs.exists(path))) {
       return { ...EMPTY };
     }

--- a/apps/claude-sdk-cli/src/AuditWriter.ts
+++ b/apps/claude-sdk-cli/src/AuditWriter.ts
@@ -4,6 +4,7 @@ import { IHistoryWriter } from '@shellicar/claude-core/history/interfaces';
 import type { HistoryMessage } from '@shellicar/claude-core/history/types';
 import { calculateCostSplit, type MessageIdentity, reconstructCacheSplit } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
+import { auditPathFor } from './conversations/auditPath.js';
 import { logger } from './logger.js';
 import { toHistoryBlocks } from './persistence/historyBlocks.js';
 
@@ -18,12 +19,8 @@ export class AuditWriter {
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IHistoryWriter) private readonly index!: IHistoryWriter;
 
-  get #auditDir(): string {
-    return `${this.fs.homedir()}/.claude/audit`;
-  }
-
   public write(conversationId: string, request: BetaMessageParam | undefined, msg: BetaMessage, identity?: MessageIdentity): void {
-    const path = `${this.#auditDir}/${conversationId}.jsonl`;
+    const path = auditPathFor(this.fs, conversationId);
     const timestamp = new Date().toISOString();
     // Store the derived cost and the reconstructed per-duration breakdown so
     // re-derivation reads them back rather than recomputing. (Unchanged.)

--- a/apps/claude-sdk-cli/src/app/ConversationPresentation.ts
+++ b/apps/claude-sdk-cli/src/app/ConversationPresentation.ts
@@ -1,0 +1,25 @@
+import type { InputHandler } from '../controller/InputHandler.js';
+import type { View } from '../view/View.js';
+import type { Presentation } from './Presentation.js';
+
+/**
+ * The conversation presentation: a render-only ConversationView plus a single handler chain. Like
+ * history it has no turn phase of its own, so the chain is fixed for the presentation's lifetime.
+ */
+export class ConversationPresentation implements Presentation {
+  readonly #view: View;
+  readonly #chain: readonly InputHandler[];
+
+  public constructor(view: View, chain: readonly InputHandler[]) {
+    this.#view = view;
+    this.#chain = chain;
+  }
+
+  public get view(): View {
+    return this.#view;
+  }
+
+  public activeChain(): readonly InputHandler[] {
+    return this.#chain;
+  }
+}

--- a/apps/claude-sdk-cli/src/app/ViewHost.ts
+++ b/apps/claude-sdk-cli/src/app/ViewHost.ts
@@ -44,6 +44,7 @@ export class ViewHost implements Disposable {
     model.primaryViewState.on('change', this.#onChange);
     model.scrollState.on('change', this.#onChange);
     model.historyViewState.on('change', this.#onChange);
+    model.conversationListState.on('change', this.#onChange);
     appModeState.on('change', this.#onChange);
   }
 
@@ -58,6 +59,7 @@ export class ViewHost implements Disposable {
     this.#model.primaryViewState.off('change', this.#onChange);
     this.#model.scrollState.off('change', this.#onChange);
     this.#model.historyViewState.off('change', this.#onChange);
+    this.#model.conversationListState.off('change', this.#onChange);
     this.#appModeState.off('change', this.#onChange);
   }
 

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -3,20 +3,15 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { conditionImage } from '@shellicar/claude-core/image/conditionImage';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
-import { CacheTtl, IModelCatalog } from '@shellicar/claude-sdk';
+import { IModelCatalog } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
-import { AuditStats } from '../AuditStats.js';
-import { IAgentPresence } from '../agent/AgentPresence.js';
 import { detectMediaType } from '../clipboard.js';
-import { IConvServe } from '../conv/ConvServe.js';
 import { AttachmentSource } from '../model/AttachmentSource.js';
 import { ICommandModeState } from '../model/CommandModeState.js';
-import { IConversationSession } from '../model/ConversationSession.js';
-import { IConversationState } from '../model/ConversationState.js';
-import { ISystemIdentity } from '../model/ISystemIdentity.js';
 import { ModelSettings } from '../model/ModelSettings.js';
 import { StatusState } from '../model/StatusState.js';
 import { IWorkingDirectory } from '../model/WorkingDirectory.js';
+import { IConversationSwitcher } from '../setup/ConversationSwitcher.js';
 
 export type CommandIntent = 'pasteText' | 'pasteFile' | 'pasteImage' | 'removeAttachment' | 'togglePreview' | 'newSession' | 'selectPrev' | 'selectNext' | 'enterModelSubMode' | 'cycleThinking' | 'cycleEffort' | 'openModelEditor' | 'submitModel' | 'enterCdSubMode' | 'openCdEditor' | 'submitCd';
 
@@ -40,17 +35,12 @@ function isLikelyPath(s: string): boolean {
  */
 export class CommandIntentExecutor {
   @dependsOn(ICommandModeState) private readonly commandModeState!: ICommandModeState;
-  @dependsOn(IConversationState) private readonly conversationState!: IConversationState;
-  @dependsOn(IConversationSession) private readonly session!: IConversationSession;
   @dependsOn(AttachmentSource) private readonly source!: AttachmentSource;
   @dependsOn(ModelSettings) private readonly modelSettings!: ModelSettings;
   @dependsOn(SipsBridge) private readonly sips!: SipsBridge;
   @dependsOn(ILogger) private readonly logger!: ILogger;
-  @dependsOn(ISystemIdentity) private readonly systemIdentity!: ISystemIdentity;
   @dependsOn(StatusState) private readonly statusState!: StatusState;
-  @dependsOn(AuditStats) private readonly auditStats!: AuditStats;
-  @dependsOn(IConvServe) private readonly convServe!: IConvServe;
-  @dependsOn(IAgentPresence) private readonly agentPresence!: IAgentPresence;
+  @dependsOn(IConversationSwitcher) private readonly switcher!: IConversationSwitcher;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IWorkingDirectory) private readonly workingDirectory!: IWorkingDirectory;
   @dependsOn(IModelCatalog) private readonly modelCatalog!: IModelCatalog;
@@ -70,26 +60,8 @@ export class CommandIntentExecutor {
         case 'togglePreview':
           this.commandModeState.togglePreview();
           return;
-        case 'newSession': {
-          const previousId = this.session.id;
-          await this.session.createNew();
-          // A run is process + conversation, so a switch moves the addressable subject: re-point the wire
-          // serve to the new conversation so it is reachable over NATS immediately, not only after relaunch.
-          this.convServe.bind(this.session.id);
-          // The attachment moves with it — detach the old conversation, attach the new one (agent-spec).
-          this.agentPresence.detach(previousId);
-          this.agentPresence.attach(this.session.id, this.fs.cwd());
-          this.systemIdentity.inherit(this.session.id);
-          this.conversationState.clear();
-          // Re-derive the status figures for the fresh id. A brand-new id has no
-          // audit data, so this reads empty — the "clear on new" behaviour falls
-          // out of the single id-keyed rule, not a special case. The TTL is inert
-          // here: it is consulted only for a legacy flat-only audit line, and a
-          // fresh id has no lines, so the default is passed rather than threading
-          // the config provider.
-          this.statusState.resetTo(await this.auditStats.derive(this.session.id, CacheTtl.OneHour));
-          return;
-        }
+        case 'newSession':
+          return await this.switcher.createNew();
         case 'selectPrev':
           this.commandModeState.selectLeft();
           return;

--- a/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
+++ b/apps/claude-sdk-cli/src/controller/CommandIntentExecutor.ts
@@ -9,6 +9,7 @@ import { detectMediaType } from '../clipboard.js';
 import { AttachmentSource } from '../model/AttachmentSource.js';
 import { ICommandModeState } from '../model/CommandModeState.js';
 import { ModelSettings } from '../model/ModelSettings.js';
+import { IPrimaryViewState } from '../model/PrimaryViewState.js';
 import { StatusState } from '../model/StatusState.js';
 import { IWorkingDirectory } from '../model/WorkingDirectory.js';
 import { IConversationSwitcher } from '../setup/ConversationSwitcher.js';
@@ -41,6 +42,7 @@ export class CommandIntentExecutor {
   @dependsOn(ILogger) private readonly logger!: ILogger;
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(IConversationSwitcher) private readonly switcher!: IConversationSwitcher;
+  @dependsOn(IPrimaryViewState) private readonly primaryViewState!: IPrimaryViewState;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IWorkingDirectory) private readonly workingDirectory!: IWorkingDirectory;
   @dependsOn(IModelCatalog) private readonly modelCatalog!: IModelCatalog;
@@ -61,6 +63,13 @@ export class CommandIntentExecutor {
           this.commandModeState.togglePreview();
           return;
         case 'newSession':
+          // Refused while a turn is running, for the reason switching is: the turn belongs to the
+          // conversation being left, and moving out from under it strands its output. The command row
+          // shows the option greyed while that holds, so the key reads as unavailable rather than
+          // ignored.
+          if (this.primaryViewState.phase !== 'editor') {
+            return;
+          }
           return await this.switcher.createNew();
         case 'selectPrev':
           this.commandModeState.selectLeft();

--- a/apps/claude-sdk-cli/src/controller/ConversationNavHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/ConversationNavHandler.ts
@@ -1,0 +1,56 @@
+import type { KeyAction } from '@shellicar/claude-core/input';
+import { dependsOn } from '@shellicar/core-di';
+import { IConversationPeekLoader } from '../conversations/ConversationPeekLoader.js';
+import { IConversationListState } from '../model/ConversationListState.js';
+import { IPrimaryViewState } from '../model/PrimaryViewState.js';
+import { IConversationSwitcher } from '../setup/ConversationSwitcher.js';
+import { conversationKeyMap } from './conversationKeyMap.js';
+import type { InputHandler } from './InputHandler.js';
+
+/**
+ * Drives the conversation list: navigation through the key-map, peek content loaded on demand, and
+ * enter to switch.
+ *
+ * Peek content is read only when the peek opens, never when the list is drawn — the operator has
+ * chosen to wait at that point, and most conversations are never peeked.
+ *
+ * Enter is refused mid-turn: a streaming turn belongs to the conversation being left, and moving out
+ * from under it would strand its output. The refusal is silent rather than an error, because the view
+ * shows which conversation is live and there is nothing to explain.
+ */
+export class ConversationNavHandler implements InputHandler {
+  @dependsOn(IConversationListState) private readonly state!: IConversationListState;
+  @dependsOn(IConversationPeekLoader) private readonly peekLoader!: IConversationPeekLoader;
+  @dependsOn(IConversationSwitcher) private readonly switcher!: IConversationSwitcher;
+  @dependsOn(IPrimaryViewState) private readonly primaryViewState!: IPrimaryViewState;
+
+  public handleKey(key: KeyAction): boolean {
+    if (key.type === 'enter') {
+      this.#switch();
+      return true;
+    }
+    const action = conversationKeyMap(key);
+    if (action === null) {
+      return false;
+    }
+    this.state.apply(action);
+    if (action === 'toggle-peek' && this.state.peeked) {
+      const id = this.state.selectedEntry?.id;
+      if (id !== undefined) {
+        this.peekLoader.load(id);
+      }
+    }
+    return true;
+  }
+
+  #switch(): void {
+    if (this.primaryViewState.phase !== 'editor') {
+      return;
+    }
+    const id = this.state.selectedEntry?.id;
+    if (id === undefined) {
+      return;
+    }
+    void this.switcher.switchTo(id);
+  }
+}

--- a/apps/claude-sdk-cli/src/controller/ConversationNavHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/ConversationNavHandler.ts
@@ -34,7 +34,9 @@ export class ConversationNavHandler implements InputHandler {
       return false;
     }
     this.state.apply(action);
-    if (action === 'toggle-peek' && this.state.peeked) {
+    // An open peek with no content is the one state that needs a read: it arises both from opening a
+    // peek and from moving to another conversation with one already open.
+    if (this.state.peeked && this.state.peek === undefined) {
       const id = this.state.selectedEntry?.id;
       if (id !== undefined) {
         this.peekLoader.load(id);

--- a/apps/claude-sdk-cli/src/controller/ViewSelectHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/ViewSelectHandler.ts
@@ -3,6 +3,7 @@ import { dependsOn } from '@shellicar/core-di';
 import { IConversationListLoader } from '../conversations/ConversationListLoader.js';
 import { IAppModeState } from '../model/AppModeState.js';
 import { IConversationListState } from '../model/ConversationListState.js';
+import { IConversationSession } from '../model/ConversationSession.js';
 import { IConversationState } from '../model/ConversationState.js';
 import { IHistoryViewState } from '../model/HistoryViewState.js';
 import type { InputHandler } from './InputHandler.js';
@@ -25,6 +26,7 @@ export class ViewSelectHandler implements InputHandler {
   @dependsOn(IConversationState) private readonly conversation!: IConversationState;
   @dependsOn(IConversationListState) private readonly conversationListState!: IConversationListState;
   @dependsOn(IConversationListLoader) private readonly conversationListLoader!: IConversationListLoader;
+  @dependsOn(IConversationSession) private readonly session!: IConversationSession;
 
   public handleKey(key: KeyAction): boolean {
     if (key.type === 'f1') {
@@ -39,10 +41,11 @@ export class ViewSelectHandler implements InputHandler {
       return true;
     }
     // Entry rebuilds the list and starts the summary reads: a conversation may have been created or
-    // written to since the last visit, including by another CLI sharing the store.
+    // written to since the last visit, including by another CLI sharing the store. It opens on the
+    // conversation the process is on, so the operator arrives where they already are.
     if (key.type === 'f3') {
       if (this.appModeState.active !== 'conversations') {
-        this.conversationListState.reset();
+        this.conversationListState.enterAt(this.session.id);
       }
       this.conversationListLoader.refresh();
       this.appModeState.setActive('conversations');

--- a/apps/claude-sdk-cli/src/controller/ViewSelectHandler.ts
+++ b/apps/claude-sdk-cli/src/controller/ViewSelectHandler.ts
@@ -1,16 +1,18 @@
 import type { KeyAction } from '@shellicar/claude-core/input';
 import { dependsOn } from '@shellicar/core-di';
+import { IConversationListLoader } from '../conversations/ConversationListLoader.js';
 import { IAppModeState } from '../model/AppModeState.js';
+import { IConversationListState } from '../model/ConversationListState.js';
 import { IConversationState } from '../model/ConversationState.js';
 import { IHistoryViewState } from '../model/HistoryViewState.js';
 import type { InputHandler } from './InputHandler.js';
 
 /**
  * Direct view selection, reachable from every presentation's chain: F1 selects
- * the primary view, F2 the history view. setActive is a no-op when the target
- * is already active. Claims only F1/F2 and passes everything else down, so it is
- * safe at the front of any chain; there is no enter/exit asymmetry — each view
- * has its own key.
+ * the primary view, F2 the history view, F3 the conversation view. setActive is
+ * a no-op when the target is already active. Claims only those keys and passes
+ * everything else down, so it is safe at the front of any chain; there is no
+ * enter/exit asymmetry — each view has its own key.
  *
  * Entry to history focuses the latest block (the bottom): pressing F2 from
  * outside history resets the focus to the newest block, so no focus state is
@@ -21,6 +23,8 @@ export class ViewSelectHandler implements InputHandler {
   @dependsOn(IAppModeState) private readonly appModeState!: IAppModeState;
   @dependsOn(IHistoryViewState) private readonly historyViewState!: IHistoryViewState;
   @dependsOn(IConversationState) private readonly conversation!: IConversationState;
+  @dependsOn(IConversationListState) private readonly conversationListState!: IConversationListState;
+  @dependsOn(IConversationListLoader) private readonly conversationListLoader!: IConversationListLoader;
 
   public handleKey(key: KeyAction): boolean {
     if (key.type === 'f1') {
@@ -32,6 +36,16 @@ export class ViewSelectHandler implements InputHandler {
         this.historyViewState.enterAtLatest(this.conversation.sealedBlocks.length);
       }
       this.appModeState.setActive('history');
+      return true;
+    }
+    // Entry rebuilds the list and starts the summary reads: a conversation may have been created or
+    // written to since the last visit, including by another CLI sharing the store.
+    if (key.type === 'f3') {
+      if (this.appModeState.active !== 'conversations') {
+        this.conversationListState.reset();
+      }
+      this.conversationListLoader.refresh();
+      this.appModeState.setActive('conversations');
       return true;
     }
     return false;

--- a/apps/claude-sdk-cli/src/controller/conversationKeyMap.ts
+++ b/apps/claude-sdk-cli/src/controller/conversationKeyMap.ts
@@ -1,0 +1,35 @@
+import type { KeyAction } from '@shellicar/claude-core/input';
+import type { ConversationAction } from '../model/ConversationListState.js';
+
+/**
+ * Translation from a key to a conversation-list Action, kept separate from applying it.
+ *
+ * Unlike the history map this is state-free, and deliberately so: peek is a flat toggle rather than a
+ * level you enter, so no key ever changes meaning. Up/down always move the selection, and the wheel is
+ * the same action as the arrows because the list is what scrolls.
+ *
+ * `enter` is not here — switching conversation is not a navigation action, so its handler claims that
+ * key directly.
+ */
+export function conversationKeyMap(key: KeyAction): ConversationAction | null {
+  switch (key.type) {
+    case 'up':
+    case 'scroll_up':
+      return 'prev';
+    case 'down':
+    case 'scroll_down':
+      return 'next';
+    case 'page_up':
+      return 'page-up';
+    case 'page_down':
+      return 'page-down';
+    case 'home':
+      return 'home';
+    case 'end':
+      return 'end';
+    case 'char':
+      return key.value === ' ' ? 'toggle-peek' : null;
+    default:
+      return null;
+  }
+}

--- a/apps/claude-sdk-cli/src/conversations/ConversationListLoader.ts
+++ b/apps/claude-sdk-cli/src/conversations/ConversationListLoader.ts
@@ -1,0 +1,30 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { dependsOn } from '@shellicar/core-di';
+import { IConversationListState } from '../model/ConversationListState.js';
+import { ISqliteSessionStore } from '../persistence/SqliteSessionStore.js';
+import { IConversationSummaryLoader } from './ConversationSummaryLoader.js';
+
+/** The loader's contract; register abstract→concrete and depend on the abstract (DI rule). */
+export abstract class IConversationListLoader {
+  public abstract refresh(): void;
+}
+
+/**
+ * Rebuilds the conversation list for the current directory and starts the summary reads.
+ *
+ * The two halves are deliberately split in time. Listing the ids is a synchronous store read, so the
+ * view can paint every row the instant F3 is pressed; the figures arrive afterwards, one file at a
+ * time. That ordering is the whole reason the view never blocks on a large conversation.
+ */
+export class ConversationListLoader extends IConversationListLoader {
+  @dependsOn(ISqliteSessionStore) private readonly sessionStore!: ISqliteSessionStore;
+  @dependsOn(IConversationListState) private readonly listState!: IConversationListState;
+  @dependsOn(IConversationSummaryLoader) private readonly summaryLoader!: IConversationSummaryLoader;
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+
+  public refresh(): void {
+    const ids = this.sessionStore.listByCwd(this.fs.cwd());
+    this.listState.setEntries(ids);
+    this.summaryLoader.load(ids);
+  }
+}

--- a/apps/claude-sdk-cli/src/conversations/ConversationPeekLoader.ts
+++ b/apps/claude-sdk-cli/src/conversations/ConversationPeekLoader.ts
@@ -1,0 +1,40 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { dependsOn } from '@shellicar/core-di';
+import { IConversationListState } from '../model/ConversationListState.js';
+import { PEEK_LINES } from '../view/ConversationView.js';
+import { scanAuditPeek } from './scanAuditPeek.js';
+
+/** The loader's contract; register abstract→concrete and depend on the abstract (DI rule). */
+export abstract class IConversationPeekLoader {
+  public abstract load(id: string): void;
+}
+
+/**
+ * Reads a conversation's tail when its peek opens.
+ *
+ * Kept apart from the summary loader because the two have opposite cost rules. A summary is read for
+ * every row the moment the view opens, so it must be cheap; a peek is read only for the one
+ * conversation the operator chose to open, so it may take as long as that conversation is large. The
+ * state ignores content that lands after the operator has moved on, so a slow read is harmless rather
+ * than something to cancel.
+ */
+export class ConversationPeekLoader extends IConversationPeekLoader {
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  @dependsOn(IConversationListState) private readonly listState!: IConversationListState;
+  @dependsOn(ILogger) private readonly logger!: ILogger;
+
+  public load(id: string): void {
+    void this.#read(id);
+  }
+
+  async #read(id: string): Promise<void> {
+    try {
+      const path = `${this.fs.homedir()}/.claude/audit/${id}.jsonl`;
+      const bytes = (await this.fs.exists(path)) ? await this.fs.readFileBytes(path) : Buffer.alloc(0);
+      this.listState.setPeek(id, scanAuditPeek(bytes, PEEK_LINES));
+    } catch (err) {
+      this.logger.warn('failed to read conversation peek', { id, err });
+    }
+  }
+}

--- a/apps/claude-sdk-cli/src/conversations/ConversationPeekLoader.ts
+++ b/apps/claude-sdk-cli/src/conversations/ConversationPeekLoader.ts
@@ -2,8 +2,8 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { dependsOn } from '@shellicar/core-di';
 import { IConversationListState } from '../model/ConversationListState.js';
-import { PEEK_LINES } from '../view/ConversationView.js';
-import { scanAuditPeek } from './scanAuditPeek.js';
+import { auditPathFor } from './auditPath.js';
+import { PEEK_LINES, scanAuditPeek } from './scanAuditPeek.js';
 
 /** The loader's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class IConversationPeekLoader {
@@ -30,7 +30,7 @@ export class ConversationPeekLoader extends IConversationPeekLoader {
 
   async #read(id: string): Promise<void> {
     try {
-      const path = `${this.fs.homedir()}/.claude/audit/${id}.jsonl`;
+      const path = auditPathFor(this.fs, id);
       const bytes = (await this.fs.exists(path)) ? await this.fs.readFileBytes(path) : Buffer.alloc(0);
       this.listState.setPeek(id, scanAuditPeek(bytes, PEEK_LINES));
     } catch (err) {

--- a/apps/claude-sdk-cli/src/conversations/ConversationSummaryLoader.ts
+++ b/apps/claude-sdk-cli/src/conversations/ConversationSummaryLoader.ts
@@ -2,6 +2,7 @@ import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { dependsOn } from '@shellicar/core-di';
 import { IConversationListState } from '../model/ConversationListState.js';
+import { auditPathFor } from './auditPath.js';
 import { type AuditSummary, scanAuditSummary } from './scanAuditSummary.js';
 
 /** The loader's contract; register abstract→concrete and depend on the abstract (DI rule). */
@@ -52,7 +53,7 @@ export class ConversationSummaryLoader extends IConversationSummaryLoader {
   }
 
   async #summaryFor(id: string): Promise<AuditSummary> {
-    const path = `${this.fs.homedir()}/.claude/audit/${id}.jsonl`;
+    const path = auditPathFor(this.fs, id);
     if (!(await this.fs.exists(path))) {
       return this.#memoise(id, 0, scanAuditSummary(Buffer.alloc(0)));
     }

--- a/apps/claude-sdk-cli/src/conversations/ConversationSummaryLoader.ts
+++ b/apps/claude-sdk-cli/src/conversations/ConversationSummaryLoader.ts
@@ -1,0 +1,71 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { dependsOn } from '@shellicar/core-di';
+import { IConversationListState } from '../model/ConversationListState.js';
+import { type AuditSummary, scanAuditSummary } from './scanAuditSummary.js';
+
+/** The loader's contract; register abstract→concrete and depend on the abstract (DI rule). */
+export abstract class IConversationSummaryLoader {
+  public abstract load(ids: readonly string[]): void;
+}
+
+/**
+ * Fills in each listed conversation's summary, one file per tick, newest first.
+ *
+ * The list paints from the session store before any of this runs, so a slow read never delays the view;
+ * each summary lands through `setSummary`, whose change event ViewHost coalesces into one repaint per
+ * tick. Newest first because that is where the selection starts and where the answer usually is.
+ *
+ * A summary is memoised against the audit file's size. An audit file only ever grows, so a changed size
+ * is exactly "this conversation has moved on"; an unchanged one means a second visit costs no read at
+ * all. A missing audit file (a conversation that never took a turn) memoises its empty summary too,
+ * rather than being retried on every visit.
+ */
+export class ConversationSummaryLoader extends IConversationSummaryLoader {
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  @dependsOn(IConversationListState) private readonly listState!: IConversationListState;
+  @dependsOn(ILogger) private readonly logger!: ILogger;
+  readonly #cache = new Map<string, { size: number; summary: AuditSummary }>();
+  /** The generation of the in-flight walk. A new `load` bumps it, so an older walk stops rather than
+   *  spending reads on a list the operator has already moved off. */
+  #generation = 0;
+
+  public load(ids: readonly string[]): void {
+    this.#generation += 1;
+    void this.#walk(ids, this.#generation);
+  }
+
+  async #walk(ids: readonly string[], generation: number): Promise<void> {
+    for (const id of ids) {
+      if (generation !== this.#generation) {
+        return;
+      }
+      try {
+        const summary = await this.#summaryFor(id);
+        this.listState.setSummary(id, summary);
+      } catch (err) {
+        // A summary is a display convenience over a file that may be missing, truncated, or written by
+        // another tool. A failure leaves the row unfilled rather than taking down the view.
+        this.logger.warn('failed to summarise conversation', { id, err });
+      }
+    }
+  }
+
+  async #summaryFor(id: string): Promise<AuditSummary> {
+    const path = `${this.fs.homedir()}/.claude/audit/${id}.jsonl`;
+    if (!(await this.fs.exists(path))) {
+      return this.#memoise(id, 0, scanAuditSummary(Buffer.alloc(0)));
+    }
+    const { size } = await this.fs.stat(path);
+    const cached = this.#cache.get(id);
+    if (cached !== undefined && cached.size === size) {
+      return cached.summary;
+    }
+    return this.#memoise(id, size, scanAuditSummary(await this.fs.readFileBytes(path)));
+  }
+
+  #memoise(id: string, size: number, summary: AuditSummary): AuditSummary {
+    this.#cache.set(id, { size, summary });
+    return summary;
+  }
+}

--- a/apps/claude-sdk-cli/src/conversations/auditPath.ts
+++ b/apps/claude-sdk-cli/src/conversations/auditPath.ts
@@ -1,0 +1,4 @@
+import type { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+
+/** Where a conversation's audit file lives. One definition, so a move updates every reader at once. */
+export const auditPathFor = (fs: IFileSystem, id: string): string => `${fs.homedir()}/.claude/audit/${id}.jsonl`;

--- a/apps/claude-sdk-cli/src/conversations/scanAuditPeek.ts
+++ b/apps/claude-sdk-cli/src/conversations/scanAuditPeek.ts
@@ -1,4 +1,5 @@
 import { isSystemReminderBlock } from '@shellicar/claude-sdk';
+import { validTimestamp } from './validTimestamp.js';
 
 /** One line of a peek: a message opening, or a collapsed run of tool activity. */
 export type PeekEntry = {
@@ -17,6 +18,9 @@ export type ConversationPeek = {
 };
 
 const NEWLINE = 0x0a;
+
+/** How many lines a peek reads. Fixed: peek is a flat toggle, not something that grows. */
+export const PEEK_LINES = 10;
 
 type AuditContent = { type?: string; text?: string };
 type AuditLine = { role?: string; timestamp?: string; content?: AuditContent[] | string };
@@ -104,14 +108,14 @@ export function scanAuditPeek(bytes: Buffer, limit: number): ConversationPeek {
       if (head?.kind === 'tools') {
         head.toolCount += 1;
         head.text = `${head.toolCount} tools`;
-        head.timestampUtc = line.timestamp ?? head.timestampUtc;
+        head.timestampUtc = validTimestamp(line.timestamp) ?? head.timestampUtc;
         continue;
       }
-      entries.unshift({ kind: 'tools', text: '1 tool', toolCount: 1, timestampUtc: line.timestamp ?? null });
+      entries.unshift({ kind: 'tools', text: '1 tool', toolCount: 1, timestampUtc: validTimestamp(line.timestamp) });
       continue;
     }
     const role = line.role ?? 'assistant';
-    entries.unshift({ kind: role === 'user' ? 'user' : 'assistant', text: shape.text, toolCount: 0, timestampUtc: line.timestamp ?? null });
+    entries.unshift({ kind: role === 'user' ? 'user' : 'assistant', text: shape.text, toolCount: 0, timestampUtc: validTimestamp(line.timestamp) });
   }
 
   return { entries, earlier: index + 1 };

--- a/apps/claude-sdk-cli/src/conversations/scanAuditPeek.ts
+++ b/apps/claude-sdk-cli/src/conversations/scanAuditPeek.ts
@@ -1,0 +1,118 @@
+import { isSystemReminderBlock } from '@shellicar/claude-sdk';
+
+/** One line of a peek: a message opening, or a collapsed run of tool activity. */
+export type PeekEntry = {
+  kind: 'user' | 'assistant' | 'tools';
+  /** The message's opening text, or the number of tool messages for a collapsed run. */
+  text: string;
+  toolCount: number;
+  timestampUtc: string | null;
+};
+
+/** What the peek shows, plus how much of the conversation it does not reach. */
+export type ConversationPeek = {
+  entries: readonly PeekEntry[];
+  /** Messages older than the oldest entry shown — the `⋮ N earlier messages` count. */
+  earlier: number;
+};
+
+const NEWLINE = 0x0a;
+
+type AuditContent = { type?: string; text?: string };
+type AuditLine = { role?: string; timestamp?: string; content?: AuditContent[] | string };
+
+/** What a message contributes to the peek: its own words, a tool execution, or nothing at all. */
+type MessageShape = { kind: 'text'; text: string } | { kind: 'tools' } | { kind: 'skip' };
+
+/**
+ * Classifies a message for the peek by what its blocks ARE, never by what they are not.
+ *
+ * A `tool_result` block is the tool activity: one per execution. Its matching `tool_use` is a
+ * separate message, so counting both would report a run of seven tools as fourteen — and inferring
+ * "tool" from the absence of text would do exactly that, as well as miscounting an image-only or
+ * thinking-only message.
+ *
+ * Everything else is either the message's own words (its first text block that is not a
+ * `<system-reminder>`) or nothing worth a line: a reminder-only message, or an assistant turn that
+ * only called a tool or only thought.
+ */
+const shapeOf = (line: AuditLine): MessageShape => {
+  if (typeof line.content === 'string') {
+    return { kind: 'text', text: line.content };
+  }
+  if (!Array.isArray(line.content)) {
+    return { kind: 'skip' };
+  }
+  if (line.content.some((block) => block?.type === 'tool_result')) {
+    return { kind: 'tools' };
+  }
+  for (const block of line.content) {
+    if (block?.type === 'text' && typeof block.text === 'string' && !isSystemReminderBlock(block.text)) {
+      return { kind: 'text', text: block.text };
+    }
+  }
+  return { kind: 'skip' };
+};
+
+/** Byte ranges of every line, so only the ones the peek shows are ever decoded. */
+const lineRanges = (bytes: Buffer): Array<[number, number]> => {
+  const ranges: Array<[number, number]> = [];
+  let from = 0;
+  for (;;) {
+    let end = bytes.indexOf(NEWLINE, from);
+    if (end < 0) {
+      end = bytes.length;
+    }
+    if (end > from) {
+      ranges.push([from, end]);
+    }
+    if (end >= bytes.length) {
+      return ranges;
+    }
+    from = end + 1;
+  }
+};
+
+/**
+ * Reads the tail of a conversation as one line per message, newest last, for the peek.
+ *
+ * A message with no text — a tool call, a tool result, an assistant turn that only thought — is not a
+ * line of its own: a run of them collapses to a single `tools` entry carrying the count. Without that,
+ * ten lines of peek on a working conversation would show ten tool calls and nothing said. `limit`
+ * counts entries after collapsing, so it is ten lines of conversation rather than ten raw messages.
+ *
+ * Decodes only the lines it returns, walking backwards from the end. The megabyte tool-result lines in
+ * the middle are counted, never read.
+ */
+export function scanAuditPeek(bytes: Buffer, limit: number): ConversationPeek {
+  const ranges = lineRanges(bytes);
+  const entries: PeekEntry[] = [];
+  let index = ranges.length - 1;
+
+  for (; index >= 0 && entries.length < limit; index--) {
+    const range = ranges[index];
+    if (range === undefined) {
+      continue;
+    }
+    const line = JSON.parse(bytes.toString('utf8', range[0], range[1])) as AuditLine;
+    const shape = shapeOf(line);
+    if (shape.kind === 'skip') {
+      continue;
+    }
+    if (shape.kind === 'tools') {
+      const head = entries[0];
+      if (head?.kind === 'tools') {
+        head.toolCount += 1;
+        head.text = `${head.toolCount} tools`;
+        head.timestampUtc = line.timestamp ?? head.timestampUtc;
+        continue;
+      }
+      entries.unshift({ kind: 'tools', text: '1 tool', toolCount: 1, timestampUtc: line.timestamp ?? null });
+      continue;
+    }
+    const role = line.role ?? 'assistant';
+    entries.unshift({ kind: role === 'user' ? 'user' : 'assistant', text: shape.text, toolCount: 0, timestampUtc: line.timestamp ?? null });
+  }
+
+  return { entries, earlier: index + 1 };
+}

--- a/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
+++ b/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
@@ -1,5 +1,5 @@
-import { Instant } from '@js-joda/core';
 import { isSystemReminderBlock } from '@shellicar/claude-sdk';
+import { validTimestamp } from './validTimestamp.js';
 
 /** What the conversation list shows for one conversation, derived from its audit file. */
 export type AuditSummary = {
@@ -92,29 +92,6 @@ const numberValue = (window: string, key: string): number | null => {
     i++;
   }
   return i === start ? null : Number(window.slice(start, i));
-};
-
-/**
- * A timestamp that survived the scan, or null if it is not one.
- *
- * The scan lifts these by matching bytes in a file another tool may have written, so the value is a
- * string that looked like a timestamp, not a timestamp. Everything downstream parses it to format a
- * time or a duration, and a parse that throws there kills the render rather than spoiling a line.
- *
- * Checked here rather than per line: only two of a file's timestamps survive, so this costs two
- * parses however large the conversation, where validating as they are read would cost one per line
- * against the string comparison it replaces.
- */
-const validTimestamp = (candidate: string | null): string | null => {
-  if (candidate === null) {
-    return null;
-  }
-  try {
-    Instant.parse(candidate);
-    return candidate;
-  } catch {
-    return null;
-  }
 };
 
 type AuditContent = { type?: string; text?: string };

--- a/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
+++ b/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
@@ -1,0 +1,195 @@
+import { isSystemReminderBlock } from '@shellicar/claude-sdk';
+
+/** What the conversation list shows for one conversation, derived from its audit file. */
+export type AuditSummary = {
+  /** Distinct turns — one per assistant round trip. */
+  turns: number;
+  /** Distinct queries — one per thing the operator asked. */
+  queries: number;
+  costUsd: number;
+  /** ISO timestamp of the earliest line, or null when no line carries one. */
+  firstUtc: string | null;
+  /** ISO timestamp of the latest line. */
+  lastUtc: string | null;
+  /** The model of the last assistant line — what the conversation would resume on. */
+  model: string | null;
+  /** Context used by the last assistant turn: input + cache creation + cache read. */
+  contextTokens: number;
+  /** The opening ask, which says what the conversation is. */
+  firstUserText: string | null;
+  /** The last reply, which says where it got to. */
+  lastAssistantText: string | null;
+};
+
+const EMPTY: AuditSummary = {
+  turns: 0,
+  queries: 0,
+  costUsd: 0,
+  firstUtc: null,
+  lastUtc: null,
+  model: null,
+  contextTokens: 0,
+  firstUserText: null,
+  lastAssistantText: null,
+};
+
+const NEWLINE = 0x0a;
+const QUOTE = 0x22;
+const BACKSLASH = 0x5c;
+
+/** How much of a line's head holds its scalar keys. On a user line role/turnId/queryId/timestamp all
+ *  sit before the content starts; on an assistant line timestamp/costUsd/model do. */
+const PREFIX_BYTES = 256;
+/** How much of a line's tail holds usage/turnId/queryId on an assistant line. */
+const SUFFIX_BYTES = 2048;
+
+/**
+ * Value of a string key within one window. The window is a latin1 decode of a bounded slice, never
+ * the whole line — a line can be megabytes of base64 in the middle, and none of it is read.
+ *
+ * `fromEnd` finds the LAST occurrence, which is what the tail window needs: turnId and queryId are
+ * the final keys of the object, so the last match is the real one even if quoted content repeats
+ * the same key text earlier in the window.
+ */
+const stringValue = (window: string, key: string, fromEnd: boolean): string | null => {
+  const marker = `"${key}":"`;
+  const at = fromEnd ? window.lastIndexOf(marker) : window.indexOf(marker);
+  if (at < 0) {
+    return null;
+  }
+  const start = at + marker.length;
+  for (let i = start; i < window.length; i++) {
+    const code = window.charCodeAt(i);
+    if (code === BACKSLASH) {
+      i++;
+      continue;
+    }
+    if (code === QUOTE) {
+      const raw = window.slice(start, i);
+      return raw.includes('\\') ? (JSON.parse(`"${raw}"`) as string) : raw;
+    }
+  }
+  return null;
+};
+
+const numberValue = (window: string, key: string): number | null => {
+  const marker = `"${key}":`;
+  const at = window.indexOf(marker);
+  if (at < 0) {
+    return null;
+  }
+  let i = at + marker.length;
+  const start = i;
+  while (i < window.length) {
+    const code = window.charCodeAt(i);
+    const isNumeric = (code >= 0x30 && code <= 0x39) || code === 0x2d || code === 0x2e || code === 0x65 || code === 0x45 || code === 0x2b;
+    if (!isNumeric) {
+      break;
+    }
+    i++;
+  }
+  return i === start ? null : Number(window.slice(start, i));
+};
+
+type AuditContent = { type?: string; text?: string };
+type AuditLine = { content?: AuditContent[] | string };
+
+/**
+ * The message's own words: its first text block that is not a `<system-reminder>`.
+ *
+ * A user message arrives as several text blocks the API concatenates, and the CLI leads the first
+ * one with reminders — the skill catalogue, CLAUDE.md, the clock stamp. Taking the first block
+ * blindly previews that machinery instead of what was said, so whole reminder blocks are skipped.
+ * The predicate is the SDK's own, so the preview agrees with what the SDK counts as a reminder
+ * rather than drifting from it.
+ *
+ * Tool and thinking blocks are skipped the same way: neither is a message opening.
+ */
+const messageText = (line: AuditLine): string | null => {
+  if (typeof line.content === 'string') {
+    return line.content;
+  }
+  if (!Array.isArray(line.content)) {
+    return null;
+  }
+  for (const block of line.content) {
+    if (block?.type === 'text' && typeof block.text === 'string' && !isSystemReminderBlock(block.text)) {
+      return block.text;
+    }
+  }
+  return null;
+};
+
+/**
+ * Derives a conversation's summary from its whole audit file, in one forward pass over the bytes.
+ *
+ * Two properties make this cheap enough to run on a keypress. Nothing is decoded but a bounded head
+ * and tail window per line, so the megabyte tool-result lines are stepped over rather than read. And
+ * `JSON.parse` runs at most twice for the file: only the first user line and the last assistant line
+ * need their text, and which line is last is not known until the end, so its byte range is recorded
+ * and decoded once the scan finishes.
+ *
+ * Returns the empty summary for a file this CLI did not write (Claude Code's audit format nests
+ * everything under `message`, so none of the top-level keys are found).
+ */
+export function scanAuditSummary(bytes: Buffer): AuditSummary {
+  const turnIds = new Set<string>();
+  const queryIds = new Set<string>();
+  const summary: AuditSummary = { ...EMPTY };
+  let lastAssistantStart = -1;
+  let lastAssistantEnd = -1;
+
+  let from = 0;
+  for (;;) {
+    let end = bytes.indexOf(NEWLINE, from);
+    if (end < 0) {
+      end = bytes.length;
+    }
+    if (end > from) {
+      const head = bytes.toString('latin1', from, Math.min(from + PREFIX_BYTES, end));
+      const tail = bytes.toString('latin1', Math.max(from, end - SUFFIX_BYTES), end);
+
+      const role = stringValue(head, 'role', false) ?? 'assistant';
+      const timestamp = stringValue(head, 'timestamp', false);
+      if (timestamp !== null) {
+        if (summary.firstUtc === null || timestamp < summary.firstUtc) {
+          summary.firstUtc = timestamp;
+        }
+        if (summary.lastUtc === null || timestamp > summary.lastUtc) {
+          summary.lastUtc = timestamp;
+        }
+      }
+      const turnId = stringValue(head, 'turnId', false) ?? stringValue(tail, 'turnId', true);
+      const queryId = stringValue(head, 'queryId', false) ?? stringValue(tail, 'queryId', true);
+      if (turnId !== null) {
+        turnIds.add(turnId);
+      }
+      if (queryId !== null) {
+        queryIds.add(queryId);
+      }
+
+      const usageAt = tail.lastIndexOf('"usage":{');
+      if (role === 'assistant' && usageAt >= 0) {
+        summary.costUsd += numberValue(head, 'costUsd') ?? 0;
+        summary.model = stringValue(head, 'model', false) ?? summary.model;
+        const usage = tail.slice(usageAt);
+        summary.contextTokens = (numberValue(usage, 'input_tokens') ?? 0) + (numberValue(usage, 'cache_creation_input_tokens') ?? 0) + (numberValue(usage, 'cache_read_input_tokens') ?? 0);
+        lastAssistantStart = from;
+        lastAssistantEnd = end;
+      } else if (role === 'user' && summary.firstUserText === null) {
+        summary.firstUserText = messageText(JSON.parse(bytes.toString('utf8', from, end)) as AuditLine);
+      }
+    }
+    if (end >= bytes.length) {
+      break;
+    }
+    from = end + 1;
+  }
+
+  summary.turns = turnIds.size;
+  summary.queries = queryIds.size;
+  if (lastAssistantStart >= 0) {
+    summary.lastAssistantText = messageText(JSON.parse(bytes.toString('utf8', lastAssistantStart, lastAssistantEnd)) as AuditLine);
+  }
+  return summary;
+}

--- a/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
+++ b/apps/claude-sdk-cli/src/conversations/scanAuditSummary.ts
@@ -1,3 +1,4 @@
+import { Instant } from '@js-joda/core';
 import { isSystemReminderBlock } from '@shellicar/claude-sdk';
 
 /** What the conversation list shows for one conversation, derived from its audit file. */
@@ -39,9 +40,11 @@ const BACKSLASH = 0x5c;
 
 /** How much of a line's head holds its scalar keys. On a user line role/turnId/queryId/timestamp all
  *  sit before the content starts; on an assistant line timestamp/costUsd/model do. */
-const PREFIX_BYTES = 256;
+export const PREFIX_BYTES = 256;
 /** How much of a line's tail holds usage/turnId/queryId on an assistant line. */
-const SUFFIX_BYTES = 2048;
+export const SUFFIX_BYTES = 2048;
+/** Marks a user line as a tool result rather than something said. */
+const TOOL_RESULT = '"type":"tool_result"';
 
 /**
  * Value of a string key within one window. The window is a latin1 decode of a bounded slice, never
@@ -91,6 +94,29 @@ const numberValue = (window: string, key: string): number | null => {
   return i === start ? null : Number(window.slice(start, i));
 };
 
+/**
+ * A timestamp that survived the scan, or null if it is not one.
+ *
+ * The scan lifts these by matching bytes in a file another tool may have written, so the value is a
+ * string that looked like a timestamp, not a timestamp. Everything downstream parses it to format a
+ * time or a duration, and a parse that throws there kills the render rather than spoiling a line.
+ *
+ * Checked here rather than per line: only two of a file's timestamps survive, so this costs two
+ * parses however large the conversation, where validating as they are read would cost one per line
+ * against the string comparison it replaces.
+ */
+const validTimestamp = (candidate: string | null): string | null => {
+  if (candidate === null) {
+    return null;
+  }
+  try {
+    Instant.parse(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+};
+
 type AuditContent = { type?: string; text?: string };
 type AuditLine = { content?: AuditContent[] | string };
 
@@ -125,9 +151,9 @@ const messageText = (line: AuditLine): string | null => {
  *
  * Two properties make this cheap enough to run on a keypress. Nothing is decoded but a bounded head
  * and tail window per line, so the megabyte tool-result lines are stepped over rather than read. And
- * `JSON.parse` runs at most twice for the file: only the first user line and the last assistant line
- * need their text, and which line is last is not known until the end, so its byte range is recorded
- * and decoded once the scan finishes.
+ * `JSON.parse` runs only on lines that can carry a message: the last assistant line, whose byte range
+ * is recorded as the scan goes because which line is last is not known until the end, and user lines
+ * until one yields text, skipping any whose head shows it opens with a tool result.
  *
  * Returns the empty summary for a file this CLI did not write (Claude Code's audit format nests
  * everything under `message`, so none of the top-level keys are found).
@@ -176,7 +202,9 @@ export function scanAuditSummary(bytes: Buffer): AuditSummary {
         summary.contextTokens = (numberValue(usage, 'input_tokens') ?? 0) + (numberValue(usage, 'cache_creation_input_tokens') ?? 0) + (numberValue(usage, 'cache_read_input_tokens') ?? 0);
         lastAssistantStart = from;
         lastAssistantEnd = end;
-      } else if (role === 'user' && summary.firstUserText === null) {
+      } else if (role === 'user' && summary.firstUserText === null && !head.includes(TOOL_RESULT)) {
+        // A tool result carries no message and can be megabytes of one. Its type shows in the head
+        // window, ahead of the payload, so the line is skipped without decoding what follows.
         summary.firstUserText = messageText(JSON.parse(bytes.toString('utf8', from, end)) as AuditLine);
       }
     }
@@ -188,6 +216,8 @@ export function scanAuditSummary(bytes: Buffer): AuditSummary {
 
   summary.turns = turnIds.size;
   summary.queries = queryIds.size;
+  summary.firstUtc = validTimestamp(summary.firstUtc);
+  summary.lastUtc = validTimestamp(summary.lastUtc);
   if (lastAssistantStart >= 0) {
     summary.lastAssistantText = messageText(JSON.parse(bytes.toString('utf8', lastAssistantStart, lastAssistantEnd)) as AuditLine);
   }

--- a/apps/claude-sdk-cli/src/conversations/validTimestamp.ts
+++ b/apps/claude-sdk-cli/src/conversations/validTimestamp.ts
@@ -1,0 +1,25 @@
+import { Instant } from '@js-joda/core';
+
+/**
+ * A timestamp that survived a scan, or null if it is not one.
+ *
+ * A scan lifts these by matching bytes in a file another tool may have written, so the value is a
+ * string that looked like a timestamp, not a timestamp. Everything downstream parses it to format a
+ * time or a duration, and a parse that throws there is not a spoiled line: the render runs in a
+ * deferred callback with nothing catching it, so the process exits.
+ *
+ * Checked where the value leaves the scan rather than as each line is read. A summary keeps two
+ * timestamps out of the whole file and a peek keeps one per shown line, so the cost is bounded by
+ * what is displayed rather than by the size of the conversation.
+ */
+export const validTimestamp = (candidate: string | null | undefined): string | null => {
+  if (candidate == null) {
+    return null;
+  }
+  try {
+    Instant.parse(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+};

--- a/apps/claude-sdk-cli/src/model/AppModeState.ts
+++ b/apps/claude-sdk-cli/src/model/AppModeState.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 
 /** Which presentation is active. */
-export type AppModeKey = 'primary' | 'history';
+export type AppModeKey = 'primary' | 'history' | 'conversations';
 
 type AppModeStateEvents = {
   change: [];

--- a/apps/claude-sdk-cli/src/model/ConversationListState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationListState.ts
@@ -47,6 +47,7 @@ export abstract class IConversationListState {
   public abstract setSummary(id: string, summary: AuditSummary): void;
   public abstract setPeek(id: string, peek: ConversationPeek): void;
   public abstract apply(action: ConversationAction): void;
+  public abstract enterAt(id: string): void;
   public abstract reset(): void;
 }
 
@@ -55,6 +56,8 @@ export class ConversationListState extends IConversationListState {
   #selected = 0;
   #peeked = false;
   #peek: ConversationPeek | undefined;
+  /** The conversation the view was opened on, held until it appears in a rebuilt list. */
+  #enteredId: string | undefined;
   readonly #emitter = new EventEmitter<ConversationListStateEvents>();
 
   public on<K extends keyof ConversationListStateEvents>(event: K, listener: (...args: ConversationListStateEvents[K]) => void): void {
@@ -88,12 +91,30 @@ export class ConversationListState extends IConversationListState {
   /** Replace the list, keeping the selection on the same conversation where it still exists — entering the
    *  view twice in a row should not silently move what is selected. */
   public setEntries(ids: readonly string[]): void {
-    const previousId = this.selectedEntry?.id;
     const bySummary = new Map(this.#entries.map((entry) => [entry.id, entry.summary]));
-    this.#entries = ids.map((id) => ({ id, summary: bySummary.get(id) }));
-    const restored = previousId === undefined ? -1 : this.#entries.findIndex((entry) => entry.id === previousId);
-    this.#selected = restored >= 0 ? restored : 0;
+    this.#reorder(
+      ids.map((id) => ({ id, summary: bySummary.get(id) })),
+      this.#enteredId ?? this.selectedEntry?.id,
+    );
     this.#emitter.emit('change');
+  }
+
+  /**
+   * Orders the list by when each conversation was last active, newest first, and puts the selection back
+   * on the conversation it was on.
+   *
+   * That timestamp is the one the row displays as its age, so the order is the one the operator can see
+   * rather than an invisible property like when the session store last recorded the conversation —
+   * which switching itself changes, so the list would reorder as a result of being used.
+   *
+   * A conversation whose summary has not loaded has no timestamp yet and sorts last, so rows settle as
+   * their summaries arrive rather than the list waiting to be shown.
+   */
+  #reorder(entries: ConversationEntry[], keepSelectedId: string | undefined): void {
+    const activity = (entry: ConversationEntry): string => entry.summary?.lastUtc ?? '';
+    this.#entries = [...entries].sort((left, right) => activity(right).localeCompare(activity(left)));
+    const restored = keepSelectedId === undefined ? -1 : this.#entries.findIndex((entry) => entry.id === keepSelectedId);
+    this.#selected = restored >= 0 ? restored : 0;
   }
 
   /** Land the peek's content. Ignores a read that lands after the operator moved on, so a slow peek can
@@ -114,6 +135,7 @@ export class ConversationListState extends IConversationListState {
       return;
     }
     entry.summary = summary;
+    this.#reorder(this.#entries, this.selectedEntry?.id);
     this.#emitter.emit('change');
   }
 
@@ -155,6 +177,8 @@ export class ConversationListState extends IConversationListState {
     if (this.#entries.length === 0) {
       return;
     }
+    // Moving is the operator choosing a row, which supersedes where entry put them.
+    this.#enteredId = undefined;
     const next = clamp(target, 0, this.#entries.length - 1);
     if (next === this.#selected) {
       return;
@@ -173,8 +197,26 @@ export class ConversationListState extends IConversationListState {
     this.#emitter.emit('change');
   }
 
-  /** Back to the newest conversation, folded. Called on entry so the view always opens at the top. */
+  /**
+   * Opens the view on a given conversation, folded — the one the process is on, so entry lands where the
+   * operator already is rather than at the top of the list.
+   *
+   * Records the id rather than an index: the list is rebuilt and reordered on entry, and the entries are
+   * seeded before their summaries decide the order, so an index chosen now would address a different
+   * conversation a moment later.
+   */
+  public enterAt(id: string): void {
+    this.#enteredId = id;
+    this.#peeked = false;
+    this.#peek = undefined;
+    const found = this.#entries.findIndex((entry) => entry.id === id);
+    this.#selected = found >= 0 ? found : 0;
+    this.#emitter.emit('change');
+  }
+
+  /** Back to the newest conversation, folded. */
   public reset(): void {
+    this.#enteredId = undefined;
     this.#selected = 0;
     this.#peeked = false;
     this.#peek = undefined;

--- a/apps/claude-sdk-cli/src/model/ConversationListState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationListState.ts
@@ -143,12 +143,14 @@ export class ConversationListState extends IConversationListState {
     }
   }
 
-  /** Move the selection, clamped: a move at either boundary is a no-op. Moving folds any open peek, so the
-   *  peek always belongs to the conversation currently selected. */
+  /** Move the selection, clamped: a move at either boundary is a no-op. */
   #move(delta: number): void {
     this.#moveTo(this.#selected + delta);
   }
 
+  /** A move keeps the peek open and drops only its content, so moving down a peeked list peeks each
+   *  conversation in turn rather than folding shut on the first move. The content belongs to the
+   *  conversation that was selected, so it goes; the loader fills the new one in. */
   #moveTo(target: number): void {
     if (this.#entries.length === 0) {
       return;
@@ -158,7 +160,6 @@ export class ConversationListState extends IConversationListState {
       return;
     }
     this.#selected = next;
-    this.#peeked = false;
     this.#peek = undefined;
     this.#emitter.emit('change');
   }

--- a/apps/claude-sdk-cli/src/model/ConversationListState.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationListState.ts
@@ -1,0 +1,182 @@
+import EventEmitter from 'node:events';
+import type { ConversationPeek } from '../conversations/scanAuditPeek.js';
+import type { AuditSummary } from '../conversations/scanAuditSummary.js';
+
+type ConversationListStateEvents = {
+  change: [];
+};
+
+/** One row of the conversation view. `summary` is undefined until its audit file has been read, which is
+ *  what lets the list paint from the session store alone and fill in behind. */
+export type ConversationEntry = {
+  id: string;
+  summary: AuditSummary | undefined;
+};
+
+/** The outline actions the key-map produces (see conversationKeyMap). */
+export type ConversationAction = 'prev' | 'next' | 'page-up' | 'page-down' | 'home' | 'end' | 'toggle-peek';
+
+/** Rows a page-up/page-down moves the selection. */
+const PAGE_ENTRIES = 5;
+
+const clamp = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(n, hi));
+
+/**
+ * The conversation view's state: which conversations exist for this directory, which is selected, and
+ * whether the selected one is peeked open.
+ *
+ * Peek is a flat toggle, not a level: it changes what the selected entry renders and nothing else, so
+ * up/down and the page keys always move the selection and never change meaning. That is the whole
+ * reason this state is so much smaller than HistoryViewState, which has an open/close level and a
+ * tools sub-level to arbitrate.
+ *
+ * `setEntries` seeds the ids (a synchronous store read); `setSummary` lands each summary as its audit
+ * file finishes reading. Every mutation emits change, so ViewHost repaints while the view is on screen.
+ */
+/** The state's contract; register abstract→concrete and depend on the abstract (DI rule). */
+export abstract class IConversationListState {
+  public abstract on<K extends keyof ConversationListStateEvents>(event: K, listener: (...args: ConversationListStateEvents[K]) => void): void;
+  public abstract off<K extends keyof ConversationListStateEvents>(event: K, listener: (...args: ConversationListStateEvents[K]) => void): void;
+  public abstract get entries(): readonly ConversationEntry[];
+  public abstract get selected(): number;
+  public abstract get peeked(): boolean;
+  /** The open peek's content, undefined while it is still being read. */
+  public abstract get peek(): ConversationPeek | undefined;
+  public abstract get selectedEntry(): ConversationEntry | undefined;
+  public abstract setEntries(ids: readonly string[]): void;
+  public abstract setSummary(id: string, summary: AuditSummary): void;
+  public abstract setPeek(id: string, peek: ConversationPeek): void;
+  public abstract apply(action: ConversationAction): void;
+  public abstract reset(): void;
+}
+
+export class ConversationListState extends IConversationListState {
+  #entries: ConversationEntry[] = [];
+  #selected = 0;
+  #peeked = false;
+  #peek: ConversationPeek | undefined;
+  readonly #emitter = new EventEmitter<ConversationListStateEvents>();
+
+  public on<K extends keyof ConversationListStateEvents>(event: K, listener: (...args: ConversationListStateEvents[K]) => void): void {
+    this.#emitter.on(event, listener);
+  }
+
+  public off<K extends keyof ConversationListStateEvents>(event: K, listener: (...args: ConversationListStateEvents[K]) => void): void {
+    this.#emitter.off(event, listener);
+  }
+
+  public get entries(): readonly ConversationEntry[] {
+    return this.#entries;
+  }
+
+  public get selected(): number {
+    return this.#selected;
+  }
+
+  public get peeked(): boolean {
+    return this.#peeked;
+  }
+
+  public get peek(): ConversationPeek | undefined {
+    return this.#peek;
+  }
+
+  public get selectedEntry(): ConversationEntry | undefined {
+    return this.#entries[this.#selected];
+  }
+
+  /** Replace the list, keeping the selection on the same conversation where it still exists — entering the
+   *  view twice in a row should not silently move what is selected. */
+  public setEntries(ids: readonly string[]): void {
+    const previousId = this.selectedEntry?.id;
+    const bySummary = new Map(this.#entries.map((entry) => [entry.id, entry.summary]));
+    this.#entries = ids.map((id) => ({ id, summary: bySummary.get(id) }));
+    const restored = previousId === undefined ? -1 : this.#entries.findIndex((entry) => entry.id === previousId);
+    this.#selected = restored >= 0 ? restored : 0;
+    this.#emitter.emit('change');
+  }
+
+  /** Land the peek's content. Ignores a read that lands after the operator moved on, so a slow peek can
+   *  never appear under a conversation it does not belong to. */
+  public setPeek(id: string, peek: ConversationPeek): void {
+    if (!this.#peeked || this.selectedEntry?.id !== id) {
+      return;
+    }
+    this.#peek = peek;
+    this.#emitter.emit('change');
+  }
+
+  /** Land a summary against its id. Silently ignores an id no longer listed: a read in flight when the
+   *  list is rebuilt lands late, and there is no row for it to fill. */
+  public setSummary(id: string, summary: AuditSummary): void {
+    const entry = this.#entries.find((candidate) => candidate.id === id);
+    if (entry === undefined) {
+      return;
+    }
+    entry.summary = summary;
+    this.#emitter.emit('change');
+  }
+
+  public apply(action: ConversationAction): void {
+    switch (action) {
+      case 'next':
+        this.#move(1);
+        return;
+      case 'prev':
+        this.#move(-1);
+        return;
+      case 'page-down':
+        this.#move(PAGE_ENTRIES);
+        return;
+      case 'page-up':
+        this.#move(-PAGE_ENTRIES);
+        return;
+      case 'home':
+        this.#moveTo(0);
+        return;
+      case 'end':
+        this.#moveTo(this.#entries.length - 1);
+        return;
+      case 'toggle-peek':
+        this.#togglePeek();
+        return;
+    }
+  }
+
+  /** Move the selection, clamped: a move at either boundary is a no-op. Moving folds any open peek, so the
+   *  peek always belongs to the conversation currently selected. */
+  #move(delta: number): void {
+    this.#moveTo(this.#selected + delta);
+  }
+
+  #moveTo(target: number): void {
+    if (this.#entries.length === 0) {
+      return;
+    }
+    const next = clamp(target, 0, this.#entries.length - 1);
+    if (next === this.#selected) {
+      return;
+    }
+    this.#selected = next;
+    this.#peeked = false;
+    this.#peek = undefined;
+    this.#emitter.emit('change');
+  }
+
+  #togglePeek(): void {
+    if (this.#entries.length === 0) {
+      return;
+    }
+    this.#peeked = !this.#peeked;
+    this.#peek = undefined;
+    this.#emitter.emit('change');
+  }
+
+  /** Back to the newest conversation, folded. Called on entry so the view always opens at the top. */
+  public reset(): void {
+    this.#selected = 0;
+    this.#peeked = false;
+    this.#peek = undefined;
+    this.#emitter.emit('change');
+  }
+}

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -48,6 +48,10 @@ export class ConversationSession extends IConversationSession {
     const historyPath = `${this.fs.homedir()}/.claude/conversations/${id}.jsonl`;
     const historyExists = await this.fs.exists(historyPath);
     if (!historyExists) {
+      // An id with no stored history is an empty conversation, not "leave what is loaded". The
+      // distinction only bites once a conversation can be adopted mid-process: whatever was in
+      // memory would become this conversation's history and be written back out under its id.
+      this.conversation.setHistory([]);
       return;
     }
     const raw = await this.fs.readFile(historyPath);

--- a/apps/claude-sdk-cli/src/model/ConversationSession.ts
+++ b/apps/claude-sdk-cli/src/model/ConversationSession.ts
@@ -74,16 +74,19 @@ export class ConversationSession extends IConversationSession {
     this.conversation.healDanglingToolUse(HEAL_REASON_ABANDONED);
   }
 
+  /** Loads first and adopts the id only once the history is in memory. The order matters: between the
+   *  two the process would otherwise claim to be the new conversation while still holding the old
+   *  one's messages, and anything saving in that window would write them out under the new id. */
   public async resume(id: string): Promise<void> {
-    this.#id = id;
     await this.#loadHistoryForId(id);
+    this.#id = id;
   }
 
   public async load(): Promise<void> {
     const savedId = this.sessionStore.mostRecentByCwd(this.fs.cwd());
     if (savedId !== undefined) {
+      await this.#loadHistoryForId(savedId);
       this.#id = savedId;
-      await this.#loadHistoryForId(this.#id);
     } else {
       this.#id = randomUUID();
     }

--- a/apps/claude-sdk-cli/src/model/PrimaryViewState.ts
+++ b/apps/claude-sdk-cli/src/model/PrimaryViewState.ts
@@ -13,6 +13,12 @@ type PrimaryViewStateEvents = {
  * selects the streaming chain. runAgent sets it around a turn; PrimaryView
  * reads it for the editor region; PrimaryPresentation reads it to pick the
  * active chain. Nested inside the primary, never a top-level mode.
+ *
+ * It also carries whether a conversation move is in flight. That sits beside the
+ * phase because the two together decide whether an action on the current
+ * conversation is available, and both are read to grey the ones that are not.
+ * Keeping it in a store rather than on the switcher is what lets a view read it
+ * without the view model bag carrying a service.
  */
 /** The state's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class IPrimaryViewState {
@@ -20,10 +26,14 @@ export abstract class IPrimaryViewState {
   public abstract off<K extends keyof PrimaryViewStateEvents>(event: K, listener: (...args: PrimaryViewStateEvents[K]) => void): void;
   public abstract get phase(): TurnPhase;
   public abstract setPhase(phase: TurnPhase): void;
+  /** True while the process is moving between conversations. */
+  public abstract get conversationMoving(): boolean;
+  public abstract setConversationMoving(moving: boolean): void;
 }
 
 export class PrimaryViewState extends IPrimaryViewState {
   #phase: TurnPhase = 'editor';
+  #conversationMoving = false;
   readonly #emitter = new EventEmitter<PrimaryViewStateEvents>();
 
   public on<K extends keyof PrimaryViewStateEvents>(event: K, listener: (...args: PrimaryViewStateEvents[K]) => void): void {
@@ -43,6 +53,18 @@ export class PrimaryViewState extends IPrimaryViewState {
       return;
     }
     this.#phase = phase;
+    this.#emitter.emit('change');
+  }
+
+  public get conversationMoving(): boolean {
+    return this.#conversationMoving;
+  }
+
+  public setConversationMoving(moving: boolean): void {
+    if (moving === this.#conversationMoving) {
+      return;
+    }
+    this.#conversationMoving = moving;
     this.#emitter.emit('change');
   }
 }

--- a/apps/claude-sdk-cli/src/persistence/SqliteSessionStore.ts
+++ b/apps/claude-sdk-cli/src/persistence/SqliteSessionStore.ts
@@ -33,6 +33,7 @@ const SESSION_MIGRATIONS: readonly Migration[] = [
 export abstract class ISqliteSessionStore {
   public abstract append(conversationId: string, cwd: string, timestamp: string): void;
   public abstract mostRecentByCwd(cwd: string): string | undefined;
+  public abstract listByCwd(cwd: string): readonly string[];
 }
 
 export class SqliteSessionStore extends ISqliteSessionStore {
@@ -51,5 +52,12 @@ export class SqliteSessionStore extends ISqliteSessionStore {
   public mostRecentByCwd(cwd: string): string | undefined {
     const row = this.#db.prepare('SELECT conversation_id FROM sessions WHERE cwd = ? ORDER BY id DESC LIMIT 1').get(cwd) as { conversation_id: string } | undefined;
     return row?.conversation_id;
+  }
+
+  /** Every conversation ever live under a directory, most recently written first. The log holds one row
+   *  per write, so the rows are grouped and ordered by each id's newest row. */
+  public listByCwd(cwd: string): readonly string[] {
+    const rows = this.#db.prepare('SELECT conversation_id FROM sessions WHERE cwd = ? GROUP BY conversation_id ORDER BY MAX(id) DESC').all(cwd) as { conversation_id: string }[];
+    return rows.map((row) => row.conversation_id);
   }
 }

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -44,33 +44,33 @@ export class ConversationSwitcher extends IConversationSwitcher {
   @dependsOn(IConversation) private readonly conversation!: IConversation;
   @dependsOn(IPrimaryViewState) private readonly primaryViewState!: IPrimaryViewState;
   @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<typeof sdkConfigSchema>;
-  /** A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
-   *  agent attachment against a conversation the first has not finished adopting. */
-  #moving = false;
-
   public async createNew(): Promise<void> {
-    if (this.#moving) {
+    if (this.primaryViewState.conversationMoving) {
       return;
     }
     await this.#move(() => this.#createNew());
   }
 
   public async switchTo(id: string): Promise<void> {
-    if (this.#moving || id === this.session.id) {
+    if (this.primaryViewState.conversationMoving || id === this.session.id) {
       return;
     }
     await this.#move(() => this.#switchTo(id));
   }
 
-  /** Holds the in-flight flag across one move, in the field the guard reads and in the store the views
-   *  read to grey what a move makes unavailable. */
+  /**
+   * Holds the in-flight flag across one move.
+   *
+   * A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
+   * agent attachment against a conversation the first has not finished adopting. The flag lives in the
+   * store rather than here so the guard and the views that grey what a move makes unavailable read one
+   * value, not two kept in step by hand.
+   */
   async #move(run: () => Promise<void>): Promise<void> {
-    this.#moving = true;
     this.primaryViewState.setConversationMoving(true);
     try {
       await run();
     } finally {
-      this.#moving = false;
       this.primaryViewState.setConversationMoving(false);
     }
   }

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -4,6 +4,7 @@ import { CacheTtl, IConversation } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
 import { AuditStats } from '../AuditStats.js';
 import { IAgentPresence } from '../agent/AgentPresence.js';
+import type { sdkConfigSchema } from '../cli-config/schema.js';
 import { IConvServe } from '../conv/ConvServe.js';
 import { IConversationSession } from '../model/ConversationSession.js';
 import { IConversationState } from '../model/ConversationState.js';
@@ -13,6 +14,9 @@ import { replayHistory } from '../replayHistory.js';
 
 /** The switcher's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class IConversationSwitcher {
+  /** True while a move is in flight. Read by the view so an option that would be refused is shown as
+   *  unavailable rather than appearing to be ignored. */
+  public abstract get moving(): boolean;
   public abstract createNew(): Promise<void>;
   public abstract switchTo(id: string): Promise<void>;
 }
@@ -40,10 +44,14 @@ export class ConversationSwitcher extends IConversationSwitcher {
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IConversation) private readonly conversation!: IConversation;
-  @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<any>;
+  @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<typeof sdkConfigSchema>;
   /** A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
    *  agent attachment against a conversation the first has not finished adopting. */
   #moving = false;
+
+  public get moving(): boolean {
+    return this.#moving;
+  }
 
   public async createNew(): Promise<void> {
     if (this.#moving) {

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -9,14 +9,12 @@ import { IConvServe } from '../conv/ConvServe.js';
 import { IConversationSession } from '../model/ConversationSession.js';
 import { IConversationState } from '../model/ConversationState.js';
 import { ISystemIdentity } from '../model/ISystemIdentity.js';
+import { IPrimaryViewState } from '../model/PrimaryViewState.js';
 import { StatusState } from '../model/StatusState.js';
 import { replayHistory } from '../replayHistory.js';
 
 /** The switcher's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class IConversationSwitcher {
-  /** True while a move is in flight. Read by the view so an option that would be refused is shown as
-   *  unavailable rather than appearing to be ignored. */
-  public abstract get moving(): boolean;
   public abstract createNew(): Promise<void>;
   public abstract switchTo(id: string): Promise<void>;
 }
@@ -44,36 +42,36 @@ export class ConversationSwitcher extends IConversationSwitcher {
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
   @dependsOn(IConversation) private readonly conversation!: IConversation;
+  @dependsOn(IPrimaryViewState) private readonly primaryViewState!: IPrimaryViewState;
   @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<typeof sdkConfigSchema>;
   /** A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
    *  agent attachment against a conversation the first has not finished adopting. */
   #moving = false;
 
-  public get moving(): boolean {
-    return this.#moving;
-  }
-
   public async createNew(): Promise<void> {
     if (this.#moving) {
       return;
     }
-    this.#moving = true;
-    try {
-      await this.#createNew();
-    } finally {
-      this.#moving = false;
-    }
+    await this.#move(() => this.#createNew());
   }
 
   public async switchTo(id: string): Promise<void> {
     if (this.#moving || id === this.session.id) {
       return;
     }
+    await this.#move(() => this.#switchTo(id));
+  }
+
+  /** Holds the in-flight flag across one move, in the field the guard reads and in the store the views
+   *  read to grey what a move makes unavailable. */
+  async #move(run: () => Promise<void>): Promise<void> {
     this.#moving = true;
+    this.primaryViewState.setConversationMoving(true);
     try {
-      await this.#switchTo(id);
+      await run();
     } finally {
       this.#moving = false;
+      this.primaryViewState.setConversationMoving(false);
     }
   }
 

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -1,0 +1,81 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { CacheTtl } from '@shellicar/claude-sdk';
+import { dependsOn } from '@shellicar/core-di';
+import { AuditStats } from '../AuditStats.js';
+import { IAgentPresence } from '../agent/AgentPresence.js';
+import { IConvServe } from '../conv/ConvServe.js';
+import { IConversationSession } from '../model/ConversationSession.js';
+import { IConversationState } from '../model/ConversationState.js';
+import { ISystemIdentity } from '../model/ISystemIdentity.js';
+import { StatusState } from '../model/StatusState.js';
+
+/** The switcher's contract; register abstract→concrete and depend on the abstract (DI rule). */
+export abstract class IConversationSwitcher {
+  public abstract createNew(): Promise<void>;
+  public abstract switchTo(id: string): Promise<void>;
+}
+
+/**
+ * Moves the process from one conversation to another, in place. Both entries — a fresh id
+ * (`/new`) and an existing one (the conversation view) — run the same lifecycle: re-point the
+ * wire serve, move the agent attachment, settle the system identity, reset the transcript, and
+ * re-derive the status figures from the new id's audit.
+ *
+ * The two differ in one place: a fresh id starts empty and INHERITS the running identity, while
+ * an existing one loads its own history and the identity it already owns.
+ *
+ * Neither re-resolves the system prompts. That is keyed by session id, but TurnCoordinator
+ * already checks `needsSystemPromptResolve` before every turn, so the move is picked up there
+ * rather than duplicated here.
+ */
+export class ConversationSwitcher extends IConversationSwitcher {
+  @dependsOn(IConversationSession) private readonly session!: IConversationSession;
+  @dependsOn(IConversationState) private readonly conversationState!: IConversationState;
+  @dependsOn(ISystemIdentity) private readonly systemIdentity!: ISystemIdentity;
+  @dependsOn(IAgentPresence) private readonly agentPresence!: IAgentPresence;
+  @dependsOn(IConvServe) private readonly convServe!: IConvServe;
+  @dependsOn(AuditStats) private readonly auditStats!: AuditStats;
+  @dependsOn(StatusState) private readonly statusState!: StatusState;
+  @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+
+  public async createNew(): Promise<void> {
+    const previousId = this.session.id;
+    await this.session.createNew();
+    this.#rebind(previousId);
+    this.systemIdentity.inherit(this.session.id);
+    this.conversationState.clear();
+    await this.#resetStatus();
+  }
+
+  public async switchTo(id: string): Promise<void> {
+    if (id === this.session.id) {
+      return;
+    }
+    const previousId = this.session.id;
+    // Persist the conversation being left before its history is replaced in memory: the
+    // transcript is written per turn, but the leaving turn's tip may not have been saved yet.
+    await this.session.saveConversation();
+    await this.session.resume(id);
+    await this.session.saveSession();
+    this.#rebind(previousId);
+    this.systemIdentity.load(this.session.id);
+    this.conversationState.clear();
+    await this.#resetStatus();
+  }
+
+  /** A run is process + conversation, so a move re-points the addressable subject: the wire serve
+   *  binds to the new id, and the agent attachment detaches the old and attaches the new. */
+  #rebind(previousId: string): void {
+    this.convServe.bind(this.session.id);
+    this.agentPresence.detach(previousId);
+    this.agentPresence.attach(this.session.id, this.fs.cwd());
+  }
+
+  /** Re-derive the status figures for the current id. A fresh id has no audit file, so this reads
+   *  empty and the "clear on new" behaviour falls out of the single id-keyed rule. The TTL is
+   *  inert except for a legacy flat-only audit line, so the default is passed rather than
+   *  threading the config provider. */
+  async #resetStatus(): Promise<void> {
+    this.statusState.resetTo(await this.auditStats.derive(this.session.id, CacheTtl.OneHour));
+  }
+}

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -37,8 +37,35 @@ export class ConversationSwitcher extends IConversationSwitcher {
   @dependsOn(AuditStats) private readonly auditStats!: AuditStats;
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  /** A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
+   *  agent attachment against a conversation the first has not finished adopting. */
+  #moving = false;
 
   public async createNew(): Promise<void> {
+    if (this.#moving) {
+      return;
+    }
+    this.#moving = true;
+    try {
+      await this.#createNew();
+    } finally {
+      this.#moving = false;
+    }
+  }
+
+  public async switchTo(id: string): Promise<void> {
+    if (this.#moving || id === this.session.id) {
+      return;
+    }
+    this.#moving = true;
+    try {
+      await this.#switchTo(id);
+    } finally {
+      this.#moving = false;
+    }
+  }
+
+  async #createNew(): Promise<void> {
     const previousId = this.session.id;
     await this.session.createNew();
     this.#rebind(previousId);
@@ -47,10 +74,7 @@ export class ConversationSwitcher extends IConversationSwitcher {
     await this.#resetStatus();
   }
 
-  public async switchTo(id: string): Promise<void> {
-    if (id === this.session.id) {
-      return;
-    }
+  async #switchTo(id: string): Promise<void> {
     const previousId = this.session.id;
     // Persist the conversation being left before its history is replaced in memory: the
     // transcript is written per turn, but the leaving turn's tip may not have been saved yet.

--- a/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
+++ b/apps/claude-sdk-cli/src/setup/ConversationSwitcher.ts
@@ -1,5 +1,6 @@
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
-import { CacheTtl } from '@shellicar/claude-sdk';
+import { CacheTtl, IConversation } from '@shellicar/claude-sdk';
 import { dependsOn } from '@shellicar/core-di';
 import { AuditStats } from '../AuditStats.js';
 import { IAgentPresence } from '../agent/AgentPresence.js';
@@ -8,6 +9,7 @@ import { IConversationSession } from '../model/ConversationSession.js';
 import { IConversationState } from '../model/ConversationState.js';
 import { ISystemIdentity } from '../model/ISystemIdentity.js';
 import { StatusState } from '../model/StatusState.js';
+import { replayHistory } from '../replayHistory.js';
 
 /** The switcher's contract; register abstract→concrete and depend on the abstract (DI rule). */
 export abstract class IConversationSwitcher {
@@ -37,6 +39,8 @@ export class ConversationSwitcher extends IConversationSwitcher {
   @dependsOn(AuditStats) private readonly auditStats!: AuditStats;
   @dependsOn(StatusState) private readonly statusState!: StatusState;
   @dependsOn(IFileSystem) private readonly fs!: IFileSystem;
+  @dependsOn(IConversation) private readonly conversation!: IConversation;
+  @dependsOn(ConfigLoader) private readonly configLoader!: ConfigLoader<any>;
   /** A move is a transaction: the second of two overlapping ones would rebind the wire serve and the
    *  agent attachment against a conversation the first has not finished adopting. */
   #moving = false;
@@ -84,7 +88,22 @@ export class ConversationSwitcher extends IConversationSwitcher {
     this.#rebind(previousId);
     this.systemIdentity.load(this.session.id);
     this.conversationState.clear();
+    this.#replayHistory();
     await this.#resetStatus();
+  }
+
+  /** Puts the adopted conversation on screen. Loading it makes the model aware of it; without this the
+   *  operator arrives at what looks like an empty conversation. Same replay the boot sequence runs when
+   *  the process starts on a resumed conversation. */
+  #replayHistory(): void {
+    if (!this.configLoader.config.historyReplay.enabled) {
+      return;
+    }
+    const history = this.conversation.messages;
+    if (history.length === 0) {
+      return;
+    }
+    this.conversationState.addBlocks(replayHistory(history, this.configLoader.config.historyReplay));
   }
 
   /** A run is process + conversation, so a move re-points the addressable subject: the wire serve

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -547,7 +547,6 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
         IConversationListState,
         IAppModeState,
         IConversationSession,
-        IConversationSwitcher,
         ConfigLoader,
         Clock,
         TerminalRenderer,
@@ -569,7 +568,6 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
         conversationListState,
         appModeState,
         session,
-        conversationSwitcher,
         configLoader,
         clock,
         terminalRenderer,
@@ -592,7 +590,6 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
           appModeState,
           session,
           configLoader,
-          conversationSwitcher,
           clock,
         };
         const presentations: ReadonlyMap<AppModeKey, Presentation> = new Map<AppModeKey, Presentation>([

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -61,6 +61,7 @@ import { AuditWriter } from '../AuditWriter.js';
 import { AgentPresence, IAgentPresence } from '../agent/AgentPresence.js';
 import { AgentServe, IAgentServe } from '../agent/AgentServe.js';
 import { AgentServicer, IAgentServicer } from '../agent/AgentServicer.js';
+import { ConversationPresentation } from '../app/ConversationPresentation.js';
 import { HistoryPresentation } from '../app/HistoryPresentation.js';
 import type { Presentation } from '../app/Presentation.js';
 import { PrimaryPresentation } from '../app/PrimaryPresentation.js';
@@ -75,6 +76,7 @@ import { ApprovalHandler } from '../controller/ApprovalHandler.js';
 import { CancelHandler } from '../controller/CancelHandler.js';
 import { CommandIntentExecutor } from '../controller/CommandIntentExecutor.js';
 import { CommandKeyHandler } from '../controller/CommandKeyHandler.js';
+import { ConversationNavHandler } from '../controller/ConversationNavHandler.js';
 import { EditorHandler } from '../controller/EditorHandler.js';
 import { HistoryNavHandler } from '../controller/HistoryNavHandler.js';
 import type { InputHandler } from '../controller/InputHandler.js';
@@ -86,6 +88,9 @@ import { ConvServe, IConvServe } from '../conv/ConvServe.js';
 import { ConvServicer, IConvServicer } from '../conv/ConvServicer.js';
 import { ConvTelemetryProjector, IConvTelemetryProjector } from '../conv/ConvTelemetryProjector.js';
 import { IWireSayInbox, WireSayInbox } from '../conv/WireSayInbox.js';
+import { ConversationListLoader, IConversationListLoader } from '../conversations/ConversationListLoader.js';
+import { ConversationPeekLoader, IConversationPeekLoader } from '../conversations/ConversationPeekLoader.js';
+import { ConversationSummaryLoader, IConversationSummaryLoader } from '../conversations/ConversationSummaryLoader.js';
 import { createAppTools } from '../createAppTools.js';
 import { GitStateMonitor } from '../GitStateMonitor.js';
 import { logger } from '../logger.js';
@@ -95,6 +100,7 @@ import { ApprovalNotifier } from '../model/ApprovalNotifier.js';
 import { AttachmentSource } from '../model/AttachmentSource.js';
 import { RequestClockAdapter, ToolsClockAdapter } from '../model/ClockListeners.js';
 import { CommandModeState, ICommandModeState } from '../model/CommandModeState.js';
+import { ConversationListState, IConversationListState } from '../model/ConversationListState.js';
 import { ConversationSession, IConversationSession } from '../model/ConversationSession.js';
 import { ConversationState, IConversationState } from '../model/ConversationState.js';
 import { DisabledToolsNoticeGate } from '../model/DisabledToolsNoticeGate.js';
@@ -131,6 +137,7 @@ import { ReadLine } from '../ReadLine.js';
 import { SystemPromptLoader } from '../SystemPromptLoader.js';
 import { EnvProvider } from '../secrets/EnvProvider.js';
 import { ISecrets, Secrets } from '../secrets/Secrets.js';
+import { ConversationView } from '../view/ConversationView.js';
 import { Flasher } from '../view/Flasher.js';
 import { HistoryView } from '../view/HistoryView.js';
 import { PrimaryView } from '../view/PrimaryView.js';
@@ -145,6 +152,7 @@ import { ConfigRulesConfigProvider, IRulesConfigNotifier, readToolsRaw } from '.
 import { ConsumerChannel } from './ConsumerChannel.js';
 import { ConsumerMessageRouter, IConsumerMessageRouter } from './ConsumerMessageRouter.js';
 import { ConversationBootSequence, IConversationBootSequence } from './ConversationBootSequence.js';
+import { ConversationSwitcher, IConversationSwitcher } from './ConversationSwitcher.js';
 import { CwdTracker } from './CwdTracker.js';
 import { DurableConfigFactory } from './DurableConfigFactory.js';
 import { GitMemoryEnvironmentProvider } from './GitMemoryEnvironmentProvider.js';
@@ -440,6 +448,7 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
   services.register(ScrollState).as(IScrollState);
   services.register(AppModeState).as(IAppModeState);
   services.register(HistoryViewState).as(IHistoryViewState);
+  services.register(ConversationListState).as(IConversationListState);
 
   // --- app services ---
   services.register(AuditStats).asSelf();
@@ -458,6 +467,11 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
     .asSelf();
 
   // --- handlers ---
+  services.register(ConversationSwitcher).as(IConversationSwitcher);
+  services.register(ConversationSummaryLoader).as(IConversationSummaryLoader);
+  services.register(ConversationPeekLoader).as(IConversationPeekLoader);
+  services.register(ConversationListLoader).as(IConversationListLoader);
+  services.register(ConversationNavHandler).asSelf();
   services.register(CommandIntentExecutor).asSelf();
   services.register(ShutdownCoordinator).as(IShutdownCoordinator);
   // QuitHandler may not import the setup layer (controller ⇛ setup), so the
@@ -489,6 +503,7 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
   // --- views & presentations (assembled chains/maps are composition-root work) ---
   services.register(PrimaryView).asSelf();
   services.register(HistoryView).asSelf();
+  services.register(ConversationView).asSelf();
   services
     .register(TerminalRenderer)
     .using([Screen, ITerminalState], (screen, terminalState) => new TerminalRenderer(screen, terminalState))
@@ -509,10 +524,57 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
     })
     .asSelf();
   services
+    .register(ConversationPresentation)
+    .using([QuitHandler, ViewSelectHandler, ConversationNavHandler, ConversationView], (quit, viewSelect, conversationNav, conversationView) => {
+      const chain: readonly InputHandler[] = [quit, viewSelect, conversationNav];
+      return new ConversationPresentation(conversationView, chain);
+    })
+    .asSelf();
+  services
     .register(ViewHost)
     .using(
-      [IConversationState, IEditorState, IToolApprovalState, ICommandModeState, StatusState, ITurnClock, ITerminalState, IPrimaryViewState, IScrollState, IHistoryViewState, IAppModeState, IConversationSession, ConfigLoader, TerminalRenderer, PrimaryPresentation, HistoryPresentation],
-      (conversationState, editorState, toolApprovalState, commandModeState, statusState, turnClock, terminalState, primaryViewState, scrollState, historyViewState, appModeState, session, configLoader, terminalRenderer, primaryPresentation, historyPresentation) => {
+      [
+        IConversationState,
+        IEditorState,
+        IToolApprovalState,
+        ICommandModeState,
+        StatusState,
+        ITurnClock,
+        ITerminalState,
+        IPrimaryViewState,
+        IScrollState,
+        IHistoryViewState,
+        IConversationListState,
+        IAppModeState,
+        IConversationSession,
+        ConfigLoader,
+        Clock,
+        TerminalRenderer,
+        PrimaryPresentation,
+        HistoryPresentation,
+        ConversationPresentation,
+      ],
+      (
+        conversationState,
+        editorState,
+        toolApprovalState,
+        commandModeState,
+        statusState,
+        turnClock,
+        terminalState,
+        primaryViewState,
+        scrollState,
+        historyViewState,
+        conversationListState,
+        appModeState,
+        session,
+        configLoader,
+        clock,
+        terminalRenderer,
+        primaryPresentation,
+        historyPresentation,
+        conversationPresentation,
+      ) => {
         const model: ViewModel = {
           conversationState,
           editorState,
@@ -524,13 +586,16 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
           primaryViewState,
           scrollState,
           historyViewState,
+          conversationListState,
           appModeState,
           session,
           configLoader,
+          clock,
         };
         const presentations: ReadonlyMap<AppModeKey, Presentation> = new Map<AppModeKey, Presentation>([
           ['primary', primaryPresentation],
           ['history', historyPresentation],
+          ['conversations', conversationPresentation],
         ]);
         return new ViewHost(terminalRenderer, model, presentations, appModeState);
       },

--- a/apps/claude-sdk-cli/src/setup/container.ts
+++ b/apps/claude-sdk-cli/src/setup/container.ts
@@ -547,6 +547,7 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
         IConversationListState,
         IAppModeState,
         IConversationSession,
+        IConversationSwitcher,
         ConfigLoader,
         Clock,
         TerminalRenderer,
@@ -568,6 +569,7 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
         conversationListState,
         appModeState,
         session,
+        conversationSwitcher,
         configLoader,
         clock,
         terminalRenderer,
@@ -590,6 +592,7 @@ export function buildContainer(options: ContainerOptions): IServiceCollection {
           appModeState,
           session,
           configLoader,
+          conversationSwitcher,
           clock,
         };
         const presentations: ReadonlyMap<AppModeKey, Presentation> = new Map<AppModeKey, Presentation>([

--- a/apps/claude-sdk-cli/src/view/ConversationView.ts
+++ b/apps/claude-sdk-cli/src/view/ConversationView.ts
@@ -76,10 +76,10 @@ export class ConversationView implements View {
    *  drawn whole in grey with the reason, which is what tells the operator it will do nothing — switching
    *  is refused while a turn is running, because the turn belongs to the conversation being left. */
   #hints(model: ViewModel): string {
-    const canSwitch = model.primaryViewState.phase === 'editor';
+    const canSwitch = model.primaryViewState.phase === 'editor' && !model.primaryViewState.conversationMoving;
     const key = (glyph: string, effect: string): string => `${CYAN}${glyph}${RESET} ${DIM}${effect}${RESET}`;
     const refused = (glyph: string, effect: string, why: string): string => `${DIM}${glyph} ${effect} (${why})${RESET}`;
-    const switchHint = canSwitch ? key('\u23ce', 'switch') : refused('\u23ce', 'switch', 'turn running');
+    const switchHint = canSwitch ? key('\u23ce', 'switch') : refused('\u23ce', 'switch', model.primaryViewState.conversationMoving ? 'switching' : 'turn running');
     return ` ${key('\u2191\u2193', 'select')}    ${key('space', 'peek')}    ${switchHint}`;
   }
 

--- a/apps/claude-sdk-cli/src/view/ConversationView.ts
+++ b/apps/claude-sdk-cli/src/view/ConversationView.ts
@@ -1,0 +1,149 @@
+import { ZoneId } from '@js-joda/core';
+import { BOLD_WHITE, CYAN, DIM, GOLD, RESET } from '@shellicar/claude-core/ansi';
+import { getContextWindow } from '@shellicar/claude-sdk';
+import stringWidth from 'string-width';
+import type { ConversationEntry } from '../model/ConversationListState.js';
+import { formatAge, formatContext, formatCost, formatModel, formatSpan, formatTimeOfDay, oneLine, PENDING } from './formatConversationEntry.js';
+import { renderViewBar } from './renderViewBar.js';
+import type { View, ViewModel } from './View.js';
+
+/** Marks the conversation this process is currently on. */
+const CURRENT = '●';
+/** Marks the selected row. Two columns, so selecting never reflows the line. */
+const CURSOR = '> ';
+const NO_CURSOR = '  ';
+
+const USER = '👤';
+const ASSISTANT = '🤖';
+const TOOLS = '🔧';
+const GAP = '⋮';
+/** The gap marker stands in the emoji column, under a blank timestamp. `⋮` is one column where an
+ *  emoji is two, so it carries an extra trailing space to keep the text column aligned. */
+const GAP_PREFIX = `  ${' '.repeat(8)} ${GAP}   `;
+
+/** Rows a peek shows. Fixed: peek is a flat toggle, not something that grows. */
+export const PEEK_LINES = 10;
+
+/** Truncate to a visual width, so a double-width emoji costs the two columns it occupies. */
+const fit = (text: string, width: number): string => {
+  if (width <= 0) {
+    return '';
+  }
+  if (stringWidth(text) <= width) {
+    return text;
+  }
+  let out = '';
+  for (const char of text) {
+    if (stringWidth(out + char) > width - 1) {
+      return `${out}…`;
+    }
+    out += char;
+  }
+  return out;
+};
+
+/**
+ * The conversation view: every conversation ever live in this directory, four lines each — who and
+ * when, the figures, the opening ask, the last reply. The selected one can be peeked open, which
+ * inserts the tail of the conversation between its two preview lines.
+ *
+ * A row renders the same whatever else is on screen: peek adds lines to one entry and never changes
+ * the shape of the others. Figures not yet read render as a dotted placeholder of the same width they
+ * will occupy, so nothing jumps when a summary lands.
+ *
+ * Render-only: the loader fills summaries, the state owns selection and the peek flag.
+ */
+export class ConversationView implements View {
+  public render(model: ViewModel): string[] {
+    const { conversationListState, terminalState, appModeState, session, statusState } = model;
+    const cols = terminalState.cols;
+    const rows = terminalState.rows;
+    const zone = ZoneId.systemDefault();
+
+    const header = `${DIM} conversations in ${statusState.cwdBasename}${RESET}`;
+    const bar = renderViewBar(appModeState.active);
+    // Header, blank, and the footer bar.
+    const bodyHeight = Math.max(1, rows - 3);
+
+    const blocks = conversationListState.entries.map((entry, index) => this.#entryLines(entry, index === conversationListState.selected, entry.id === session.id, conversationListState.peeked && index === conversationListState.selected, model, cols, zone));
+
+    const body = blocks.length === 0 ? [`${DIM}  no conversations recorded in this directory${RESET}`] : this.#windowed(blocks, conversationListState.selected, bodyHeight);
+
+    return [header, '', ...body.slice(0, bodyHeight), ...Array(Math.max(0, bodyHeight - body.length)).fill(''), bar];
+  }
+
+  /** Scroll so the selected entry is on screen, keeping whole entries: the list moves by entry, never
+   *  leaving a row half-drawn at the top edge. */
+  #windowed(blocks: string[][], selected: number, height: number): string[] {
+    const flat = blocks.flat();
+    if (flat.length <= height) {
+      return flat;
+    }
+    let before = 0;
+    for (let i = 0; i < selected; i++) {
+      before += blocks[i]?.length ?? 0;
+    }
+    const selectedHeight = blocks[selected]?.length ?? 0;
+    // Keep the selection visible: scroll only far enough to bring it fully into view.
+    const start = Math.max(0, Math.min(before, flat.length - height, Math.max(0, before + selectedHeight - height)));
+    return flat.slice(start, start + height);
+  }
+
+  #entryLines(entry: ConversationEntry, selected: boolean, current: boolean, peeked: boolean, model: ViewModel, cols: number, zone: ZoneId): string[] {
+    const gutter = selected ? `${CYAN}${CURSOR}${RESET}` : NO_CURSOR;
+    const summary = entry.summary;
+    const mark = current ? `${CYAN}${CURRENT}${RESET} ` : '  ';
+    const model_ = summary === undefined ? PENDING : formatModel(summary.model);
+    const age = summary === undefined ? PENDING : formatAge(summary.lastUtc, model.clock.instant());
+    const id = selected ? `${BOLD_WHITE}${entry.id}${RESET}` : `${DIM}${entry.id}${RESET}`;
+    const identity = `${gutter}${mark}${model_}  ${id}  🕐 ${age}`;
+
+    const figures =
+      summary === undefined
+        ? `${gutter}    ${DIM}💬 ${PENDING}  🔄 ${PENDING}  📊 ${PENDING}  ${PENDING}  ⏱ ${PENDING}${RESET}`
+        : `${gutter}    💬 ${summary.queries}q  🔄 ${summary.turns}t  📊 ${formatContext(summary, getContextWindow(summary.model ?? ''))}  ${GOLD}${formatCost(summary.costUsd)}${RESET}  ⏱ ${formatSpan(summary.firstUtc, summary.lastUtc)}`;
+
+    const lines = [fit(identity, cols), fit(figures, cols)];
+    const previewWidth = cols - 4;
+
+    if (peeked) {
+      lines.push(...this.#peekLines(entry, model, previewWidth, zone));
+      return lines;
+    }
+
+    lines.push(fit(`${gutter}  ${DIM}${this.#previewTime(summary?.firstUtc, zone)}${RESET} ${USER}  ${this.#preview(summary?.firstUserText, summary === undefined)}`, cols));
+    lines.push(fit(`${gutter}  ${DIM}${this.#previewTime(summary?.lastUtc, zone)}${RESET} ${ASSISTANT}  ${this.#preview(summary?.lastAssistantText, summary === undefined)}`, cols));
+    return lines;
+  }
+
+  /** The peek: the opening ask, the gap counter, then the tail of the conversation in order. The two
+   *  preview lines are the ends of the same timeline, so nothing is shown twice. */
+  #peekLines(entry: ConversationEntry, model: ViewModel, width: number, zone: ZoneId): string[] {
+    const peek = model.conversationListState.peek;
+    const summary = entry.summary;
+    const lines = [fit(`  ${DIM}${this.#previewTime(summary?.firstUtc, zone)}${RESET} ${USER}  ${this.#preview(summary?.firstUserText, summary === undefined)}`, width + 4)];
+    if (peek === undefined) {
+      lines.push(`${DIM}${GAP_PREFIX}reading…${RESET}`);
+      return lines;
+    }
+    if (peek.earlier > 0) {
+      lines.push(`${DIM}${GAP_PREFIX}${peek.earlier} earlier messages${RESET}`);
+    }
+    for (const item of peek.entries) {
+      const glyph = item.kind === 'user' ? USER : item.kind === 'assistant' ? ASSISTANT : TOOLS;
+      lines.push(fit(`  ${DIM}${this.#previewTime(item.timestampUtc, zone)}${RESET} ${glyph}  ${oneLine(item.text)}`, width + 4));
+    }
+    return lines;
+  }
+
+  #previewTime(whenUtc: string | null | undefined, zone: ZoneId): string {
+    return formatTimeOfDay(whenUtc ?? null, zone);
+  }
+
+  #preview(text: string | null | undefined, pending: boolean): string {
+    if (pending) {
+      return `${DIM}${PENDING}${RESET}`;
+    }
+    return text == null || text.length === 0 ? `${DIM}(no message)${RESET}` : oneLine(text);
+  }
+}

--- a/apps/claude-sdk-cli/src/view/ConversationView.ts
+++ b/apps/claude-sdk-cli/src/view/ConversationView.ts
@@ -72,15 +72,15 @@ export class ConversationView implements View {
     return [header, '', ...body.slice(0, bodyHeight), ...Array(Math.max(0, bodyHeight - body.length)).fill(''), hints, bar];
   }
 
-  /** What the keys do, with switching dimmed while a turn is running. Enter is refused then, because the
-   *  turn belongs to the conversation being left; showing it greyed is what tells the operator that,
-   *  rather than the key appearing to do nothing. */
+  /** What the keys do: the key itself accented, its effect beside it. A key that would be refused is
+   *  drawn whole in grey with the reason, which is what tells the operator it will do nothing — switching
+   *  is refused while a turn is running, because the turn belongs to the conversation being left. */
   #hints(model: ViewModel): string {
     const canSwitch = model.primaryViewState.phase === 'editor';
-    const move = `${DIM}\u2191\u2193 select${RESET}`;
-    const peek = `${DIM}space peek${RESET}`;
-    const enter = canSwitch ? `${CYAN}\u23ce switch${RESET}` : `${DIM}\u23ce switch (turn running)${RESET}`;
-    return ` ${move}    ${peek}    ${enter}`;
+    const key = (glyph: string, effect: string): string => `${CYAN}${glyph}${RESET} ${DIM}${effect}${RESET}`;
+    const refused = (glyph: string, effect: string, why: string): string => `${DIM}${glyph} ${effect} (${why})${RESET}`;
+    const switchHint = canSwitch ? key('\u23ce', 'switch') : refused('\u23ce', 'switch', 'turn running');
+    return ` ${key('\u2191\u2193', 'select')}    ${key('space', 'peek')}    ${switchHint}`;
   }
 
   /** Scroll so the selected entry is on screen, keeping whole entries: the list moves by entry, never

--- a/apps/claude-sdk-cli/src/view/ConversationView.ts
+++ b/apps/claude-sdk-cli/src/view/ConversationView.ts
@@ -19,10 +19,7 @@ const TOOLS = '🔧';
 const GAP = '⋮';
 /** The gap marker stands in the emoji column, under a blank timestamp. `⋮` is one column where an
  *  emoji is two, so it carries an extra trailing space to keep the text column aligned. */
-const GAP_PREFIX = `  ${' '.repeat(8)} ${GAP}   `;
-
-/** Rows a peek shows. Fixed: peek is a flat toggle, not something that grows. */
-export const PEEK_LINES = 10;
+const GAP_PREFIX = `${' '.repeat(8)} ${GAP}   `;
 
 /** Truncate to a visual width, so a double-width emoji costs the two columns it occupies. */
 const fit = (text: string, width: number): string => {
@@ -61,15 +58,29 @@ export class ConversationView implements View {
     const zone = ZoneId.systemDefault();
 
     const header = `${DIM} conversations in ${statusState.cwdBasename}${RESET}`;
+    const hints = this.#hints(model);
     const bar = renderViewBar(appModeState.active);
-    // Header, blank, and the footer bar.
-    const bodyHeight = Math.max(1, rows - 3);
+    // Header, the blank under it, the key hints and the footer bar.
+    const bodyHeight = Math.max(1, rows - 4);
 
-    const blocks = conversationListState.entries.map((entry, index) => this.#entryLines(entry, index === conversationListState.selected, entry.id === session.id, conversationListState.peeked && index === conversationListState.selected, model, cols, zone));
+    // A blank line after each entry, so the four lines of one conversation read as a block rather than
+    // running into the next. It belongs to the entry so the scroll window moves whole entries with it.
+    const blocks = conversationListState.entries.map((entry, index) => [...this.#entryLines(entry, index === conversationListState.selected, entry.id === session.id, conversationListState.peeked && index === conversationListState.selected, model, cols, zone), '']);
 
     const body = blocks.length === 0 ? [`${DIM}  no conversations recorded in this directory${RESET}`] : this.#windowed(blocks, conversationListState.selected, bodyHeight);
 
-    return [header, '', ...body.slice(0, bodyHeight), ...Array(Math.max(0, bodyHeight - body.length)).fill(''), bar];
+    return [header, '', ...body.slice(0, bodyHeight), ...Array(Math.max(0, bodyHeight - body.length)).fill(''), hints, bar];
+  }
+
+  /** What the keys do, with switching dimmed while a turn is running. Enter is refused then, because the
+   *  turn belongs to the conversation being left; showing it greyed is what tells the operator that,
+   *  rather than the key appearing to do nothing. */
+  #hints(model: ViewModel): string {
+    const canSwitch = model.primaryViewState.phase === 'editor';
+    const move = `${DIM}\u2191\u2193 select${RESET}`;
+    const peek = `${DIM}space peek${RESET}`;
+    const enter = canSwitch ? `${CYAN}\u23ce switch${RESET}` : `${DIM}\u23ce switch (turn running)${RESET}`;
+    return ` ${move}    ${peek}    ${enter}`;
   }
 
   /** Scroll so the selected entry is on screen, keeping whole entries: the list moves by entry, never
@@ -104,10 +115,9 @@ export class ConversationView implements View {
         : `${gutter}    💬 ${summary.queries}q  🔄 ${summary.turns}t  📊 ${formatContext(summary, getContextWindow(summary.model ?? ''))}  ${GOLD}${formatCost(summary.costUsd)}${RESET}  ⏱ ${formatSpan(summary.firstUtc, summary.lastUtc)}`;
 
     const lines = [fit(identity, cols), fit(figures, cols)];
-    const previewWidth = cols - 4;
 
     if (peeked) {
-      lines.push(...this.#peekLines(entry, model, previewWidth, zone));
+      lines.push(...this.#peekLines(entry, model, gutter, cols, zone));
       return lines;
     }
 
@@ -117,21 +127,22 @@ export class ConversationView implements View {
   }
 
   /** The peek: the opening ask, the gap counter, then the tail of the conversation in order. The two
-   *  preview lines are the ends of the same timeline, so nothing is shown twice. */
-  #peekLines(entry: ConversationEntry, model: ViewModel, width: number, zone: ZoneId): string[] {
+   *  preview lines are the ends of the same timeline, so nothing is shown twice. Every line carries the
+   *  selection gutter, because the whole unfold belongs to the selected conversation. */
+  #peekLines(entry: ConversationEntry, model: ViewModel, gutter: string, cols: number, zone: ZoneId): string[] {
     const peek = model.conversationListState.peek;
     const summary = entry.summary;
-    const lines = [fit(`  ${DIM}${this.#previewTime(summary?.firstUtc, zone)}${RESET} ${USER}  ${this.#preview(summary?.firstUserText, summary === undefined)}`, width + 4)];
+    const lines = [fit(`${gutter}  ${DIM}${this.#previewTime(summary?.firstUtc, zone)}${RESET} ${USER}  ${this.#preview(summary?.firstUserText, summary === undefined)}`, cols)];
     if (peek === undefined) {
-      lines.push(`${DIM}${GAP_PREFIX}reading…${RESET}`);
+      lines.push(`${gutter}${DIM}${GAP_PREFIX}reading…${RESET}`);
       return lines;
     }
     if (peek.earlier > 0) {
-      lines.push(`${DIM}${GAP_PREFIX}${peek.earlier} earlier messages${RESET}`);
+      lines.push(`${gutter}${DIM}${GAP_PREFIX}${peek.earlier} earlier messages${RESET}`);
     }
     for (const item of peek.entries) {
       const glyph = item.kind === 'user' ? USER : item.kind === 'assistant' ? ASSISTANT : TOOLS;
-      lines.push(fit(`  ${DIM}${this.#previewTime(item.timestampUtc, zone)}${RESET} ${glyph}  ${oneLine(item.text)}`, width + 4));
+      lines.push(fit(`${gutter}  ${DIM}${this.#previewTime(item.timestampUtc, zone)}${RESET} ${glyph}  ${oneLine(item.text)}`, cols));
     }
     return lines;
   }

--- a/apps/claude-sdk-cli/src/view/PrimaryView.ts
+++ b/apps/claude-sdk-cli/src/view/PrimaryView.ts
@@ -50,7 +50,7 @@ export class PrimaryView implements View {
     const { approvalRow, expandedRows: toolRows } = renderToolApproval(toolApprovalState, cols, Math.floor(rows / 2));
     // Starting a conversation is refused while a turn runs or a move is in flight; the row greys the
     // option so the key reads as unavailable rather than ignored.
-    const canStartNew = model.primaryViewState.phase === 'editor' && !model.conversationSwitcher.moving;
+    const canStartNew = model.primaryViewState.phase === 'editor' && !model.primaryViewState.conversationMoving;
     const { commandRow, editorRows, previewRows } = renderCommandMode(commandModeState, session.id, cols, Math.max(1, Math.floor(rows / 3)), Math.floor(rows / 2), canStartNew);
     const expandedRows = [...toolRows, ...previewRows];
     // editorRows (the cd path editor) sit above the command row; both add to the fixed footer height.

--- a/apps/claude-sdk-cli/src/view/PrimaryView.ts
+++ b/apps/claude-sdk-cli/src/view/PrimaryView.ts
@@ -48,7 +48,10 @@ export class PrimaryView implements View {
     const rows = terminalState.rows;
 
     const { approvalRow, expandedRows: toolRows } = renderToolApproval(toolApprovalState, cols, Math.floor(rows / 2));
-    const { commandRow, editorRows, previewRows } = renderCommandMode(commandModeState, session.id, cols, Math.max(1, Math.floor(rows / 3)), Math.floor(rows / 2));
+    // Starting a conversation is refused while a turn runs or a move is in flight; the row greys the
+    // option so the key reads as unavailable rather than ignored.
+    const canStartNew = model.primaryViewState.phase === 'editor' && !model.conversationSwitcher.moving;
+    const { commandRow, editorRows, previewRows } = renderCommandMode(commandModeState, session.id, cols, Math.max(1, Math.floor(rows / 3)), Math.floor(rows / 2), canStartNew);
     const expandedRows = [...toolRows, ...previewRows];
     // editorRows (the cd path editor) sit above the command row; both add to the fixed footer height.
     const statusBarHeight = 6 + editorRows.length + expandedRows.length;

--- a/apps/claude-sdk-cli/src/view/View.ts
+++ b/apps/claude-sdk-cli/src/view/View.ts
@@ -14,7 +14,6 @@ import type { IScrollState } from '../model/ScrollState.js';
 import type { StatusState } from '../model/StatusState.js';
 import type { ITerminalState } from '../model/TerminalState.js';
 import type { IToolApprovalState } from '../model/ToolApprovalState.js';
-import type { IConversationSwitcher } from '../setup/ConversationSwitcher.js';
 
 /**
  * The shared model bag every view reads from. A view picks the stores it
@@ -43,9 +42,6 @@ export type ViewModel = {
   conversationListState: IConversationListState;
   appModeState: IAppModeState;
   session: IConversationSession;
-  /** Read for one thing: whether a conversation move is in flight, so an option that would be refused
-   *  is shown as unavailable. */
-  conversationSwitcher: IConversationSwitcher;
   configLoader: ConfigLoader<typeof sdkConfigSchema>;
   /** Wall-clock, injected rather than read from the system, so a view that shows an age is provable. */
   clock: Clock;

--- a/apps/claude-sdk-cli/src/view/View.ts
+++ b/apps/claude-sdk-cli/src/view/View.ts
@@ -14,6 +14,7 @@ import type { IScrollState } from '../model/ScrollState.js';
 import type { StatusState } from '../model/StatusState.js';
 import type { ITerminalState } from '../model/TerminalState.js';
 import type { IToolApprovalState } from '../model/ToolApprovalState.js';
+import type { IConversationSwitcher } from '../setup/ConversationSwitcher.js';
 
 /**
  * The shared model bag every view reads from. A view picks the stores it
@@ -42,6 +43,9 @@ export type ViewModel = {
   conversationListState: IConversationListState;
   appModeState: IAppModeState;
   session: IConversationSession;
+  /** Read for one thing: whether a conversation move is in flight, so an option that would be refused
+   *  is shown as unavailable. */
+  conversationSwitcher: IConversationSwitcher;
   configLoader: ConfigLoader<typeof sdkConfigSchema>;
   /** Wall-clock, injected rather than read from the system, so a view that shows an age is provable. */
   clock: Clock;

--- a/apps/claude-sdk-cli/src/view/View.ts
+++ b/apps/claude-sdk-cli/src/view/View.ts
@@ -1,7 +1,9 @@
+import type { Clock } from '@js-joda/core';
 import type { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import type { sdkConfigSchema } from '../cli-config/schema.js';
 import type { IAppModeState } from '../model/AppModeState.js';
 import type { ICommandModeState } from '../model/CommandModeState.js';
+import type { IConversationListState } from '../model/ConversationListState.js';
 import type { IConversationSession } from '../model/ConversationSession.js';
 import type { IConversationState } from '../model/ConversationState.js';
 import type { IEditorState } from '../model/EditorState.js';
@@ -37,9 +39,12 @@ export type ViewModel = {
   primaryViewState: IPrimaryViewState;
   scrollState: IScrollState;
   historyViewState: IHistoryViewState;
+  conversationListState: IConversationListState;
   appModeState: IAppModeState;
   session: IConversationSession;
   configLoader: ConfigLoader<typeof sdkConfigSchema>;
+  /** Wall-clock, injected rather than read from the system, so a view that shows an age is provable. */
+  clock: Clock;
 };
 
 /**

--- a/apps/claude-sdk-cli/src/view/formatConversationEntry.ts
+++ b/apps/claude-sdk-cli/src/view/formatConversationEntry.ts
@@ -1,0 +1,88 @@
+import { DateTimeFormatter, Duration, Instant, type ZoneId } from '@js-joda/core';
+import type { AuditSummary } from '../conversations/scanAuditSummary.js';
+
+/** Shown in place of a figure whose audit file has not been read yet. */
+export const PENDING = '·····';
+
+/** Compact token count: 407198 → `407.2k`, 1200000 → `1.2M`. */
+export const formatTokens = (tokens: number): string => {
+  if (tokens >= 1_000_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    return `${(tokens / 1_000).toFixed(1)}k`;
+  }
+  return String(tokens);
+};
+
+/** Elapsed wall-clock, coarsened as it grows: `3m`, `1h 31m`, `3h 23m`. Seconds only under a minute,
+ *  since a conversation's span is never interesting to the second. */
+export const formatSpan = (fromUtc: string | null, toUtc: string | null): string => {
+  if (fromUtc === null || toUtc === null) {
+    return PENDING;
+  }
+  const span = Duration.between(Instant.parse(fromUtc), Instant.parse(toUtc));
+  const hours = span.toHours();
+  const minutes = span.toMinutes() % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${span.seconds()}s`;
+};
+
+/** How long ago, for finding "the one from this morning": `just now`, `2h ago`, `3d ago`. */
+export const formatAge = (thenUtc: string | null, nowUtc: Instant): string => {
+  if (thenUtc === null) {
+    return PENDING;
+  }
+  const elapsed = Duration.between(Instant.parse(thenUtc), nowUtc);
+  const days = elapsed.toDays();
+  if (days > 0) {
+    return `${days}d ago`;
+  }
+  const hours = elapsed.toHours();
+  if (hours > 0) {
+    return `${hours}h ago`;
+  }
+  const minutes = elapsed.toMinutes();
+  return minutes > 0 ? `${minutes}m ago` : 'just now';
+};
+
+/** The transcript's own time format, so a conversation line reads the same in both views. Note
+ *  LocalTime.toString() is not this: it omits zero seconds, so 21:28:00 renders as `21:28`. */
+const TIME_FORMAT = DateTimeFormatter.ofPattern('HH:mm:ss');
+
+/** Wall-clock time of a message, in the operator's own zone. */
+export const formatTimeOfDay = (whenUtc: string | null, zone: ZoneId): string => {
+  if (whenUtc === null) {
+    return '--:--:--';
+  }
+  return Instant.parse(whenUtc).atZone(zone).toLocalTime().format(TIME_FORMAT);
+};
+
+/** The model without its vendor prefix — `claude-sonnet-5` is `sonnet-5` in a list of Claude models. */
+export const formatModel = (model: string | null): string => {
+  if (model === null) {
+    return PENDING;
+  }
+  return model.startsWith('claude-') ? model.slice('claude-'.length) : model;
+};
+
+/** Cost to four decimals, matching the status line rather than inventing a second money format. */
+export const formatCost = (costUsd: number): string => `$${costUsd.toFixed(4)}`;
+
+/** Context as used-of-window with the percentage, the same shape the status line uses. */
+export const formatContext = (summary: AuditSummary, contextWindow: number): string => {
+  if (contextWindow <= 0) {
+    return formatTokens(summary.contextTokens);
+  }
+  const percent = ((summary.contextTokens / contextWindow) * 100).toFixed(1);
+  return `${formatTokens(summary.contextTokens)}/${formatTokens(contextWindow)} (${percent}%)`;
+};
+
+/** Collapse a message to one line: newlines become spaces, runs of whitespace close up. A preview is a
+ *  single line whatever the message's own shape was. */
+export const oneLine = (text: string): string => text.replace(/\s+/g, ' ').trim();

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -30,7 +30,7 @@ export type CommandModeRender = {
  * Math.max(1, Math.floor(totalRows / 3))). maxRows is the absolute cap on
  * previewRows length (caller passes Math.floor(totalRows / 2)).
  */
-export function renderCommandMode(state: ICommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number, canStartNew = true): CommandModeRender {
+export function renderCommandMode(state: ICommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number, canStartNew: boolean): CommandModeRender {
   return {
     commandRow: buildCommandRow(state, conversationId, canStartNew),
     editorRows: buildEditorRows(state, cols),

--- a/apps/claude-sdk-cli/src/view/renderCommandMode.ts
+++ b/apps/claude-sdk-cli/src/view/renderCommandMode.ts
@@ -30,9 +30,9 @@ export type CommandModeRender = {
  * Math.max(1, Math.floor(totalRows / 3))). maxRows is the absolute cap on
  * previewRows length (caller passes Math.floor(totalRows / 2)).
  */
-export function renderCommandMode(state: ICommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number): CommandModeRender {
+export function renderCommandMode(state: ICommandModeState, conversationId: string, cols: number, maxTextLines: number, maxRows: number, canStartNew = true): CommandModeRender {
   return {
-    commandRow: buildCommandRow(state, conversationId),
+    commandRow: buildCommandRow(state, conversationId, canStartNew),
     editorRows: buildEditorRows(state, cols),
     previewRows: buildPreviewRows(state, cols, maxTextLines, maxRows),
   };
@@ -76,7 +76,19 @@ function buildCursorRows(editor: IEditorState, cols: number, blue: boolean): str
   return wrapLine(` ${painted}`, cols);
 }
 
-function buildCommandRow(state: ICommandModeState, conversationId: string): string {
+/** Writes one option, greyed when it cannot run. Grey means the key will do nothing, so an option that
+ *  would be refused reads as unavailable rather than appearing to be ignored. */
+function option(b: StatusLineBuilder, text: string, available: boolean): void {
+  if (available) {
+    b.text(text);
+    return;
+  }
+  b.ansi(DIM);
+  b.text(text);
+  b.ansi(RESET);
+}
+
+function buildCommandRow(state: ICommandModeState, conversationId: string, canStartNew: boolean): string {
   const hasAttachments = state.hasAttachments;
   if (!state.commandMode && !hasAttachments) {
     return '';
@@ -140,10 +152,10 @@ function buildCommandRow(state: ICommandModeState, conversationId: string): stri
       b.text('  d directory  \u00b7  ESC back');
     } else if (state.context === 'cdEdit') {
       b.text('  ESC back');
-    } else if (hasAttachments) {
-      b.text('  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  n new  \u00b7  ESC cancel');
     } else {
-      b.text('  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  n new  \u00b7  ESC cancel');
+      b.text(hasAttachments ? '  \u2190 \u2192 select  d del  p prev  \u00b7  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  ' : '  t paste  \u00b7  f file  \u00b7  i img  \u00b7  m model  \u00b7  c cd  \u00b7  ');
+      option(b, 'n new', canStartNew);
+      b.text('  \u00b7  ESC cancel');
     }
   }
   return b.output;

--- a/apps/claude-sdk-cli/src/view/renderViewBar.ts
+++ b/apps/claude-sdk-cli/src/view/renderViewBar.ts
@@ -4,6 +4,7 @@ import type { AppModeKey } from '../model/AppModeState.js';
 const VIEWS: ReadonlyArray<{ key: AppModeKey; bind: string; label: string }> = [
   { key: 'primary', bind: 'F1', label: 'primary' },
   { key: 'history', bind: 'F2', label: 'history' },
+  { key: 'conversations', bind: 'F3', label: 'conversations' },
 ];
 
 /**

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -22,6 +22,7 @@ import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { IWorkingDirectory, WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { ISqliteSessionStore, SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
+import { ConversationSwitcher, IConversationSwitcher } from '../src/setup/ConversationSwitcher.js';
 import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
 import { MemoryObjectStore } from './MemoryObjectStore.js';
@@ -119,6 +120,7 @@ function makeExecutor(source: AttachmentSource) {
     .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
     .asSelf();
   services.register(WorkingDirectory).asSelf().as(IWorkingDirectory);
+  services.register(ConversationSwitcher).as(IConversationSwitcher);
   services.register(CommandIntentExecutor).asSelf();
   const provider = services.buildProvider();
   const executor = provider.resolve(CommandIntentExecutor);

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -19,6 +19,7 @@ import { ConversationSession, IConversationSession } from '../src/model/Conversa
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
+import { IPrimaryViewState, PrimaryViewState } from '../src/model/PrimaryViewState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { IWorkingDirectory, WorkingDirectory } from '../src/model/WorkingDirectory.js';
@@ -125,6 +126,7 @@ function makeExecutor(source: AttachmentSource) {
     .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
     .asSelf();
   services.register(WorkingDirectory).asSelf().as(IWorkingDirectory);
+  services.register(PrimaryViewState).asSelf().as(IPrimaryViewState);
   services.register(ConversationSwitcher).as(IConversationSwitcher);
   services.register(CommandIntentExecutor).asSelf();
   const provider = services.buildProvider();
@@ -132,7 +134,8 @@ function makeExecutor(source: AttachmentSource) {
   const conversationState = provider.resolve(ConversationState);
   const session = provider.resolve(ConversationSession);
   const statusState = provider.resolve(StatusState);
-  return { executor, commandModeState, conversationState, session, cycleCalls, modelCalls, statusState };
+  const primaryViewState = provider.resolve(PrimaryViewState);
+  return { executor, commandModeState, conversationState, session, cycleCalls, modelCalls, statusState, primaryViewState };
 }
 
 const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -238,6 +241,27 @@ describe('CommandIntentExecutor — newSession', () => {
     conversationState.addBlocks([{ type: 'response', content: 'old' }]);
     await executor.execute('newSession');
     const expected = 0;
+    const actual = conversationState.sealedBlocks.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('CommandIntentExecutor — newSession during a turn', () => {
+  it('does not start a new conversation while a turn is running', async () => {
+    const { executor, session, primaryViewState } = makeExecutor(new FakeAttachmentSource());
+    const before = session.id;
+    primaryViewState.setPhase('streaming');
+    await executor.execute('newSession');
+    const actual = session.id;
+    expect(actual).toBe(before);
+  });
+
+  it("leaves the running turn's conversation on screen", async () => {
+    const { executor, conversationState, primaryViewState } = makeExecutor(new FakeAttachmentSource());
+    conversationState.addBlocks([{ type: 'response', content: 'mid-turn output' }]);
+    primaryViewState.setPhase('streaming');
+    await executor.execute('newSession');
+    const expected = 1;
     const actual = conversationState.sealedBlocks.length;
     expect(actual).toBe(expected);
   });

--- a/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandIntentExecutor.spec.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -86,6 +87,10 @@ function makeExecutor(source: AttachmentSource) {
     .using(() => new MemoryObjectStore())
     .asSelf();
   services.register(SystemIdentity).as(ISystemIdentity);
+  services
+    .register(ConfigLoader)
+    .using(() => ({ config: { historyReplay: { enabled: false, showThinking: false } } }) as unknown as ConfigLoader<never>)
+    .asSelf();
   services
     .register(AttachmentSource)
     .using(() => source)

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -23,6 +23,7 @@ import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { IWorkingDirectory, WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { ISqliteSessionStore, SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
+import { ConversationSwitcher, IConversationSwitcher } from '../src/setup/ConversationSwitcher.js';
 import { FakeAttachmentSource } from './FakeAttachmentSource.js';
 import { MemoryFileSystem } from './MemoryFileSystem.js';
 import { MemoryObjectStore } from './MemoryObjectStore.js';
@@ -119,6 +120,7 @@ function makeHandler(sourceText: string | null = null) {
     .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
     .asSelf();
   services.register(WorkingDirectory).asSelf().as(IWorkingDirectory);
+  services.register(ConversationSwitcher).as(IConversationSwitcher);
   services.register(CommandIntentExecutor).asSelf();
   services.register(CommandKeyHandler).asSelf();
   const handler = services.buildProvider().resolve(CommandKeyHandler);

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -20,6 +20,7 @@ import { ConversationSession, IConversationSession } from '../src/model/Conversa
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
+import { IPrimaryViewState, PrimaryViewState } from '../src/model/PrimaryViewState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { IWorkingDirectory, WorkingDirectory } from '../src/model/WorkingDirectory.js';
@@ -125,6 +126,7 @@ function makeHandler(sourceText: string | null = null) {
     .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
     .asSelf();
   services.register(WorkingDirectory).asSelf().as(IWorkingDirectory);
+  services.register(PrimaryViewState).asSelf().as(IPrimaryViewState);
   services.register(ConversationSwitcher).as(IConversationSwitcher);
   services.register(CommandIntentExecutor).asSelf();
   services.register(CommandKeyHandler).asSelf();

--- a/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/CommandKeyHandler.spec.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -86,6 +87,10 @@ function makeHandler(sourceText: string | null = null) {
     .using(() => new MemoryObjectStore())
     .asSelf();
   services.register(SystemIdentity).as(ISystemIdentity);
+  services
+    .register(ConfigLoader)
+    .using(() => ({ config: { historyReplay: { enabled: false, showThinking: false } } }) as unknown as ConfigLoader<never>)
+    .asSelf();
   services
     .register(AttachmentSource)
     .using(() => source)

--- a/apps/claude-sdk-cli/test/ConversationListState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationListState.spec.ts
@@ -75,14 +75,14 @@ describe('ConversationListState — setSummary', () => {
     const state = listOf('conv-a', 'conv-b');
     state.setSummary('conv-b', summaryOf({ costUsd: 9.5 }));
     const expected = 9.5;
-    const actual = state.entries[1]?.summary?.costUsd;
+    const actual = state.entries.find((entry) => entry.id === 'conv-b')?.summary?.costUsd;
     expect(actual).toBe(expected);
   });
 
   it('leaves other entries unfilled', () => {
     const state = listOf('conv-a', 'conv-b');
     state.setSummary('conv-b', summaryOf());
-    const actual = state.entries[0]?.summary;
+    const actual = state.entries.find((entry) => entry.id === 'conv-a')?.summary;
     expect(actual).toBeUndefined();
   });
 
@@ -92,6 +92,34 @@ describe('ConversationListState — setSummary', () => {
     state.setSummary('conv-a', summaryOf());
     const actual = state.entries[0]?.summary;
     expect(actual).toBeUndefined();
+  });
+});
+
+describe('ConversationListState — order', () => {
+  it('puts the most recently active conversation first', () => {
+    const state = listOf('conv-old', 'conv-new');
+    state.setSummary('conv-old', summaryOf({ lastUtc: '2026-07-28T10:00:00.000Z' }));
+    state.setSummary('conv-new', summaryOf({ lastUtc: '2026-07-28T13:00:00.000Z' }));
+    const expected = 'conv-new';
+    const actual = state.entries[0]?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('puts a conversation whose summary has not loaded last, so the list can be shown before it is read', () => {
+    const state = listOf('conv-unread', 'conv-known');
+    state.setSummary('conv-known', summaryOf({ lastUtc: '2026-07-28T10:00:00.000Z' }));
+    const expected = 'conv-unread';
+    const actual = state.entries[1]?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the selection on its conversation when a summary reorders the list', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('next');
+    const selectedBefore = state.selectedEntry?.id;
+    state.setSummary('conv-b', summaryOf({ lastUtc: '2026-07-28T13:00:00.000Z' }));
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(selectedBefore);
   });
 });
 
@@ -159,6 +187,61 @@ describe('ConversationListState — selection', () => {
     state.apply('next');
     const expected = 0;
     const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ConversationListState — entry', () => {
+  it('opens on the conversation asked for rather than the top of the list', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.enterAt('conv-b');
+    const expected = 'conv-b';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('stays on that conversation when the rebuilt list reorders around it', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.enterAt('conv-b');
+    state.setEntries(['conv-new', 'conv-a', 'conv-b']);
+    const expected = 'conv-b';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('stays on that conversation when a summary lands and reorders the list', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.enterAt('conv-b');
+    state.setSummary('conv-a', summaryOf({ lastUtc: '2026-07-29T13:00:00.000Z' }));
+    const expected = 'conv-b';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('follows the operator once they move off it', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.enterAt('conv-b');
+    state.apply('prev');
+    state.setEntries(['conv-a', 'conv-b']);
+    const expected = 'conv-a';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('opens at the top when the conversation asked for is not listed', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.enterAt('conv-elsewhere');
+    const expected = 'conv-a';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('folds any open peek', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('toggle-peek');
+    state.enterAt('conv-b');
+    const expected = false;
+    const actual = state.peeked;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/ConversationListState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationListState.spec.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import type { AuditSummary } from '../src/conversations/scanAuditSummary.js';
+import { ConversationListState } from '../src/model/ConversationListState.js';
+
+const summaryOf = (overrides: Partial<AuditSummary> = {}): AuditSummary => ({
+  turns: 1,
+  queries: 1,
+  costUsd: 1,
+  firstUtc: '2026-07-28T10:00:00.000Z',
+  lastUtc: '2026-07-28T10:01:00.000Z',
+  model: 'claude-sonnet-5',
+  contextTokens: 100,
+  firstUserText: 'the opening ask',
+  lastAssistantText: 'the reply',
+  ...overrides,
+});
+
+const listOf = (...ids: string[]): ConversationListState => {
+  const state = new ConversationListState();
+  state.setEntries(ids);
+  return state;
+};
+
+describe('ConversationListState — entries', () => {
+  it('lists one entry per conversation id', () => {
+    const state = listOf('conv-a', 'conv-b');
+    const expected = 2;
+    const actual = state.entries.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('starts an entry with no summary, so the view can paint before the audit is read', () => {
+    const state = listOf('conv-a');
+    const actual = state.entries[0]?.summary;
+    expect(actual).toBeUndefined();
+  });
+
+  it('selects the newest conversation on first load', () => {
+    const state = listOf('conv-a', 'conv-b');
+    const expected = 0;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the selection on the same conversation when the list is rebuilt', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('next');
+    state.setEntries(['conv-new', 'conv-a', 'conv-b']);
+    const expected = 'conv-b';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('falls back to the newest when the selected conversation is gone', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('next');
+    state.setEntries(['conv-a']);
+    const expected = 'conv-a';
+    const actual = state.selectedEntry?.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps a summary already loaded when the list is rebuilt', () => {
+    const state = listOf('conv-a');
+    state.setSummary('conv-a', summaryOf({ costUsd: 4.2 }));
+    state.setEntries(['conv-a', 'conv-b']);
+    const expected = 4.2;
+    const actual = state.entries[0]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ConversationListState — setSummary', () => {
+  it('lands the summary against its conversation', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.setSummary('conv-b', summaryOf({ costUsd: 9.5 }));
+    const expected = 9.5;
+    const actual = state.entries[1]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves other entries unfilled', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.setSummary('conv-b', summaryOf());
+    const actual = state.entries[0]?.summary;
+    expect(actual).toBeUndefined();
+  });
+
+  it('ignores a summary for a conversation no longer listed', () => {
+    const state = listOf('conv-a');
+    state.setEntries(['conv-b']);
+    state.setSummary('conv-a', summaryOf());
+    const actual = state.entries[0]?.summary;
+    expect(actual).toBeUndefined();
+  });
+});
+
+describe('ConversationListState — selection', () => {
+  it('moves down the list', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('next');
+    const expected = 1;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('stays put at the bottom', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('next');
+    state.apply('next');
+    const expected = 1;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('stays put at the top', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('prev');
+    const expected = 0;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('moves a page at a time', () => {
+    const state = listOf('a', 'b', 'c', 'd', 'e', 'f', 'g');
+    state.apply('page-down');
+    const expected = 5;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('clamps a page move to the last conversation', () => {
+    const state = listOf('a', 'b', 'c');
+    state.apply('page-down');
+    const expected = 2;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('jumps to the last conversation on end', () => {
+    const state = listOf('a', 'b', 'c');
+    state.apply('end');
+    const expected = 2;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('jumps to the first conversation on home', () => {
+    const state = listOf('a', 'b', 'c');
+    state.apply('end');
+    state.apply('home');
+    const expected = 0;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not move on an empty list', () => {
+    const state = listOf();
+    state.apply('next');
+    const expected = 0;
+    const actual = state.selected;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ConversationListState — peek', () => {
+  it('opens the peek on the selected conversation', () => {
+    const state = listOf('conv-a');
+    state.apply('toggle-peek');
+    const expected = true;
+    const actual = state.peeked;
+    expect(actual).toBe(expected);
+  });
+
+  it('closes the peek when toggled again', () => {
+    const state = listOf('conv-a');
+    state.apply('toggle-peek');
+    state.apply('toggle-peek');
+    const expected = false;
+    const actual = state.peeked;
+    expect(actual).toBe(expected);
+  });
+
+  it('folds the peek when the selection moves', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('toggle-peek');
+    state.apply('next');
+    const expected = false;
+    const actual = state.peeked;
+    expect(actual).toBe(expected);
+  });
+
+  it('does not peek an empty list', () => {
+    const state = listOf();
+    state.apply('toggle-peek');
+    const expected = false;
+    const actual = state.peeked;
+    expect(actual).toBe(expected);
+  });
+
+  it('folds the peek on reset', () => {
+    const state = listOf('conv-a');
+    state.apply('toggle-peek');
+    state.reset();
+    const expected = false;
+    const actual = state.peeked;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ConversationListState.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationListState.spec.ts
@@ -181,13 +181,31 @@ describe('ConversationListState — peek', () => {
     expect(actual).toBe(expected);
   });
 
-  it('folds the peek when the selection moves', () => {
+  it('stays open when the selection moves', () => {
     const state = listOf('conv-a', 'conv-b');
     state.apply('toggle-peek');
     state.apply('next');
-    const expected = false;
+    const expected = true;
     const actual = state.peeked;
     expect(actual).toBe(expected);
+  });
+
+  it('drops the content of the conversation moved away from', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('toggle-peek');
+    state.setPeek('conv-a', { entries: [{ kind: 'user', text: 'from conv-a', toolCount: 0, timestampUtc: null }], earlier: 0 });
+    state.apply('next');
+    const actual = state.peek;
+    expect(actual).toBeUndefined();
+  });
+
+  it('ignores content that lands for the conversation just moved away from', () => {
+    const state = listOf('conv-a', 'conv-b');
+    state.apply('toggle-peek');
+    state.apply('next');
+    state.setPeek('conv-a', { entries: [{ kind: 'user', text: 'from conv-a', toolCount: 0, timestampUtc: null }], earlier: 0 });
+    const actual = state.peek;
+    expect(actual).toBeUndefined();
   });
 
   it('does not peek an empty list', () => {

--- a/apps/claude-sdk-cli/test/ConversationSummaryLoader.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSummaryLoader.spec.ts
@@ -1,0 +1,122 @@
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { createServiceCollection, Lifetime } from '@shellicar/core-di';
+import { describe, expect, it } from 'vitest';
+import { ConversationSummaryLoader } from '../src/conversations/ConversationSummaryLoader.js';
+import { ConversationListState, IConversationListState } from '../src/model/ConversationListState.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
+
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+const auditFor = (id: string): string => `/home/user/.claude/audit/${id}.jsonl`;
+
+const auditContent = (text: string, costUsd: number): string =>
+  [
+    JSON.stringify({ role: 'user', turnId: 'turn-1', queryId: 'query-1', timestamp: '2026-07-28T10:00:00.000Z', content: [{ type: 'text', text }] }),
+    JSON.stringify({ timestamp: '2026-07-28T10:01:00.000Z', costUsd, model: 'claude-sonnet-5', role: 'assistant', content: [{ type: 'text', text: 'the reply' }], usage: { input_tokens: 1, cache_creation_input_tokens: 2, cache_read_input_tokens: 3 }, turnId: 'turn-1', queryId: 'query-1' }),
+  ].join('\n');
+
+function makeLoader(files: Record<string, string>) {
+  const fs = new MemoryFileSystem(files, '/home/user', '/project');
+  const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
+  services
+    .register(IFileSystem)
+    .using(() => fs)
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => noopLogger)
+    .asSelf();
+  services.register(ConversationListState).asSelf().as(IConversationListState);
+  services.register(ConversationSummaryLoader).asSelf();
+  const provider = services.buildProvider();
+  return { loader: provider.resolve(ConversationSummaryLoader), listState: provider.resolve(ConversationListState), fs };
+}
+
+/** Lets every queued read settle, since the loader walks one file per tick. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+};
+
+describe('ConversationSummaryLoader', () => {
+  it('fills in the summary for a listed conversation', async () => {
+    const { loader, listState } = makeLoader({ [auditFor('conv-a')]: auditContent('the opening ask', 3.5) });
+    listState.setEntries(['conv-a']);
+    loader.load(['conv-a']);
+    await settle();
+    const expected = 3.5;
+    const actual = listState.entries[0]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('fills in every listed conversation', async () => {
+    const { loader, listState } = makeLoader({ [auditFor('conv-a')]: auditContent('first', 1), [auditFor('conv-b')]: auditContent('second', 2) });
+    listState.setEntries(['conv-a', 'conv-b']);
+    loader.load(['conv-a', 'conv-b']);
+    await settle();
+    const expected = 2;
+    const actual = listState.entries[1]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('reads the opening ask into the summary', async () => {
+    const { loader, listState } = makeLoader({ [auditFor('conv-a')]: auditContent('so after all this time', 1) });
+    listState.setEntries(['conv-a']);
+    loader.load(['conv-a']);
+    await settle();
+    const expected = 'so after all this time';
+    const actual = listState.entries[0]?.summary?.firstUserText;
+    expect(actual).toBe(expected);
+  });
+
+  it('summarises a conversation with no audit file as empty rather than leaving it unfilled', async () => {
+    const { loader, listState } = makeLoader({});
+    listState.setEntries(['conv-a']);
+    loader.load(['conv-a']);
+    await settle();
+    const expected = 0;
+    const actual = listState.entries[0]?.summary?.turns;
+    expect(actual).toBe(expected);
+  });
+
+  it('serves an unchanged conversation from cache without re-reading', async () => {
+    const { loader, listState, fs } = makeLoader({ [auditFor('conv-a')]: auditContent('the opening ask', 3.5) });
+    listState.setEntries(['conv-a']);
+    loader.load(['conv-a']);
+    await settle();
+    await fs.writeFile(auditFor('conv-a'), auditContent('rewritten identically', 9.9).slice(0, auditContent('the opening ask', 3.5).length));
+    loader.load(['conv-a']);
+    await settle();
+    const expected = 3.5;
+    const actual = listState.entries[0]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('re-reads a conversation whose audit file has grown', async () => {
+    const { loader, listState, fs } = makeLoader({ [auditFor('conv-a')]: auditContent('the opening ask', 3.5) });
+    listState.setEntries(['conv-a']);
+    loader.load(['conv-a']);
+    await settle();
+    await fs.writeFile(
+      auditFor('conv-a'),
+      `${auditContent('the opening ask', 3.5)}\n${JSON.stringify({ timestamp: '2026-07-28T10:02:00.000Z', costUsd: 1.5, model: 'claude-sonnet-5', role: 'assistant', content: [{ type: 'text', text: 'a later reply' }], usage: { input_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }, turnId: 'turn-2', queryId: 'query-1' })}`,
+    );
+    loader.load(['conv-a']);
+    await settle();
+    const expected = 5;
+    const actual = listState.entries[0]?.summary?.costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('stops reading the rest of a list once a newer one is loaded', async () => {
+    const { loader, listState } = makeLoader({ [auditFor('conv-a')]: auditContent('first', 1), [auditFor('conv-b')]: auditContent('second', 2) });
+    listState.setEntries(['conv-a', 'conv-b']);
+    loader.load(['conv-a', 'conv-b']);
+    loader.load([]);
+    await settle();
+    const actual = listState.entries[1]?.summary;
+    expect(actual).toBeUndefined();
+  });
+});

--- a/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
@@ -144,6 +144,19 @@ describe('ConversationSwitcher — switchTo', () => {
     const actual = conversation.messages.length;
     expect(actual).toBe(expected);
   });
+
+  /** A conversation can be listed with no stored history: the session store records an id as soon as
+   *  it is live, so an id that never took a turn has a row and no file. Arriving at one must leave
+   *  nothing of the conversation being left behind, or its messages become the new conversation's and
+   *  are written back out under the new id. */
+  it('carries nothing of the previous conversation into a target with no stored history', async () => {
+    const { switcher, conversation } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    await switcher.switchTo(OTHER_ID);
+    const expected = 0;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
 });
 
 describe('ConversationSwitcher — createNew', () => {

--- a/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
@@ -61,6 +62,10 @@ function makeSwitcher() {
     .asSelf();
   services.register(SystemIdentity).as(ISystemIdentity);
   services
+    .register(ConfigLoader)
+    .using(() => ({ config: { historyReplay: { enabled: true, showThinking: false } } }) as unknown as ConfigLoader<never>)
+    .asSelf();
+  services
     .register(StatusState)
     .using(() => new StatusState('test'))
     .asSelf();
@@ -101,10 +106,32 @@ describe('ConversationSwitcher — switchTo', () => {
     expect(actual).toBe(expected);
   });
 
-  it('clears the transcript of the conversation being left', async () => {
+  it('replaces the transcript of the conversation being left', async () => {
     const { switcher, conversationState } = makeSwitcher();
     conversationState.addBlocks([{ type: 'meta', content: 'from the previous conversation' }]);
     await switcher.switchTo(EXISTING_ID);
+    const actual = conversationState.sealedBlocks.map((block) => block.content).join('\n');
+    expect(actual).not.toContain('from the previous conversation');
+  });
+
+  it('puts the adopted conversation on screen', async () => {
+    const { switcher, conversationState } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    const actual = conversationState.sealedBlocks.map((block) => block.content).join('\n');
+    expect(actual).toContain('the existing ask');
+  });
+
+  it('shows the replies of the adopted conversation, not only what was asked', async () => {
+    const { switcher, conversationState } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    const actual = conversationState.sealedBlocks.map((block) => block.content).join('\n');
+    expect(actual).toContain('the existing reply');
+  });
+
+  it('leaves the transcript empty when arriving at a conversation with no history', async () => {
+    const { switcher, conversationState } = makeSwitcher();
+    conversationState.addBlocks([{ type: 'meta', content: 'from the previous conversation' }]);
+    await switcher.switchTo(OTHER_ID);
     const expected = 0;
     const actual = conversationState.sealedBlocks.length;
     expect(actual).toBe(expected);
@@ -130,9 +157,10 @@ describe('ConversationSwitcher — switchTo', () => {
   it('leaves the transcript untouched when the target is already live', async () => {
     const { switcher, conversationState, session } = makeSwitcher();
     await switcher.switchTo(EXISTING_ID);
+    const settled = conversationState.sealedBlocks.length;
     conversationState.addBlocks([{ type: 'meta', content: 'said after arriving' }]);
     await switcher.switchTo(session.id);
-    const expected = 1;
+    const expected = settled + 1;
     const actual = conversationState.sealedBlocks.length;
     expect(actual).toBe(expected);
   });

--- a/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
@@ -1,0 +1,175 @@
+import { DatabaseSync } from 'node:sqlite';
+import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
+import { ILogger } from '@shellicar/claude-core/logging/ILogger';
+import { IObjectStore } from '@shellicar/claude-core/persistence/interfaces';
+import { Conversation, IConversation } from '@shellicar/claude-sdk';
+import { createServiceCollection, Lifetime } from '@shellicar/core-di';
+import { describe, expect, it } from 'vitest';
+import { AuditStats } from '../src/AuditStats.js';
+import { IAgentPresence } from '../src/agent/AgentPresence.js';
+import { IConvServe } from '../src/conv/ConvServe.js';
+import { logger } from '../src/logger.js';
+import { ConversationSession, IConversationSession } from '../src/model/ConversationSession.js';
+import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
+import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
+import { StatusState } from '../src/model/StatusState.js';
+import { SystemIdentity } from '../src/model/SystemIdentity.js';
+import { ISqliteSessionStore, SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
+import { ConversationSwitcher, IConversationSwitcher } from '../src/setup/ConversationSwitcher.js';
+import { MemoryFileSystem } from './MemoryFileSystem.js';
+import { MemoryObjectStore } from './MemoryObjectStore.js';
+
+const EXISTING_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ID = '22222222-2222-4222-8222-222222222222';
+
+/** Test double: a logger that discards everything, so the switcher resolves without the app's logger. */
+const noopLogger: ILogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+const conversationLine = (role: 'user' | 'assistant', text: string): string => JSON.stringify({ role, content: [{ type: 'text', text }] });
+
+/** Builds the switcher over in-memory everything, with `EXISTING_ID` already on disk as a two-message conversation. */
+function makeSwitcher() {
+  const files: Record<string, string> = {
+    [`/home/user/.claude/conversations/${EXISTING_ID}.jsonl`]: [conversationLine('user', 'the existing ask'), conversationLine('assistant', 'the existing reply')].join('\n'),
+  };
+  const fs = new MemoryFileSystem(files, '/home/user', '/test');
+  const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
+  services
+    .register(IFileSystem)
+    .using(() => fs)
+    .asSelf();
+  services
+    .register(ILogger)
+    .using(() => noopLogger)
+    .asSelf();
+  services
+    .register(Clock)
+    .using(() => Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC))
+    .asSelf();
+  services.register(Conversation).asSelf().as(IConversation);
+  services.register(ConversationState).asSelf().as(IConversationState);
+  services
+    .register(SqliteSessionStore)
+    .using(() => new SqliteSessionStore(new DatabaseSync(':memory:'), logger))
+    .asSelf()
+    .as(ISqliteSessionStore);
+  services.register(ConversationSession).asSelf().as(IConversationSession);
+  services
+    .register(IObjectStore)
+    .using(() => new MemoryObjectStore())
+    .asSelf();
+  services.register(SystemIdentity).as(ISystemIdentity);
+  services
+    .register(StatusState)
+    .using(() => new StatusState('test'))
+    .asSelf();
+  services.register(AuditStats).asSelf();
+  services
+    .register(IConvServe)
+    .using(() => ({ bind: () => {} }))
+    .asSelf();
+  services
+    .register(IAgentPresence)
+    .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
+    .asSelf();
+  services.register(ConversationSwitcher).asSelf().as(IConversationSwitcher);
+  const provider = services.buildProvider();
+  return {
+    switcher: provider.resolve(ConversationSwitcher),
+    session: provider.resolve(ConversationSession),
+    conversation: provider.resolve(Conversation),
+    conversationState: provider.resolve(ConversationState),
+    statusState: provider.resolve(StatusState),
+  };
+}
+
+describe('ConversationSwitcher — switchTo', () => {
+  it('adopts the target id as the live conversation', async () => {
+    const { switcher, session } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    const expected = EXISTING_ID;
+    const actual = session.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('loads the target conversation history', async () => {
+    const { switcher, conversation } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    const expected = 2;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('clears the transcript of the conversation being left', async () => {
+    const { switcher, conversationState } = makeSwitcher();
+    conversationState.addBlocks([{ type: 'meta', content: 'from the previous conversation' }]);
+    await switcher.switchTo(EXISTING_ID);
+    const expected = 0;
+    const actual = conversationState.sealedBlocks.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('records the target under the current directory so it resumes there', async () => {
+    const { switcher, session } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    await session.load();
+    const expected = EXISTING_ID;
+    const actual = session.id;
+    expect(actual).toBe(expected);
+  });
+
+  it('reads empty status figures for a conversation with no audit', async () => {
+    const { switcher, statusState } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    const expected = 0;
+    const actual = statusState.totalCostUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves the transcript untouched when the target is already live', async () => {
+    const { switcher, conversationState, session } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    conversationState.addBlocks([{ type: 'meta', content: 'said after arriving' }]);
+    await switcher.switchTo(session.id);
+    const expected = 1;
+    const actual = conversationState.sealedBlocks.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('starts empty when the target has no stored history', async () => {
+    const { switcher, conversation } = makeSwitcher();
+    await switcher.switchTo(OTHER_ID);
+    const expected = 0;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ConversationSwitcher — createNew', () => {
+  it('moves off the conversation it was on', async () => {
+    const { switcher, session } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    await switcher.createNew();
+    const actual = session.id;
+    expect(actual).not.toBe(EXISTING_ID);
+  });
+
+  it('starts the new conversation with no history', async () => {
+    const { switcher, conversation } = makeSwitcher();
+    await switcher.switchTo(EXISTING_ID);
+    await switcher.createNew();
+    const expected = 0;
+    const actual = conversation.messages.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('clears the transcript', async () => {
+    const { switcher, conversationState } = makeSwitcher();
+    conversationState.addBlocks([{ type: 'meta', content: 'from the previous conversation' }]);
+    await switcher.createNew();
+    const expected = 0;
+    const actual = conversationState.sealedBlocks.length;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationSwitcher.spec.ts
@@ -14,6 +14,7 @@ import { logger } from '../src/logger.js';
 import { ConversationSession, IConversationSession } from '../src/model/ConversationSession.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
+import { IPrimaryViewState, PrimaryViewState } from '../src/model/PrimaryViewState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
 import { ISqliteSessionStore, SqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
@@ -61,6 +62,7 @@ function makeSwitcher() {
     .using(() => new MemoryObjectStore())
     .asSelf();
   services.register(SystemIdentity).as(ISystemIdentity);
+  services.register(PrimaryViewState).asSelf().as(IPrimaryViewState);
   services
     .register(ConfigLoader)
     .using(() => ({ config: { historyReplay: { enabled: true, showThinking: false } } }) as unknown as ConfigLoader<never>)
@@ -86,6 +88,7 @@ function makeSwitcher() {
     conversation: provider.resolve(Conversation),
     conversationState: provider.resolve(ConversationState),
     statusState: provider.resolve(StatusState),
+    primaryViewState: provider.resolve(PrimaryViewState),
   };
 }
 

--- a/apps/claude-sdk-cli/test/ConversationView.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationView.spec.ts
@@ -30,13 +30,14 @@ function plain(rows: string[]): string {
   return rows.join('\n').replace(/\x1b\[[^m]*m/g, '');
 }
 
-function render(listState: ConversationListState, sessionId = CURRENT_ID, cols = 120): string {
+function render(listState: ConversationListState, sessionId = CURRENT_ID, phase: 'editor' | 'streaming' = 'editor', cols = 120): string {
   const terminalState = new TerminalState();
   terminalState.setSize(cols, 40);
   const model = {
     conversationListState: listState,
     terminalState,
     appModeState: new AppModeState(),
+    primaryViewState: { phase },
     session: { id: sessionId },
     statusState: { cwdBasename: 'claude-cli' },
     clock: Clock.fixed(NOW, ZoneId.UTC),
@@ -89,6 +90,31 @@ describe('ConversationView — the list', () => {
   it('does not mark a conversation the process is not on', () => {
     const rows = render(listWith({ id: OTHER_ID, summary: summaryOf() }), CURRENT_ID);
     expect(rows).not.toContain('●');
+  });
+
+  it('separates one conversation from the next', () => {
+    const rows = render(listWith({ id: CURRENT_ID, summary: summaryOf() }, { id: OTHER_ID, summary: summaryOf() })).split('\n');
+    const firstOfSecond = rows.findIndex((row) => row.includes(OTHER_ID));
+    const expected = '';
+    const actual = rows[firstOfSecond - 1]?.trim();
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('ConversationView — the key hints', () => {
+  it('offers switching while the CLI is awaiting input', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('⏎ switch');
+  });
+
+  it('says why switching is unavailable during a turn', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }), CURRENT_ID, 'streaming');
+    expect(actual).toContain('⏎ switch (turn running)');
+  });
+
+  it('still offers the keys that work during a turn', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }), CURRENT_ID, 'streaming');
+    expect(actual).toContain('space peek');
   });
 });
 

--- a/apps/claude-sdk-cli/test/ConversationView.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationView.spec.ts
@@ -1,0 +1,170 @@
+import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { describe, expect, it } from 'vitest';
+import type { AuditSummary } from '../src/conversations/scanAuditSummary.js';
+import { AppModeState } from '../src/model/AppModeState.js';
+import { ConversationListState } from '../src/model/ConversationListState.js';
+import { TerminalState } from '../src/model/TerminalState.js';
+import { ConversationView } from '../src/view/ConversationView.js';
+import type { ViewModel } from '../src/view/View.js';
+
+const NOW = Instant.parse('2026-07-28T14:00:00.000Z');
+const CURRENT_ID = '96ad1460-4382-4b4f-bf92-97570dc8285a';
+const OTHER_ID = '22392ae9-b2e7-4d33-9141-7170bad7eb9e';
+
+const summaryOf = (overrides: Partial<AuditSummary> = {}): AuditSummary => ({
+  turns: 190,
+  queries: 19,
+  costUsd: 16.24,
+  firstUtc: '2026-07-28T10:15:14.000Z',
+  lastUtc: '2026-07-28T13:37:50.000Z',
+  model: 'claude-sonnet-5',
+  contextTokens: 407_198,
+  firstUserText: 'so after all this time, i want a read only mode',
+  lastAssistantText: 'PR #490 is committed, pushed, and marked ready for review',
+  ...overrides,
+});
+
+/** Strips ANSI so an assertion is about the text, not its colouring. */
+function plain(rows: string[]): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI for test assertions
+  return rows.join('\n').replace(/\x1b\[[^m]*m/g, '');
+}
+
+function render(listState: ConversationListState, sessionId = CURRENT_ID, cols = 120): string {
+  const terminalState = new TerminalState();
+  terminalState.setSize(cols, 40);
+  const model = {
+    conversationListState: listState,
+    terminalState,
+    appModeState: new AppModeState(),
+    session: { id: sessionId },
+    statusState: { cwdBasename: 'claude-cli' },
+    clock: Clock.fixed(NOW, ZoneId.UTC),
+  } as unknown as ViewModel;
+  return plain(new ConversationView().render(model));
+}
+
+const listWith = (...entries: Array<{ id: string; summary?: AuditSummary }>): ConversationListState => {
+  const state = new ConversationListState();
+  state.setEntries(entries.map((entry) => entry.id));
+  for (const entry of entries) {
+    if (entry.summary !== undefined) {
+      state.setSummary(entry.id, entry.summary);
+    }
+  }
+  return state;
+};
+
+describe('ConversationView — the list', () => {
+  it('names the directory the conversations belong to', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('conversations in claude-cli');
+  });
+
+  it('says so when the directory has no conversations', () => {
+    const actual = render(listWith());
+    expect(actual).toContain('no conversations recorded in this directory');
+  });
+
+  it('shows the full conversation id, never truncated', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain(CURRENT_ID);
+  });
+
+  it('shows the opening ask', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('so after all this time, i want a read only mode');
+  });
+
+  it('shows the last reply', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('PR #490 is committed');
+  });
+
+  it('marks the conversation the process is currently on', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain(`● claude-sonnet-5`.replace('claude-', ''));
+  });
+
+  it('does not mark a conversation the process is not on', () => {
+    const rows = render(listWith({ id: OTHER_ID, summary: summaryOf() }), CURRENT_ID);
+    expect(rows).not.toContain('●');
+  });
+});
+
+describe('ConversationView — the figures', () => {
+  it('shows the query count', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('19q');
+  });
+
+  it('shows the turn count', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('190t');
+  });
+
+  it('shows the cost', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('$16.2400');
+  });
+
+  it('shows the span between the first and last message', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('3h 22m');
+  });
+
+  it('shows how long ago the conversation was last active', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('22m ago');
+  });
+
+  it('shows the model without its vendor prefix', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }));
+    expect(actual).toContain('sonnet-5');
+  });
+});
+
+describe('ConversationView — before a summary has loaded', () => {
+  it('still shows the conversation id', () => {
+    const actual = render(listWith({ id: CURRENT_ID }));
+    expect(actual).toContain(CURRENT_ID);
+  });
+
+  it('shows a placeholder in place of the figures', () => {
+    const actual = render(listWith({ id: CURRENT_ID }));
+    expect(actual).toContain('·····');
+  });
+});
+
+describe('ConversationView — peek', () => {
+  it('shows a reading marker until the peek content lands', () => {
+    const state = listWith({ id: CURRENT_ID, summary: summaryOf() });
+    state.apply('toggle-peek');
+    const actual = render(state);
+    expect(actual).toContain('reading…');
+  });
+
+  it('shows each message opening once the peek has landed', () => {
+    const state = listWith({ id: CURRENT_ID, summary: summaryOf() });
+    state.apply('toggle-peek');
+    state.setPeek(CURRENT_ID, { entries: [{ kind: 'user', text: 'alright, commit and push', toolCount: 0, timestampUtc: '2026-07-28T13:19:02.000Z' }], earlier: 142 });
+    const actual = render(state);
+    expect(actual).toContain('alright, commit and push');
+  });
+
+  it('counts the messages the peek does not reach', () => {
+    const state = listWith({ id: CURRENT_ID, summary: summaryOf() });
+    state.apply('toggle-peek');
+    state.setPeek(CURRENT_ID, { entries: [], earlier: 142 });
+    const actual = render(state);
+    expect(actual).toContain('142 earlier messages');
+  });
+
+  it('shows a collapsed tool run', () => {
+    const state = listWith({ id: CURRENT_ID, summary: summaryOf() });
+    state.apply('toggle-peek');
+    state.setPeek(CURRENT_ID, { entries: [{ kind: 'tools', text: '14 tools', toolCount: 14, timestampUtc: '2026-07-28T13:19:05.000Z' }], earlier: 0 });
+    const actual = render(state);
+    expect(actual).toContain('14 tools');
+  });
+});

--- a/apps/claude-sdk-cli/test/ConversationView.spec.ts
+++ b/apps/claude-sdk-cli/test/ConversationView.spec.ts
@@ -30,14 +30,14 @@ function plain(rows: string[]): string {
   return rows.join('\n').replace(/\x1b\[[^m]*m/g, '');
 }
 
-function render(listState: ConversationListState, sessionId = CURRENT_ID, phase: 'editor' | 'streaming' = 'editor', cols = 120): string {
+function render(listState: ConversationListState, sessionId = CURRENT_ID, phase: 'editor' | 'streaming' = 'editor', conversationMoving = false, cols = 120): string {
   const terminalState = new TerminalState();
   terminalState.setSize(cols, 40);
   const model = {
     conversationListState: listState,
     terminalState,
     appModeState: new AppModeState(),
-    primaryViewState: { phase },
+    primaryViewState: { phase, conversationMoving },
     session: { id: sessionId },
     statusState: { cwdBasename: 'claude-cli' },
     clock: Clock.fixed(NOW, ZoneId.UTC),
@@ -115,6 +115,11 @@ describe('ConversationView — the key hints', () => {
   it('still offers the keys that work during a turn', () => {
     const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }), CURRENT_ID, 'streaming');
     expect(actual).toContain('space peek');
+  });
+
+  it('says why switching is unavailable while a switch is already under way', () => {
+    const actual = render(listWith({ id: CURRENT_ID, summary: summaryOf() }), CURRENT_ID, 'editor', true);
+    expect(actual).toContain('⏎ switch (switching)');
   });
 });
 

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -62,6 +62,7 @@ function makeModel(firstContent = 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8'): ViewModel {
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     conversationListState: new ConversationListState(),
+    conversationSwitcher: { moving: false } as unknown as ViewModel['conversationSwitcher'],
     clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess', turnCount: 0 } as unknown as ConversationSession,

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -1,8 +1,9 @@
-import { Clock } from '@js-joda/core';
+import { Clock, Instant, ZoneId } from '@js-joda/core';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { AppModeState } from '../src/model/AppModeState.js';
 import { CommandModeState } from '../src/model/CommandModeState.js';
+import { ConversationListState } from '../src/model/ConversationListState.js';
 import type { ConversationSession } from '../src/model/ConversationSession.js';
 import { ConversationState } from '../src/model/ConversationState.js';
 import { EditorState } from '../src/model/EditorState.js';
@@ -60,6 +61,8 @@ function makeModel(firstContent = 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8'): ViewModel {
     primaryViewState: new PrimaryViewState(),
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
+    conversationListState: new ConversationListState(),
+    clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess', turnCount: 0 } as unknown as ConversationSession,
     configLoader: { config: { markdown: { enabled: true, streaming: true } } } as unknown as ViewModel['configLoader'],

--- a/apps/claude-sdk-cli/test/HistoryView.spec.ts
+++ b/apps/claude-sdk-cli/test/HistoryView.spec.ts
@@ -62,7 +62,6 @@ function makeModel(firstContent = 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8'): ViewModel {
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     conversationListState: new ConversationListState(),
-    conversationSwitcher: { moving: false } as unknown as ViewModel['conversationSwitcher'],
     clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess', turnCount: 0 } as unknown as ConversationSession,

--- a/apps/claude-sdk-cli/test/MemoryFileSystem.ts
+++ b/apps/claude-sdk-cli/test/MemoryFileSystem.ts
@@ -75,6 +75,10 @@ export class MemoryFileSystem extends IFileSystem {
     return content;
   }
 
+  public async readFileBytes(path: string): Promise<Buffer> {
+    return Buffer.from(await this.readFile(path), 'utf-8');
+  }
+
   public async writeFile(path: string, content: string): Promise<void> {
     this.files.set(path, content);
   }

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -51,11 +51,10 @@ function makeTurnClock(): ITurnClock {
   return services.buildProvider().resolve(ITurnClock);
 }
 
-function makeModel(canStartNew = true): ViewModel {
+function makeModel(): ViewModel {
   const terminalState = new TerminalState();
   terminalState.setSize(80, 24);
   return {
-    conversationSwitcher: { moving: !canStartNew } as unknown as ViewModel['conversationSwitcher'],
     conversationState: new ConversationState(),
     editorState: new EditorState(),
     toolApprovalState: new ToolApprovalState(),

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -4,6 +4,7 @@ import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { AppModeState } from '../src/model/AppModeState.js';
 import { CommandModeState } from '../src/model/CommandModeState.js';
+import { ConversationListState } from '../src/model/ConversationListState.js';
 import type { ConversationSession } from '../src/model/ConversationSession.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { EditorState } from '../src/model/EditorState.js';
@@ -64,6 +65,8 @@ function makeModel(): ViewModel {
     primaryViewState: new PrimaryViewState(),
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
+    conversationListState: new ConversationListState(),
+    clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess-123', turnCount: 0 } as unknown as ConversationSession,
     configLoader: { config: { markdown: { enabled: true, streaming: true } } } as unknown as ViewModel['configLoader'],

--- a/apps/claude-sdk-cli/test/PrimaryView.spec.ts
+++ b/apps/claude-sdk-cli/test/PrimaryView.spec.ts
@@ -51,10 +51,11 @@ function makeTurnClock(): ITurnClock {
   return services.buildProvider().resolve(ITurnClock);
 }
 
-function makeModel(): ViewModel {
+function makeModel(canStartNew = true): ViewModel {
   const terminalState = new TerminalState();
   terminalState.setSize(80, 24);
   return {
+    conversationSwitcher: { moving: !canStartNew } as unknown as ViewModel['conversationSwitcher'],
     conversationState: new ConversationState(),
     editorState: new EditorState(),
     toolApprovalState: new ToolApprovalState(),

--- a/apps/claude-sdk-cli/test/SqliteSessionStore.spec.ts
+++ b/apps/claude-sdk-cli/test/SqliteSessionStore.spec.ts
@@ -56,3 +56,55 @@ describe('SqliteSessionStore — mostRecentByCwd', () => {
     expect(actual).toBe(expected);
   });
 });
+
+describe('SqliteSessionStore — listByCwd', () => {
+  it('lists every conversation ever live under the cwd', () => {
+    const store = new SqliteSessionStore(createDb(), logger);
+    store.append('conv-a', '/project', '2026-07-05T00:00:00Z');
+    store.append('conv-b', '/project', '2026-07-05T00:01:00Z');
+
+    const expected = ['conv-b', 'conv-a'];
+    const actual = store.listByCwd('/project');
+    expect(actual).toEqual(expected);
+  });
+
+  it('lists a conversation once however many times it was written', () => {
+    const store = new SqliteSessionStore(createDb(), logger);
+    store.append('conv-a', '/project', '2026-07-05T00:00:00Z');
+    store.append('conv-a', '/project', '2026-07-05T00:01:00Z');
+    store.append('conv-a', '/project', '2026-07-05T00:02:00Z');
+
+    const expected = ['conv-a'];
+    const actual = store.listByCwd('/project');
+    expect(actual).toEqual(expected);
+  });
+
+  it("orders by each conversation's most recent write, not its first", () => {
+    const store = new SqliteSessionStore(createDb(), logger);
+    store.append('conv-a', '/project', '2026-07-05T00:00:00Z');
+    store.append('conv-b', '/project', '2026-07-05T00:01:00Z');
+    store.append('conv-a', '/project', '2026-07-05T00:02:00Z');
+
+    const expected = ['conv-a', 'conv-b'];
+    const actual = store.listByCwd('/project');
+    expect(actual).toEqual(expected);
+  });
+
+  it('excludes conversations from other directories', () => {
+    const store = new SqliteSessionStore(createDb(), logger);
+    store.append('conv-a', '/project-a', '2026-07-05T00:00:00Z');
+    store.append('conv-b', '/project-b', '2026-07-05T00:01:00Z');
+
+    const expected = ['conv-a'];
+    const actual = store.listByCwd('/project-a');
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns nothing for a directory with no conversations', () => {
+    const store = new SqliteSessionStore(createDb(), logger);
+
+    const expected: string[] = [];
+    const actual = store.listByCwd('/nowhere');
+    expect(actual).toEqual(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -97,7 +97,6 @@ function makeModel(): ViewModel {
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     conversationListState: new ConversationListState(),
-    conversationSwitcher: { moving: false } as unknown as ViewModel['conversationSwitcher'],
     clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess' } as unknown as IConversationSession,

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -31,7 +31,7 @@ import { HistoryViewState } from '../src/model/HistoryViewState.js';
 import { ISystemIdentity } from '../src/model/ISystemIdentity.js';
 import { ITurnClock } from '../src/model/ITurnClock.js';
 import { ModelSettings } from '../src/model/ModelSettings.js';
-import { PrimaryViewState } from '../src/model/PrimaryViewState.js';
+import { IPrimaryViewState, PrimaryViewState } from '../src/model/PrimaryViewState.js';
 import { ScrollState } from '../src/model/ScrollState.js';
 import { StatusState } from '../src/model/StatusState.js';
 import { SystemIdentity } from '../src/model/SystemIdentity.js';
@@ -97,6 +97,7 @@ function makeModel(): ViewModel {
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
     conversationListState: new ConversationListState(),
+    conversationSwitcher: { moving: false } as unknown as ViewModel['conversationSwitcher'],
     clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess' } as unknown as IConversationSession,
@@ -316,6 +317,7 @@ describe('ViewHost — escape routing through the primary chains', () => {
       .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
       .asSelf();
     services.register(WorkingDirectory).as(IWorkingDirectory);
+    services.register(PrimaryViewState).asSelf().as(IPrimaryViewState);
     services.register(ConversationSwitcher).as(IConversationSwitcher);
     services.register(CommandIntentExecutor).asSelf();
     services.register(ApprovalHandler).asSelf();

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -1,4 +1,5 @@
 import { Clock, Instant, ZoneId } from '@js-joda/core';
+import { ConfigLoader } from '@shellicar/claude-core/Config/ConfigLoader';
 import { IFileSystem } from '@shellicar/claude-core/fs/interfaces';
 import { SipsBridge } from '@shellicar/claude-core/image/SipsBridge';
 import { ILogger } from '@shellicar/claude-core/logging/ILogger';
@@ -273,6 +274,10 @@ describe('ViewHost — escape routing through the primary chains', () => {
       .using(() => new MemoryObjectStore())
       .asSelf();
     services.register(SystemIdentity).as(ISystemIdentity);
+    services
+      .register(ConfigLoader)
+      .using(() => ({ config: { historyReplay: { enabled: false, showThinking: false } } }) as unknown as ConfigLoader<never>)
+      .asSelf();
     services
       .register(AttachmentSource)
       .using(() => new FakeAttachmentSource())

--- a/apps/claude-sdk-cli/test/ViewHost.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewHost.spec.ts
@@ -22,6 +22,7 @@ import type { AppModeKey } from '../src/model/AppModeState.js';
 import { AppModeState } from '../src/model/AppModeState.js';
 import { AttachmentSource } from '../src/model/AttachmentSource.js';
 import { CommandModeState, ICommandModeState } from '../src/model/CommandModeState.js';
+import { ConversationListState } from '../src/model/ConversationListState.js';
 import { IConversationSession } from '../src/model/ConversationSession.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { EditorState, IEditorState } from '../src/model/EditorState.js';
@@ -39,6 +40,7 @@ import { TurnClock } from '../src/model/TurnClock.js';
 import { IWorkingDirectory, WorkingDirectory } from '../src/model/WorkingDirectory.js';
 import { ISqliteSessionStore } from '../src/persistence/SqliteSessionStore.js';
 import { ConsumerChannel } from '../src/setup/ConsumerChannel.js';
+import { ConversationSwitcher, IConversationSwitcher } from '../src/setup/ConversationSwitcher.js';
 import { PrimaryView } from '../src/view/PrimaryView.js';
 import type { TerminalRenderer } from '../src/view/TerminalRenderer.js';
 import type { ViewModel } from '../src/view/View.js';
@@ -93,6 +95,8 @@ function makeModel(): ViewModel {
     primaryViewState: new PrimaryViewState(),
     scrollState: new ScrollState(),
     historyViewState: new HistoryViewState(),
+    conversationListState: new ConversationListState(),
+    clock: Clock.fixed(Instant.ofEpochMilli(0), ZoneId.UTC),
     appModeState: new AppModeState(),
     session: { id: 'sess' } as unknown as IConversationSession,
     configLoader: { config: { markdown: { enabled: true, streaming: true } } } as unknown as ViewModel['configLoader'],
@@ -307,6 +311,7 @@ describe('ViewHost — escape routing through the primary chains', () => {
       .using(() => ({ instanceId: 'inst-test', world: 'test', boot: () => {}, attach: () => {}, detach: () => {}, stop: () => {} }))
       .asSelf();
     services.register(WorkingDirectory).as(IWorkingDirectory);
+    services.register(ConversationSwitcher).as(IConversationSwitcher);
     services.register(CommandIntentExecutor).asSelf();
     services.register(ApprovalHandler).asSelf();
     services.register(CommandKeyHandler).asSelf();

--- a/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
@@ -6,8 +6,12 @@ import { ViewSelectHandler } from '../src/controller/ViewSelectHandler.js';
 import { IConversationListLoader } from '../src/conversations/ConversationListLoader.js';
 import { AppModeState, IAppModeState } from '../src/model/AppModeState.js';
 import { ConversationListState, IConversationListState } from '../src/model/ConversationListState.js';
+import { IConversationSession } from '../src/model/ConversationSession.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { HistoryViewState, IHistoryViewState } from '../src/model/HistoryViewState.js';
+
+/** The conversation this process is on, which entry to the view should land on. */
+const LIVE_ID = 'conv-live';
 
 class NoopLogger extends ILogger {
   public trace(): void {}
@@ -54,6 +58,10 @@ function buildViewSelectHandler(appModeState: AppModeState, historyViewState: Hi
   services
     .register(IConversationListLoader)
     .using(() => ({ refresh: onRefresh }))
+    .asSelf();
+  services
+    .register(IConversationSession)
+    .using(() => ({ id: LIVE_ID }) as unknown as IConversationSession)
     .asSelf();
   services.register(ViewSelectHandler).asSelf();
   return services.buildProvider().resolve(ViewSelectHandler);
@@ -136,6 +144,15 @@ describe('ViewSelectHandler', () => {
     const { handler } = setup();
     const expected = true;
     const actual = handler.handleKey({ type: 'f3' });
+    expect(actual).toBe(expected);
+  });
+
+  it('opens the conversation view on the conversation the process is on', () => {
+    const { handler, listState } = setup();
+    listState.setEntries(['conv-other', LIVE_ID]);
+    handler.handleKey({ type: 'f3' });
+    const expected = LIVE_ID;
+    const actual = listState.selectedEntry?.id;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
+++ b/apps/claude-sdk-cli/test/ViewSelectHandler.spec.ts
@@ -3,7 +3,9 @@ import { ILogger } from '@shellicar/claude-core/logging/ILogger';
 import { createServiceCollection, Lifetime } from '@shellicar/core-di';
 import { describe, expect, it } from 'vitest';
 import { ViewSelectHandler } from '../src/controller/ViewSelectHandler.js';
+import { IConversationListLoader } from '../src/conversations/ConversationListLoader.js';
 import { AppModeState, IAppModeState } from '../src/model/AppModeState.js';
+import { ConversationListState, IConversationListState } from '../src/model/ConversationListState.js';
 import { ConversationState, IConversationState } from '../src/model/ConversationState.js';
 import { HistoryViewState, IHistoryViewState } from '../src/model/HistoryViewState.js';
 
@@ -19,7 +21,7 @@ class NoopLogger extends ILogger {
 // container. ConversationState's own declared dependencies (Clock, ILogger) still need
 // registrations for the container's dependency plan, even though this factory supplies a
 // pre-built instance.
-function buildViewSelectHandler(appModeState: AppModeState, historyViewState: HistoryViewState, conversation: ConversationState): ViewSelectHandler {
+function buildViewSelectHandler(appModeState: AppModeState, historyViewState: HistoryViewState, conversation: ConversationState, listState: ConversationListState, onRefresh: () => void): ViewSelectHandler {
   const services = createServiceCollection({ defaultLifetime: Lifetime.Singleton });
   services
     .register(Clock)
@@ -44,6 +46,15 @@ function buildViewSelectHandler(appModeState: AppModeState, historyViewState: Hi
     .using(() => conversation)
     .asSelf()
     .as(IConversationState);
+  services
+    .register(ConversationListState)
+    .using(() => listState)
+    .asSelf()
+    .as(IConversationListState);
+  services
+    .register(IConversationListLoader)
+    .using(() => ({ refresh: onRefresh }))
+    .asSelf();
   services.register(ViewSelectHandler).asSelf();
   return services.buildProvider().resolve(ViewSelectHandler);
 }
@@ -57,8 +68,12 @@ function setup() {
     { type: 'response', content: 'b' },
     { type: 'response', content: 'c' },
   ]);
-  const handler = buildViewSelectHandler(appModeState, historyViewState, conversation);
-  return { handler, appModeState, historyViewState };
+  const listState = new ConversationListState();
+  const refreshes = { count: 0 };
+  const handler = buildViewSelectHandler(appModeState, historyViewState, conversation, listState, () => {
+    refreshes.count += 1;
+  });
+  return { handler, appModeState, historyViewState, listState, refreshes };
 }
 
 describe('ViewSelectHandler', () => {
@@ -98,6 +113,29 @@ describe('ViewSelectHandler', () => {
     const { handler } = setup();
     const expected = false;
     const actual = handler.handleKey({ type: 'char', value: 'a' });
+    expect(actual).toBe(expected);
+  });
+
+  it('selects the conversation view on F3', () => {
+    const { handler, appModeState } = setup();
+    handler.handleKey({ type: 'f3' });
+    const expected = 'conversations';
+    const actual = appModeState.active;
+    expect(actual).toBe(expected);
+  });
+
+  it('rebuilds the conversation list on entry, so a conversation created since is listed', () => {
+    const { handler, refreshes } = setup();
+    handler.handleKey({ type: 'f3' });
+    const expected = 1;
+    const actual = refreshes.count;
+    expect(actual).toBe(expected);
+  });
+
+  it('claims F3', () => {
+    const { handler } = setup();
+    const expected = true;
+    const actual = handler.handleKey({ type: 'f3' });
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/auditWindowBudget.spec.ts
+++ b/apps/claude-sdk-cli/test/auditWindowBudget.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { PREFIX_BYTES, SUFFIX_BYTES, scanAuditSummary } from '../src/conversations/scanAuditSummary.js';
+
+/**
+ * The summariser reads a bounded head and tail of each audit line rather than the line, which is what
+ * makes the conversation view cheap. Nothing in AuditWriter knows that, so a field added to the header
+ * it composes can push the fields the reader needs outside the window it looks in — and a field the
+ * reader cannot find reads as absent, not as an error, so the view would show every conversation
+ * costing nothing with no failure anywhere.
+ *
+ * These lines mirror what AuditWriter writes (see its `assistant` and `user` composition). They fail
+ * when the header grows past what the reader can see, at the cause rather than at the symptom.
+ */
+const assistantLine = (): string =>
+  JSON.stringify({
+    timestamp: '2026-07-28T13:37:50.219Z',
+    costUsd: 0.38673100000000005,
+    cacheCreation: { fiveMinute: 0, oneHour: 300 },
+    model: 'claude-sonnet-5',
+    id: 'msg_011CdUY4grMQtiDvoz3CrVcp',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'the reply' }],
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    stop_details: null,
+    usage: {
+      input_tokens: 2,
+      cache_creation_input_tokens: 300,
+      cache_read_input_tokens: 373761,
+      cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 300 },
+      output_tokens: 139,
+      service_tier: 'standard',
+      inference_geo: 'not_available',
+      output_tokens_details: { thinking_tokens: 0 },
+    },
+    turnId: '98f84714-ad5d-4221-adf0-adaf5ef37984',
+    queryId: '4024fdea-294f-484e-9ca6-31b7a53a0ebd',
+  });
+
+const userLine = (): string =>
+  JSON.stringify({
+    role: 'user',
+    id: '8aac0563-b237-4031-9c3f-088248eb127a',
+    turnId: '98f84714-ad5d-4221-adf0-adaf5ef37984',
+    queryId: '4024fdea-294f-484e-9ca6-31b7a53a0ebd',
+    timestamp: '2026-07-28T11:58:32.511Z',
+    content: [{ type: 'text', text: 'the opening ask' }],
+  });
+
+/** Where a key sits from the start of the line, which is what the head window has to reach. */
+const headOffsetOf = (line: string, key: string): number => line.indexOf(`"${key}":`);
+/** How far a key sits from the end, which is what the tail window has to reach. */
+const tailOffsetOf = (line: string, key: string): number => line.length - line.lastIndexOf(`"${key}":`);
+
+describe('audit line fields stay inside the summariser windows', () => {
+  it('finds role within the head window of an assistant line', () => {
+    expect(headOffsetOf(assistantLine(), 'role')).toBeLessThan(PREFIX_BYTES);
+  });
+
+  it('finds costUsd within the head window', () => {
+    expect(headOffsetOf(assistantLine(), 'costUsd')).toBeLessThan(PREFIX_BYTES);
+  });
+
+  it('finds model within the head window', () => {
+    expect(headOffsetOf(assistantLine(), 'model')).toBeLessThan(PREFIX_BYTES);
+  });
+
+  it('finds timestamp within the head window of a user line', () => {
+    expect(headOffsetOf(userLine(), 'timestamp')).toBeLessThan(PREFIX_BYTES);
+  });
+
+  it('finds turnId within the head window of a user line', () => {
+    expect(headOffsetOf(userLine(), 'turnId')).toBeLessThan(PREFIX_BYTES);
+  });
+
+  it('finds usage within the tail window of an assistant line', () => {
+    expect(tailOffsetOf(assistantLine(), 'usage')).toBeLessThan(SUFFIX_BYTES);
+  });
+
+  it('finds queryId within the tail window of an assistant line', () => {
+    expect(tailOffsetOf(assistantLine(), 'queryId')).toBeLessThan(SUFFIX_BYTES);
+  });
+});
+
+describe('a written audit line summarises to its real figures', () => {
+  const bytes = Buffer.from(`${userLine()}\n${assistantLine()}\n`, 'utf-8');
+
+  it('reads the cost', () => {
+    const expected = 0.38673100000000005;
+    const actual = scanAuditSummary(bytes).costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('reads the model', () => {
+    const expected = 'claude-sonnet-5';
+    const actual = scanAuditSummary(bytes).model;
+    expect(actual).toBe(expected);
+  });
+
+  it('reads the context total of the last assistant turn', () => {
+    const expected = 374063;
+    const actual = scanAuditSummary(bytes).contextTokens;
+    expect(actual).toBe(expected);
+  });
+
+  it('counts the turn once across the pair of lines', () => {
+    const expected = 1;
+    const actual = scanAuditSummary(bytes).turns;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/conversationKeyMap.spec.ts
+++ b/apps/claude-sdk-cli/test/conversationKeyMap.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { conversationKeyMap } from '../src/controller/conversationKeyMap.js';
+
+describe('conversationKeyMap — navigation', () => {
+  it('moves up the list on the up arrow', () => {
+    const expected = 'prev';
+    const actual = conversationKeyMap({ type: 'up' });
+    expect(actual).toBe(expected);
+  });
+
+  it('moves down the list on the down arrow', () => {
+    const expected = 'next';
+    const actual = conversationKeyMap({ type: 'down' });
+    expect(actual).toBe(expected);
+  });
+
+  it('moves up the list on a wheel scroll up', () => {
+    const expected = 'prev';
+    const actual = conversationKeyMap({ type: 'scroll_up' });
+    expect(actual).toBe(expected);
+  });
+
+  it('moves down the list on a wheel scroll down', () => {
+    const expected = 'next';
+    const actual = conversationKeyMap({ type: 'scroll_down' });
+    expect(actual).toBe(expected);
+  });
+
+  it('pages up', () => {
+    const expected = 'page-up';
+    const actual = conversationKeyMap({ type: 'page_up' });
+    expect(actual).toBe(expected);
+  });
+
+  it('pages down', () => {
+    const expected = 'page-down';
+    const actual = conversationKeyMap({ type: 'page_down' });
+    expect(actual).toBe(expected);
+  });
+
+  it('jumps to the newest on home', () => {
+    const expected = 'home';
+    const actual = conversationKeyMap({ type: 'home' });
+    expect(actual).toBe(expected);
+  });
+
+  it('jumps to the oldest on end', () => {
+    const expected = 'end';
+    const actual = conversationKeyMap({ type: 'end' });
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('conversationKeyMap — peek', () => {
+  it('toggles the peek on space', () => {
+    const expected = 'toggle-peek';
+    const actual = conversationKeyMap({ type: 'char', value: ' ' });
+    expect(actual).toBe(expected);
+  });
+
+  it('ignores any other character', () => {
+    const actual = conversationKeyMap({ type: 'char', value: 'a' });
+    expect(actual).toBeNull();
+  });
+});
+
+describe('conversationKeyMap — unclaimed keys', () => {
+  it('leaves enter to the handler, since switching is not navigation', () => {
+    const actual = conversationKeyMap({ type: 'enter' });
+    expect(actual).toBeNull();
+  });
+
+  it('leaves the view keys alone so they reach the view selector', () => {
+    const actual = conversationKeyMap({ type: 'f1' });
+    expect(actual).toBeNull();
+  });
+});

--- a/apps/claude-sdk-cli/test/formatConversationEntry.spec.ts
+++ b/apps/claude-sdk-cli/test/formatConversationEntry.spec.ts
@@ -1,0 +1,143 @@
+import { Instant, ZoneId, ZoneOffset } from '@js-joda/core';
+import { describe, expect, it } from 'vitest';
+import { formatAge, formatCost, formatModel, formatSpan, formatTimeOfDay, formatTokens, oneLine } from '../src/view/formatConversationEntry.js';
+
+const UTC = ZoneId.UTC;
+
+describe('formatTimeOfDay', () => {
+  it('renders hours, minutes and seconds', () => {
+    const expected = '13:37:50';
+    const actual = formatTimeOfDay('2026-07-28T13:37:50.000Z', UTC);
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the seconds field when the seconds are zero', () => {
+    const expected = '21:28:00';
+    const actual = formatTimeOfDay('2026-07-29T21:28:00.000Z', UTC);
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps the hours field when the hour is early', () => {
+    const expected = '02:05:09';
+    const actual = formatTimeOfDay('2026-07-29T02:05:09.000Z', UTC);
+    expect(actual).toBe(expected);
+  });
+
+  // A fixed offset rather than a named zone: named zones need @js-joda/timezone, which this
+  // package does not carry, and the behaviour under test is the offset shift either way.
+  it('renders in the given zone, not UTC', () => {
+    const expected = '23:37:50';
+    const actual = formatTimeOfDay('2026-07-28T13:37:50.000Z', ZoneOffset.ofHours(10));
+    expect(actual).toBe(expected);
+  });
+
+  it('shows a placeholder when the message has no timestamp', () => {
+    const expected = '--:--:--';
+    const actual = formatTimeOfDay(null, UTC);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatSpan', () => {
+  it('renders hours and minutes for a long conversation', () => {
+    const expected = '3h 22m';
+    const actual = formatSpan('2026-07-28T10:15:14.000Z', '2026-07-28T13:37:50.000Z');
+    expect(actual).toBe(expected);
+  });
+
+  it('renders minutes alone under an hour', () => {
+    const expected = '3m';
+    const actual = formatSpan('2026-07-28T13:56:36.000Z', '2026-07-28T13:59:39.000Z');
+    expect(actual).toBe(expected);
+  });
+
+  it('renders seconds for a conversation under a minute', () => {
+    const expected = '42s';
+    const actual = formatSpan('2026-07-28T13:56:36.000Z', '2026-07-28T13:57:18.000Z');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatAge', () => {
+  const NOW = Instant.parse('2026-07-29T14:00:00.000Z');
+
+  it('renders days for a conversation from a previous day', () => {
+    const expected = '1d ago';
+    const actual = formatAge('2026-07-28T13:37:50.000Z', NOW);
+    expect(actual).toBe(expected);
+  });
+
+  it('renders hours within the day', () => {
+    const expected = '3h ago';
+    const actual = formatAge('2026-07-29T10:30:00.000Z', NOW);
+    expect(actual).toBe(expected);
+  });
+
+  it('renders minutes within the hour', () => {
+    const expected = '22m ago';
+    const actual = formatAge('2026-07-29T13:38:00.000Z', NOW);
+    expect(actual).toBe(expected);
+  });
+
+  it('says just now under a minute', () => {
+    const expected = 'just now';
+    const actual = formatAge('2026-07-29T13:59:30.000Z', NOW);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatTokens', () => {
+  it('renders millions compactly', () => {
+    const expected = '1.2M';
+    const actual = formatTokens(1_200_000);
+    expect(actual).toBe(expected);
+  });
+
+  it('renders thousands compactly', () => {
+    const expected = '407.2k';
+    const actual = formatTokens(407_198);
+    expect(actual).toBe(expected);
+  });
+
+  it('renders a small count as it is', () => {
+    const expected = '512';
+    const actual = formatTokens(512);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatModel', () => {
+  it('drops the vendor prefix', () => {
+    const expected = 'sonnet-5';
+    const actual = formatModel('claude-sonnet-5');
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves a model without the prefix alone', () => {
+    const expected = 'some-other-model';
+    const actual = formatModel('some-other-model');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatCost', () => {
+  it('matches the status line to four decimals', () => {
+    const expected = '$16.2400';
+    const actual = formatCost(16.24);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('oneLine', () => {
+  it('collapses a multi-line message to a single line', () => {
+    const expected = 'first line second line';
+    const actual = oneLine('first line\nsecond line');
+    expect(actual).toBe(expected);
+  });
+
+  it('closes up runs of whitespace', () => {
+    const expected = 'spaced out';
+    const actual = oneLine('spaced     out');
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
+++ b/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
@@ -1,3 +1,4 @@
+import { DIM } from '@shellicar/claude-core/ansi';
 import { describe, expect, it } from 'vitest';
 import { CommandModeState } from '../src/model/CommandModeState.js';
 import { renderCommandMode } from '../src/view/renderCommandMode.js';
@@ -97,6 +98,36 @@ describe('renderCommandMode — command mode active', () => {
   it('commandRow includes new-conversation hint when in command mode with no attachments', () => {
     const expected = true;
     const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('n new');
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('renderCommandMode — the new-conversation option', () => {
+  it('offers starting a conversation when one can be started', () => {
+    const row = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow;
+    const expected = false;
+    const actual = row.includes(`${DIM}n new`);
+    expect(actual).toBe(expected);
+  });
+
+  it('greys the option when a conversation cannot be started', () => {
+    const row = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, false).commandRow;
+    const expected = true;
+    const actual = row.includes(`${DIM}n new`);
+    expect(actual).toBe(expected);
+  });
+
+  it('still shows the option when it cannot be used', () => {
+    const row = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, false).commandRow;
+    const expected = true;
+    const actual = row.includes('n new');
+    expect(actual).toBe(expected);
+  });
+
+  it('leaves the other options alone when it cannot be used', () => {
+    const row = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, false).commandRow;
+    const expected = true;
+    const actual = row.includes('ESC cancel');
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
+++ b/apps/claude-sdk-cli/test/renderCommandMode.spec.ts
@@ -37,13 +37,13 @@ function stateInCommandModeWithText(text = 'hello world'): CommandModeState {
 describe('renderCommandMode — empty state', () => {
   it('commandRow is empty when no command mode and no attachments', () => {
     const expected = '';
-    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow;
+    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow;
     expect(actual).toBe(expected);
   });
 
   it('previewRows is empty when no command mode and no attachments', () => {
     const expected = 0;
-    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(emptyState(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows.length;
     expect(actual).toBe(expected);
   });
 });
@@ -55,13 +55,13 @@ describe('renderCommandMode — empty state', () => {
 describe('renderCommandMode — attachment chips without command mode', () => {
   it('commandRow is non-empty when attachments exist even without command mode', () => {
     const expected = true;
-    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.length > 0;
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.length > 0;
     expect(actual).toBe(expected);
   });
 
   it('commandRow does not include cmd hint when not in command mode', () => {
     const expected = false;
-    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('cmd');
     expect(actual).toBe(expected);
   });
 });
@@ -73,31 +73,31 @@ describe('renderCommandMode — attachment chips without command mode', () => {
 describe('renderCommandMode — command mode active', () => {
   it('commandRow includes "cmd" when in command mode', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('cmd');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('cmd');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes paste hint when in command mode with no attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('paste');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('paste');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes select hint when in command mode with attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandModeWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('select');
+    const actual = renderCommandMode(stateInCommandModeWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('select');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes model sub-mode hint when in command mode with no attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('m model');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('m model');
     expect(actual).toBe(expected);
   });
 
   it('commandRow includes new-conversation hint when in command mode with no attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('n new');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('n new');
     expect(actual).toBe(expected);
   });
 });
@@ -139,7 +139,7 @@ describe('renderCommandMode — the new-conversation option', () => {
 describe('renderCommandMode — text attachment chip', () => {
   it('commandRow includes [txt ...] chip for text attachments', () => {
     const expected = true;
-    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('[txt ');
+    const actual = renderCommandMode(stateWithText(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('[txt ');
     expect(actual).toBe(expected);
   });
 });
@@ -149,7 +149,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/myfile.txt', 'file', 512);
     const expected = true;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('myfile.txt');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('myfile.txt');
     expect(actual).toBe(expected);
   });
 
@@ -157,7 +157,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/mydir', 'dir');
     const expected = true;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('mydir/');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('mydir/');
     expect(actual).toBe(expected);
   });
 
@@ -165,7 +165,7 @@ describe('renderCommandMode — file attachment chip', () => {
     const state = new CommandModeState();
     state.addFile('/tmp/missing.txt', 'missing');
     const expected = true;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('?');
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('?');
     expect(actual).toBe(expected);
   });
 });
@@ -180,7 +180,7 @@ describe('renderCommandMode — previewRows', () => {
     state.togglePreview(); // no selection, no-op initially — need to add text first... actually addText selects it
     // Re-create: addText selects the item, but commandMode is off
     const expected = 0;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows.length;
     expect(actual).toBe(expected);
   });
 
@@ -188,7 +188,7 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText('line one\nline two');
     // previewMode is still false
     const expected = 0;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows.length;
     expect(actual).toBe(expected);
   });
 
@@ -196,14 +196,14 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText('line one\nline two');
     state.togglePreview();
     const expected = true;
-    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows.length > 0;
+    const actual = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows.length > 0;
     expect(actual).toBe(expected);
   });
 
   it('previewRows contains text attachment content', () => {
     const state = stateInCommandModeWithText('unique-sentinel-value');
     state.togglePreview();
-    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('unique-sentinel-value'));
     expect(actual).toBe(expected);
@@ -214,7 +214,7 @@ describe('renderCommandMode — previewRows', () => {
     state.addFile('/tmp/special-path', 'file', 100);
     state.toggleCommandMode();
     state.togglePreview();
-    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).previewRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('special-path'));
     expect(actual).toBe(expected);
@@ -225,7 +225,7 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText(manyLines);
     state.togglePreview();
     const cap = 3;
-    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, cap).previewRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, cap, true).previewRows;
     const expected = true;
     const actual = rows.length <= cap;
     expect(actual).toBe(expected);
@@ -236,7 +236,7 @@ describe('renderCommandMode — previewRows', () => {
     const state = stateInCommandModeWithText(manyLines);
     state.togglePreview();
     const maxText = 4;
-    const rows = renderCommandMode(state, '', COLS, maxText, MAX_ROWS).previewRows;
+    const rows = renderCommandMode(state, '', COLS, maxText, MAX_ROWS, true).previewRows;
     const expected = true;
     // Should see the "more lines" ellipsis
     const actual = rows.some((r) => r.includes('more lines'));
@@ -252,13 +252,13 @@ describe('renderCommandMode — conversationId', () => {
   it('shows the short ID in the command row when conversationId is set', () => {
     const id = 'abcd1234-5678-90ab-cdef-1234567890ab';
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), id, COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes(id.slice(0, 8));
+    const actual = renderCommandMode(stateInCommandMode(), id, COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes(id.slice(0, 8));
     expect(actual).toBe(expected);
   });
 
   it('does not show an ID label when conversationId is empty', () => {
     const expected = false;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('abcd1234');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('abcd1234');
     expect(actual).toBe(expected);
   });
 });
@@ -284,13 +284,13 @@ function stateInCdEditor(cwd = '/repos/project'): CommandModeState {
 describe('renderCommandMode — cd sub-menu', () => {
   it('root command row offers the c cd entry', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('c cd');
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('c cd');
     expect(actual).toBe(expected);
   });
 
   it('cd sub-menu command row offers the directory entry', () => {
     const expected = true;
-    const actual = renderCommandMode(stateInCd(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).commandRow.includes('d directory');
+    const actual = renderCommandMode(stateInCd(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).commandRow.includes('d directory');
     expect(actual).toBe(expected);
   });
 });
@@ -298,12 +298,12 @@ describe('renderCommandMode — cd sub-menu', () => {
 describe('renderCommandMode — cd path editor', () => {
   it('editorRows is empty when the cd editor is closed', () => {
     const expected = 0;
-    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows.length;
+    const actual = renderCommandMode(stateInCommandMode(), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).editorRows.length;
     expect(actual).toBe(expected);
   });
 
   it('editorRows shows the pre-filled path', () => {
-    const rows = renderCommandMode(stateInCdEditor('/repos/sentinel-dir'), '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows;
+    const rows = renderCommandMode(stateInCdEditor('/repos/sentinel-dir'), '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).editorRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('/repos/sentinel-dir'));
     expect(actual).toBe(expected);
@@ -312,7 +312,7 @@ describe('renderCommandMode — cd path editor', () => {
   it('editorRows shows the failure message when a move failed', () => {
     const state = stateInCdEditor();
     state.setCdError('no such directory');
-    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS).editorRows;
+    const rows = renderCommandMode(state, '', COLS, MAX_TEXT_LINES, MAX_ROWS, true).editorRows;
     const expected = true;
     const actual = rows.some((r) => r.includes('no such directory'));
     expect(actual).toBe(expected);

--- a/apps/claude-sdk-cli/test/renderViewBar.spec.ts
+++ b/apps/claude-sdk-cli/test/renderViewBar.spec.ts
@@ -3,15 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { renderViewBar } from '../src/view/renderViewBar.js';
 
 describe('renderViewBar', () => {
-  it('renders the active primary entry accented and the history entry dimmed', () => {
-    const expected = `${CYAN}${UNDERLINE}F1 primary${RESET}    ${DIM}F2 history${RESET}`;
+  it('renders the active primary entry accented and the others dimmed', () => {
+    const expected = `${CYAN}${UNDERLINE}F1 primary${RESET}    ${DIM}F2 history${RESET}    ${DIM}F3 conversations${RESET}`;
     const actual = renderViewBar('primary');
     expect(actual).toBe(expected);
   });
 
-  it('renders the active history entry accented and the primary entry dimmed', () => {
-    const expected = `${DIM}F1 primary${RESET}    ${CYAN}${UNDERLINE}F2 history${RESET}`;
+  it('renders the active history entry accented and the others dimmed', () => {
+    const expected = `${DIM}F1 primary${RESET}    ${CYAN}${UNDERLINE}F2 history${RESET}    ${DIM}F3 conversations${RESET}`;
     const actual = renderViewBar('history');
+    expect(actual).toBe(expected);
+  });
+
+  it('renders the active conversations entry accented and the others dimmed', () => {
+    const expected = `${DIM}F1 primary${RESET}    ${DIM}F2 history${RESET}    ${CYAN}${UNDERLINE}F3 conversations${RESET}`;
+    const actual = renderViewBar('conversations');
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/scanAuditPeek.spec.ts
+++ b/apps/claude-sdk-cli/test/scanAuditPeek.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { scanAuditPeek } from '../src/conversations/scanAuditPeek.js';
+
+const userLine = (text: string, timestamp = '2026-07-28T10:00:00.000Z'): string => JSON.stringify({ role: 'user', timestamp, content: [{ type: 'text', text }] });
+
+const assistantLine = (text: string, timestamp = '2026-07-28T10:01:00.000Z'): string => JSON.stringify({ timestamp, role: 'assistant', content: [{ type: 'text', text }] });
+
+const toolUseLine = (timestamp = '2026-07-28T10:02:00.000Z'): string => JSON.stringify({ timestamp, role: 'assistant', content: [{ type: 'tool_use', name: 'EditFile', input: {} }] });
+
+const toolResultLine = (timestamp = '2026-07-28T10:03:00.000Z'): string => JSON.stringify({ role: 'user', timestamp, content: [{ type: 'tool_result', content: 'done' }] });
+
+const auditOf = (...lines: string[]): Buffer => Buffer.from(`${lines.join('\n')}\n`, 'utf-8');
+
+describe('scanAuditPeek — ordering', () => {
+  it('returns messages oldest first', () => {
+    const bytes = auditOf(userLine('the ask'), assistantLine('the reply'));
+    const expected = ['the ask', 'the reply'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('keeps the newest messages when the limit cuts the conversation', () => {
+    const bytes = auditOf(userLine('first'), assistantLine('second'), userLine('third'));
+    const expected = ['second', 'third'];
+    const actual = scanAuditPeek(bytes, 2).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('reports how many messages it did not reach', () => {
+    const bytes = auditOf(userLine('first'), assistantLine('second'), userLine('third'));
+    const expected = 1;
+    const actual = scanAuditPeek(bytes, 2).earlier;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports nothing earlier when the whole conversation fits', () => {
+    const bytes = auditOf(userLine('first'), assistantLine('second'));
+    const expected = 0;
+    const actual = scanAuditPeek(bytes, 10).earlier;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditPeek — roles', () => {
+  it('marks a user message', () => {
+    const bytes = auditOf(userLine('the ask'));
+    const expected = 'user';
+    const actual = scanAuditPeek(bytes, 10).entries[0]?.kind;
+    expect(actual).toBe(expected);
+  });
+
+  it('marks an assistant message', () => {
+    const bytes = auditOf(assistantLine('the reply'));
+    const expected = 'assistant';
+    const actual = scanAuditPeek(bytes, 10).entries[0]?.kind;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditPeek — tool runs', () => {
+  it('counts one tool per execution, not one per message', () => {
+    const bytes = auditOf(userLine('the ask'), toolUseLine(), toolResultLine(), toolUseLine(), toolResultLine(), assistantLine('the reply'));
+    const expected = ['the ask', '2 tools', 'the reply'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('names a single tool in the singular', () => {
+    const bytes = auditOf(userLine('the ask'), toolUseLine(), toolResultLine(), assistantLine('the reply'));
+    const expected = '1 tool';
+    const actual = scanAuditPeek(bytes, 10).entries[1]?.text;
+    expect(actual).toBe(expected);
+  });
+
+  it('keeps separate tool runs separate', () => {
+    const bytes = auditOf(toolResultLine(), assistantLine('between'), toolResultLine());
+    const expected = 3;
+    const actual = scanAuditPeek(bytes, 10).entries.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('counts a collapsed run as one entry against the limit', () => {
+    const bytes = auditOf(userLine('the ask'), toolResultLine(), toolResultLine(), toolResultLine(), assistantLine('the reply'));
+    const expected = ['the ask', '3 tools', 'the reply'];
+    const actual = scanAuditPeek(bytes, 3).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives an assistant tool call no line of its own, since its result carries the count', () => {
+    const bytes = auditOf(userLine('the ask'), toolUseLine(), assistantLine('the reply'));
+    const expected = ['the ask', 'the reply'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives a thinking-only assistant turn no line of its own', () => {
+    const thinkingLine = JSON.stringify({ role: 'assistant', timestamp: '2026-07-28T10:04:00.000Z', content: [{ type: 'thinking', thinking: 'working it out' }] });
+    const bytes = auditOf(userLine('the ask'), thinkingLine, assistantLine('the reply'));
+    const expected = ['the ask', 'the reply'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('scanAuditPeek — system reminders', () => {
+  const reminderLedLine = (text: string): string =>
+    JSON.stringify({
+      role: 'user',
+      timestamp: '2026-07-28T10:00:00.000Z',
+      content: [
+        { type: 'text', text: '<system-reminder>\nskills catalogue\n</system-reminder>\n\n' },
+        { type: 'text', text },
+      ],
+    });
+
+  const reminderOnlyLine = (): string => JSON.stringify({ role: 'user', timestamp: '2026-07-28T10:00:30.000Z', content: [{ type: 'text', text: '<system-reminder>\nclock stamp\n</system-reminder>' }] });
+
+  it('shows what the operator said, not the reminders leading the message', () => {
+    const bytes = auditOf(reminderLedLine('can we strip system reminders please'));
+    const expected = 'can we strip system reminders please';
+    const actual = scanAuditPeek(bytes, 10).entries[0]?.text;
+    expect(actual).toBe(expected);
+  });
+
+  it('drops a message that is only reminders', () => {
+    const bytes = auditOf(userLine('the ask'), reminderOnlyLine(), assistantLine('the reply'));
+    const expected = ['the ask', 'the reply'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+
+  it('does not count a reminder-only message as tool activity', () => {
+    const bytes = auditOf(reminderOnlyLine(), toolResultLine());
+    const expected = ['1 tool'];
+    const actual = scanAuditPeek(bytes, 10).entries.map((entry) => entry.text);
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('scanAuditPeek — edge cases', () => {
+  it('reads an empty file as no entries', () => {
+    const expected = 0;
+    const actual = scanAuditPeek(Buffer.alloc(0), 10).entries.length;
+    expect(actual).toBe(expected);
+  });
+
+  it('carries each message timestamp', () => {
+    const bytes = auditOf(userLine('the ask', '2026-07-28T10:15:14.000Z'));
+    const expected = '2026-07-28T10:15:14.000Z';
+    const actual = scanAuditPeek(bytes, 10).entries[0]?.timestampUtc;
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/claude-sdk-cli/test/scanAuditSummary.spec.ts
+++ b/apps/claude-sdk-cli/test/scanAuditSummary.spec.ts
@@ -133,6 +133,16 @@ describe('scanAuditSummary — preview text', () => {
     const actual = scanAuditSummary(bytes).firstUserText;
     expect(actual).toBe(expected);
   });
+
+  it('does not decode a tool result while looking for the opening ask', () => {
+    // Truncated JSON: readable in the head window, unparseable as a whole. Decoding it would throw,
+    // so the summary coming back at all is the proof the payload was stepped over.
+    const unparseableToolResult = `${JSON.stringify({ role: 'user', turnId: 'turn-1', queryId: 'query-1', timestamp: '2026-07-28T10:00:00.000Z', content: [{ type: 'tool_result', content: 'x'.repeat(400) }] }).slice(0, -3)}`;
+    const bytes = auditOf(unparseableToolResult, userLine({ text: 'the opening ask' }));
+    const expected = 'the opening ask';
+    const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
 });
 
 describe('scanAuditSummary — system reminders', () => {
@@ -162,6 +172,29 @@ describe('scanAuditSummary — system reminders', () => {
     const bytes = auditOf(reminderOnly, userLine({ text: 'the real ask' }));
     const expected = 'the real ask';
     const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — timestamps', () => {
+  const withTimestamp = (timestamp: string): string => JSON.stringify({ role: 'user', turnId: 'turn-1', queryId: 'query-1', timestamp, content: [{ type: 'text', text: 'the ask' }] });
+
+  it('reports a timestamp that is not a date as absent', () => {
+    const bytes = auditOf(withTimestamp('not a date at all'));
+    const actual = scanAuditSummary(bytes).firstUtc;
+    expect(actual).toBeNull();
+  });
+
+  it('reports a truncated timestamp as absent', () => {
+    const bytes = auditOf(withTimestamp('2026-07-28T13'));
+    const actual = scanAuditSummary(bytes).lastUtc;
+    expect(actual).toBeNull();
+  });
+
+  it('still reads the rest of the summary when a timestamp is unusable', () => {
+    const bytes = auditOf(withTimestamp('not a date at all'), assistantLine({ costUsd: 2.5 }));
+    const expected = 2.5;
+    const actual = scanAuditSummary(bytes).costUsd;
     expect(actual).toBe(expected);
   });
 });

--- a/apps/claude-sdk-cli/test/scanAuditSummary.spec.ts
+++ b/apps/claude-sdk-cli/test/scanAuditSummary.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { scanAuditSummary } from '../src/conversations/scanAuditSummary.js';
+
+type LineOverrides = {
+  timestamp?: string;
+  turnId?: string;
+  queryId?: string;
+  text?: string;
+  costUsd?: number;
+  model?: string;
+  usage?: { input_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number };
+};
+
+/** A user line, in the shape this CLI writes: role and ids first, content after. */
+const userLine = (o: LineOverrides = {}): string =>
+  JSON.stringify({
+    role: 'user',
+    id: 'msg-user',
+    turnId: o.turnId ?? 'turn-1',
+    queryId: o.queryId ?? 'query-1',
+    timestamp: o.timestamp ?? '2026-07-28T10:00:00.000Z',
+    content: [{ type: 'text', text: o.text ?? 'the opening ask' }],
+  });
+
+/** An assistant line: timestamp/costUsd/model at the head, usage and ids at the tail. */
+const assistantLine = (o: LineOverrides = {}): string =>
+  JSON.stringify({
+    timestamp: o.timestamp ?? '2026-07-28T10:01:00.000Z',
+    costUsd: o.costUsd ?? 1.5,
+    model: o.model ?? 'claude-sonnet-5',
+    id: 'msg-assistant',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text: o.text ?? 'the reply' }],
+    usage: o.usage ?? { input_tokens: 10, cache_creation_input_tokens: 20, cache_read_input_tokens: 30 },
+    turnId: o.turnId ?? 'turn-1',
+    queryId: o.queryId ?? 'query-1',
+  });
+
+const auditOf = (...lines: string[]): Buffer => Buffer.from(`${lines.join('\n')}\n`, 'utf-8');
+
+/** A user line carrying a huge base64 payload, as a real tool result does. */
+const fatUserLine = (): string =>
+  JSON.stringify({
+    role: 'user',
+    id: 'msg-fat',
+    turnId: 'turn-fat',
+    queryId: 'query-1',
+    timestamp: '2026-07-28T10:02:00.000Z',
+    content: [{ type: 'tool_result', content: [{ type: 'image', source: { data: 'A'.repeat(200_000) } }] }],
+  });
+
+describe('scanAuditSummary — counts', () => {
+  it('counts distinct turns', () => {
+    const bytes = auditOf(userLine({ turnId: 'turn-1' }), assistantLine({ turnId: 'turn-1' }), assistantLine({ turnId: 'turn-2' }));
+    const expected = 2;
+    const actual = scanAuditSummary(bytes).turns;
+    expect(actual).toBe(expected);
+  });
+
+  it('counts distinct queries', () => {
+    const bytes = auditOf(userLine({ queryId: 'query-1' }), assistantLine({ queryId: 'query-1' }), userLine({ queryId: 'query-2' }), assistantLine({ queryId: 'query-2' }));
+    const expected = 2;
+    const actual = scanAuditSummary(bytes).queries;
+    expect(actual).toBe(expected);
+  });
+
+  it('sums the cost of every assistant line', () => {
+    const bytes = auditOf(userLine(), assistantLine({ costUsd: 1.25 }), assistantLine({ costUsd: 2.5 }));
+    const expected = 3.75;
+    const actual = scanAuditSummary(bytes).costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('ignores user lines when summing cost', () => {
+    const bytes = auditOf(userLine(), assistantLine({ costUsd: 1.25 }));
+    const expected = 1.25;
+    const actual = scanAuditSummary(bytes).costUsd;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — timing', () => {
+  it('reports the earliest timestamp', () => {
+    const bytes = auditOf(userLine({ timestamp: '2026-07-28T10:00:00.000Z' }), assistantLine({ timestamp: '2026-07-28T13:37:50.000Z' }));
+    const expected = '2026-07-28T10:00:00.000Z';
+    const actual = scanAuditSummary(bytes).firstUtc;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports the latest timestamp', () => {
+    const bytes = auditOf(userLine({ timestamp: '2026-07-28T10:00:00.000Z' }), assistantLine({ timestamp: '2026-07-28T13:37:50.000Z' }));
+    const expected = '2026-07-28T13:37:50.000Z';
+    const actual = scanAuditSummary(bytes).lastUtc;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — the last assistant turn', () => {
+  it('reports the model of the last assistant line', () => {
+    const bytes = auditOf(assistantLine({ model: 'claude-sonnet-5' }), assistantLine({ model: 'claude-fable-5' }));
+    const expected = 'claude-fable-5';
+    const actual = scanAuditSummary(bytes).model;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports context as the last turn total, not an accumulation', () => {
+    const bytes = auditOf(assistantLine({ usage: { input_tokens: 1, cache_creation_input_tokens: 2, cache_read_input_tokens: 3 } }), assistantLine({ usage: { input_tokens: 10, cache_creation_input_tokens: 20, cache_read_input_tokens: 30 } }));
+    const expected = 60;
+    const actual = scanAuditSummary(bytes).contextTokens;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — preview text', () => {
+  it('reports the first user message', () => {
+    const bytes = auditOf(userLine({ text: 'the opening ask' }), assistantLine(), userLine({ text: 'a later ask' }));
+    const expected = 'the opening ask';
+    const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
+
+  it('reports the last assistant message', () => {
+    const bytes = auditOf(userLine(), assistantLine({ text: 'an early reply' }), assistantLine({ text: 'the final reply' }));
+    const expected = 'the final reply';
+    const actual = scanAuditSummary(bytes).lastAssistantText;
+    expect(actual).toBe(expected);
+  });
+
+  it('skips a line whose first block is not text', () => {
+    const bytes = auditOf(fatUserLine(), userLine({ text: 'the opening ask' }));
+    const expected = 'the opening ask';
+    const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — system reminders', () => {
+  /** How the CLI actually writes a first user message: reminders lead, the operator's words follow. */
+  const reminderLedLine = (text: string): string =>
+    JSON.stringify({
+      role: 'user',
+      turnId: 'turn-1',
+      queryId: 'query-1',
+      timestamp: '2026-07-28T10:00:00.000Z',
+      content: [
+        { type: 'text', text: '<system-reminder>\nThe following skills are available\n</system-reminder>\n\n' },
+        { type: 'text', text: '<system-reminder>\nCLAUDE.md content\n</system-reminder>\n\n' },
+        { type: 'text', text },
+      ],
+    });
+
+  it('previews what the operator said, not the reminders that lead the message', () => {
+    const bytes = auditOf(reminderLedLine('so after all this time, i want a read only mode'));
+    const expected = 'so after all this time, i want a read only mode';
+    const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
+
+  it('looks past a message that is only reminders to the first one with words', () => {
+    const reminderOnly = JSON.stringify({ role: 'user', turnId: 'turn-1', queryId: 'query-1', timestamp: '2026-07-28T10:00:00.000Z', content: [{ type: 'text', text: '<system-reminder>\nclock stamp\n</system-reminder>' }] });
+    const bytes = auditOf(reminderOnly, userLine({ text: 'the real ask' }));
+    const expected = 'the real ask';
+    const actual = scanAuditSummary(bytes).firstUserText;
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('scanAuditSummary — edge cases', () => {
+  it('reads an empty file as an empty summary', () => {
+    const expected = 0;
+    const actual = scanAuditSummary(Buffer.alloc(0)).turns;
+    expect(actual).toBe(expected);
+  });
+
+  it('counts a fat tool-result line towards the turns without reading its payload', () => {
+    const bytes = auditOf(userLine({ turnId: 'turn-1' }), fatUserLine());
+    const expected = 2;
+    const actual = scanAuditSummary(bytes).turns;
+    expect(actual).toBe(expected);
+  });
+
+  it('reads no cost from a Claude Code audit file, whose fields are nested under message', () => {
+    const foreign = JSON.stringify({ timestamp: '2026-03-28T09:23:53.195Z', type: 'assistant', message: { model: 'claude-sonnet-4-6', role: 'assistant', content: [{ type: 'text', text: 'hi' }], usage: { input_tokens: 5 } } });
+    const expected = 0;
+    const actual = scanAuditSummary(auditOf(foreign)).costUsd;
+    expect(actual).toBe(expected);
+  });
+
+  it('tolerates a file with no trailing newline', () => {
+    const bytes = Buffer.from(`${userLine()}\n${assistantLine({ costUsd: 2 })}`, 'utf-8');
+    const expected = 2;
+    const actual = scanAuditSummary(bytes).costUsd;
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/claude-core/CHANGELOG.md
+++ b/packages/claude-core/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the conversation-history model: store types, read/write interfaces, and near-duplicate detection (shingle, minhash, LSH) for the sweep
 - Add the Memory tool: a persistent, shared, relevance-searchable memory Claude reads and writes across sessions
 - Condition attached images: resize to a 2000px PNG long edge via sips, downscaling only, and log each outcome to the debug log; a missing or failing sips passes the image through unchanged
+- F3 is now recognised as a key action
+- IFileSystem gains readFileBytes, for a reader that scans a file's bytes rather than decoding it to a string
 - Parse mouse-wheel events from stdin into scroll_up/scroll_down key actions; add enableMouse/disableMouse escape sequences
 - Support binary file reads through encoding parameter on IFileSystem.readFile
 

--- a/packages/claude-core/changes.jsonl
+++ b/packages/claude-core/changes.jsonl
@@ -23,3 +23,5 @@
 {"description":"Fix version metadata","category":"fixed"}
 {"description":"Depend on @shellicar/core-di instead of @shellicar/core-di-lite","category":"changed"}
 {"description":"Config merge now recurses arbitrarily deep instead of stopping after one nested level, so a local override several levels down (e.g. one entry of a nested record) no longer silently replaces its whole containing object and drops its siblings","category":"fixed"}
+{"description":"IFileSystem gains readFileBytes, for a reader that scans a file's bytes rather than decoding it to a string","category":"added"}
+{"description":"F3 is now recognised as a key action","category":"added"}

--- a/packages/claude-core/src/ansi.ts
+++ b/packages/claude-core/src/ansi.ts
@@ -30,6 +30,7 @@ export const RED = '\x1B[31m';
 export const GREEN = '\x1B[32m';
 export const YELLOW = '\x1B[33m';
 export const CYAN = '\x1B[36m';
+export const GOLD = '\x1B[93m';
 export const BOLD_WHITE = '\x1B[1;97m';
 
 // Mouse tracking. 1000 = button-event tracking (reports the wheel as buttons

--- a/packages/claude-core/src/fs/interfaces.ts
+++ b/packages/claude-core/src/fs/interfaces.ts
@@ -10,6 +10,8 @@ export abstract class IFileSystem {
   public abstract homedir(): string;
   public abstract exists(path: string): Promise<boolean>;
   public abstract readFile(path: string, encoding?: BufferEncoding): Promise<string>;
+  /** The file's raw bytes, for a reader that scans rather than decodes. */
+  public abstract readFileBytes(path: string): Promise<Buffer>;
   public abstract writeFile(path: string, content: string): Promise<void>;
   public abstract deleteFile(path: string): Promise<void>;
   public abstract deleteDirectory(path: string): Promise<void>;

--- a/packages/claude-core/src/input.ts
+++ b/packages/claude-core/src/input.ts
@@ -42,6 +42,7 @@ export type KeyAction =
   | { type: 'page_down' }
   | { type: 'f1' }
   | { type: 'f2' }
+  | { type: 'f3' }
   | { type: 'shift+up' }
   | { type: 'shift+down' }
   | { type: 'scroll_up' }
@@ -208,6 +209,8 @@ export function translateKey(ch: string | undefined, key: NodeKey | undefined): 
       return { type: 'f1' };
     case 'f2':
       return { type: 'f2' };
+    case 'f3':
+      return { type: 'f3' };
     case 'pageup':
       return { type: 'page_up' };
     case 'pagedown':

--- a/packages/claude-core/test/MemoryFileSystem.ts
+++ b/packages/claude-core/test/MemoryFileSystem.ts
@@ -42,6 +42,10 @@ export class MemoryFileSystem extends IFileSystem {
     throw new Error('MemoryFileSystem: exists() not supported');
   }
 
+  public readFileBytes(_path?: string): Promise<Buffer> {
+    throw new Error('MemoryFileSystem: readFileBytes() not supported');
+  }
+
   public readFile(_path?: string, _encoding?: BufferEncoding): Promise<string> {
     throw new Error('MemoryFileSystem: readFile() not supported');
   }

--- a/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
+++ b/packages/claude-sdk-tools/src/fs/NodeFileSystem.ts
@@ -34,6 +34,10 @@ export class NodeFileSystem extends IFileSystem {
     return readFile(path, encoding);
   }
 
+  public async readFileBytes(path: string): Promise<Buffer> {
+    return readFile(path);
+  }
+
   public async writeFile(path: string, content: string): Promise<void> {
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, content, 'utf-8');

--- a/packages/claude-sdk-tools/test/MemoryFileSystem.ts
+++ b/packages/claude-sdk-tools/test/MemoryFileSystem.ts
@@ -63,6 +63,16 @@ export class MemoryFileSystem extends IFileSystem {
     return content.toString('utf8');
   }
 
+  public async readFileBytes(path: string): Promise<Buffer> {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      const err = new Error(`ENOENT: no such file or directory, open '${path}'`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return content;
+  }
+
   public async writeFile(path: string, content: string): Promise<void> {
     this.files.set(path, Buffer.from(content));
   }

--- a/packages/claude-sdk-tools/test/find-symlinks.spec.ts
+++ b/packages/claude-sdk-tools/test/find-symlinks.spec.ts
@@ -77,6 +77,9 @@ class SymlinkMockFileSystem extends IFileSystem {
   public async readFile(): Promise<string> {
     throw new Error('not implemented');
   }
+  public async readFileBytes(): Promise<Buffer> {
+    throw new Error('not implemented');
+  }
   public async writeFile(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/packages/claude-sdk/CHANGELOG.md
+++ b/packages/claude-sdk/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESC while a tool is running cancels the tool and delivers a cancellation result to Claude; ESC otherwise ends the query
 - Export `IMessageStreamer` from the public barrel
 - Inject a live per-turn date/time stamp into every request
+- isSystemReminderBlock is now exported, so a consumer can tell a <system-reminder> block apart from a message's own words without reimplementing the test
 - Mark a tool-schema field as a filesystem path and normalise all marked paths once from that marker, so the display, the permission check, and handler execution read one produced path
 - Publish defineTool, ToolCancelledError, ToolRefusedError, and pathSchema as their own subpath exports, so a consumer can import just one without pulling in the whole SDK module graph
 - Stamp `messageId`, `turnId`, and `queryId` into each conversation record as nested fields, carried through the jsonl save and load round-trip

--- a/packages/claude-sdk/changes.jsonl
+++ b/packages/claude-sdk/changes.jsonl
@@ -64,3 +64,4 @@
 {"description":"Generalise the dangling tool_use self-heal to cover a partially-answered multi-tool batch, prepending the synthetic result so it still leads the reply as the API requires","category":"fixed"}
 {"description":"ToolRegistry can be configured to require a named skill be loaded before a tool is callable, via a new ISkillGateProvider hook","category":"added"}
 {"description":"A conversation interrupted mid-tool-call now repairs itself automatically before the next message is sent","category":"fixed"}
+{"description":"isSystemReminderBlock is now exported, so a consumer can tell a <system-reminder> block apart from a message's own words without reimplementing the test","category":"added"}

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -9,7 +9,7 @@ import { IMessageStreamer } from './private/MessageStreamer';
 import { IModelCatalog, ModelCatalog } from './private/ModelCatalog';
 import { calculateCost, calculateCostSplit, getContextWindow, reconstructCacheSplit } from './private/pricing';
 import { QueryRunner } from './private/QueryRunner';
-import { toWireTool } from './private/RequestBuilder';
+import { isSystemReminderBlock, toWireTool } from './private/RequestBuilder';
 import { StreamProcessor } from './private/StreamProcessor';
 import { ToolBlockNotifier } from './private/ToolBlockNotifier';
 import { ToolRegistry } from './private/ToolRegistry';
@@ -141,6 +141,7 @@ export {
   IToolsClockListener,
   ITurnRunner,
   IWakeLock,
+  isSystemReminderBlock,
   ModelCatalog,
   normalisePaths,
   pathSchema,


### PR DESCRIPTION
## Summary

- F3 lists every conversation held in the current directory, showing each one's model, cost, query and turn counts, context use, span and age.
- Each entry previews the opening ask and the last reply, so a conversation is identifiable without opening it.
- Space peeks at the tail of a conversation, one line per message with tool runs collapsed to a count.
- Enter switches to a conversation in place, without restarting the CLI.
- The list appears immediately and fills in each conversation's figures as they are read.
- A `<system-reminder>` block never appears in a preview, so what shows is what was said.
