### PR TITLE
Make the Azure identity setup scripts idempotent

### DIFF
--- a/.claude/scripts/az-keychain-cert-create.sh
+++ b/.claude/scripts/az-keychain-cert-create.sh
@@ -2,7 +2,7 @@
 # Generates a self-signed certificate credential for an existing App Registration (created by
 # az-sp-create.sh, which deliberately creates the SP with no credential) and stores it in the
 # macOS login Keychain under the item apps/claude-sdk-cli/src/secrets/Secrets.ts reads: service
-# '@shellicar/credentials', account '<account-name>-cert'.
+# '@shellicar/credentials', account 'az-<account-name>-<identity>-cert'.
 #
 # Owns the certificate's entire local lifecycle in one place: generate, store, delete the temp
 # file. The PEM never leaves this script as an argument the operator has to carry between two
@@ -16,34 +16,50 @@
 #
 # --account-name is the bare key from sdk-config.json's az.accounts (e.g. 'hopeventures'), and
 # --identity is reader|holder — the same two inputs az-sp-create.sh took. This script builds the
-# actual Keychain account name itself, 'az-<account-name>-<identity>', matching exactly what
+# actual Keychain account name itself, 'az-<account-name>-<identity>-cert', matching exactly what
 # Secrets.ts's azCert(account, identity) looks up. It is not typed in already-assembled: making
 # the operator hand-assemble 'az-hopeventures-reader' themselves is exactly the kind of manual
 # string-matching that caused the original bug this pair of scripts replaced.
 #
-# The Keychain write always overwrites (`security add-generic-password -U`) — this script's only
-# job for the Keychain side is "the current cert lives at this account name", so a second run
-# against the same --account-name/--identity must always succeed, not be blocked by refusing to
-# touch an existing item. --delete-old is unrelated to the Keychain: it only prunes stale Entra AD
-# credentials — every credential that existed on the app *before* this run, so old unused certs
-# don't pile up on the App Registration after repeated rotation. Off by default: --append (used
-# regardless) is always safe on its own, since it only ever adds; --delete-old is the deliberate,
-# explicit opt-in to also clean up what preceded it.
+# Idempotent, and the check is exact rather than a guess about what a previous run did. The
+# certificate stored in the Keychain is read back, its SHA-1 thumbprint computed, and compared
+# against the base64 customKeyIdentifier of each certificate credential on the App Registration.
+# So the script knows the difference between nothing stored, something stored that the app does
+# not accept, and the right certificate already in place. A matching, unexpired certificate means
+# there is no work to do and the run is a no-op.
 #
-# --tenant is optional and pins every az call in this script to that Entra tenant, isolated from
-# whatever the operator's own ambient `az login` session currently defaults to. Without it, `az ad
-# app list`/`az ad app credential reset` run against whatever tenant the ambient session happens
-# to be logged into right now — wrong for an operator who is a guest across many tenants (the
-# exact failure this flag exists to close: the script silently acting against the wrong tenant's
-# app registration). When given, this script logs in fresh, into a throwaway AZURE_CONFIG_DIR
-# scoped to this one run, so it never touches or depends on the operator's real `~/.azure` session.
+# Mismatched certificates were the failure this check exists to close: a Keychain item and an app
+# registration that had drifted apart looked identical to one that was fine, and nothing short of
+# an authentication attempt would tell you which you had.
+#
+# A certificate within 30 days of expiring counts as work to do, so ordinary re-runs renew it
+# before it lapses rather than after.
+#
+# --rotate forces a new certificate even when the stored one is valid. Needed because generating
+# is no longer what a bare run does.
+#
+# The Keychain write always overwrites (`security add-generic-password -U`) — this script's only
+# job for the Keychain side is "the current cert lives at this account name", so a run that does
+# generate must always succeed, not be blocked by refusing to touch an existing item.
+# --delete-old is unrelated to the Keychain: it only prunes stale Entra AD credentials — every
+# credential that existed on the app *before* this run, so old unused certs don't pile up on the
+# App Registration after repeated rotation. Off by default: --append (used regardless) is always
+# safe on its own, since it only ever adds; --delete-old is the deliberate, explicit opt-in to
+# also clean up what preceded it.
+#
+# --tenant is required and pins every az call in this script to that Entra tenant, in an
+# AZURE_CONFIG_DIR isolated from the operator's real `~/.azure`. Were it not pinned, `az ad app
+# list`/`az ad app credential reset` would run against whatever tenant the ambient session happens
+# to be logged into right now — wrong for an operator who is a guest across many tenants, and
+# silent when it goes wrong: the script would act against the wrong tenant's app registration and
+# report success. See lib/az-session.sh for how the session is derived and reused.
 #
 # Dry run by default: prints the plan, touches nothing. Pass --apply to actually generate and store.
 #
 # Usage:
-#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --tenant <tenant-id>
-#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --tenant <tenant-id> --apply
-#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --tenant <tenant-id> --delete-old --apply
+#   .claude/scripts/az-keychain-cert-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder
+#   .claude/scripts/az-keychain-cert-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --apply
+#   .claude/scripts/az-keychain-cert-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --rotate --delete-old --apply
 
 set -eu
 
@@ -54,15 +70,31 @@ IDENTITY=''
 TENANT=''
 APPLY=0
 DELETE_OLD=0
+DELETE_OLD_ARG=''
+ROTATE=0
+ROTATE_ARG=''
+EXPIRY_DAYS=30
 
 while [ $# -gt 0 ]; do
+  # Checked before the case below reads $2, because `set -u` turns a flag with no value into a
+  # bare "$2: unbound variable" shell error rather than anything that says which flag was wrong.
+  case "$1" in
+    --display-name | --account-name | --identity | --tenant)
+      if [ $# -lt 2 ]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+      fi
+      ;;
+  esac
+
   case "$1" in
     --display-name) DISPLAY_NAME="$2"; shift 2 ;;
     --account-name) ACCOUNT_NAME="$2"; shift 2 ;;
     --identity) IDENTITY="$2"; shift 2 ;;
     --tenant) TENANT="$2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
-    --delete-old) DELETE_OLD=1; shift ;;
+    --delete-old) DELETE_OLD=1; DELETE_OLD_ARG=' --delete-old'; shift ;;
+    --rotate) ROTATE=1; ROTATE_ARG=' --rotate'; shift ;;
     *)
       echo "unknown argument: $1" >&2
       exit 1
@@ -70,8 +102,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ]; then
-  echo "usage: az-keychain-cert-create.sh --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder [--delete-old] [--apply]" >&2
+if [ -z "$TENANT" ] || [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ]; then
+  echo "usage: az-keychain-cert-create.sh --tenant TENANT --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder [--rotate] [--delete-old] [--apply]" >&2
   exit 1
 fi
 
@@ -85,16 +117,12 @@ esac
 
 ACCOUNT="az-${ACCOUNT_NAME}-${IDENTITY}-cert"
 
-# Isolated, throwaway login for this run only — never the operator's real ~/.azure. Read-only, so
-# this runs regardless of --apply: a dry run should report against the actual target tenant, not
-# whatever the ambient session happens to default to.
-if [ -n "$TENANT" ]; then
-  AZURE_CONFIG_DIR=$(mktemp -d)
-  export AZURE_CONFIG_DIR
-  trap 'rm -rf "$AZURE_CONFIG_DIR"' EXIT
-  echo "plan: az login --tenant $TENANT --allow-no-subscriptions (isolated session, this run only)"
-  az login --tenant "$TENANT" --allow-no-subscriptions >/dev/null
-fi
+# Read-only calls happen below regardless of --apply, so the session is established
+# unconditionally: a dry run should report against the actual target tenant, not whatever the
+# ambient session happens to default to.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/lib/az-session.sh"
+az_session_begin "$TENANT"
 
 # Resolved from the display name, not typed in by hand as a GUID — the operator only ever knows
 # the app by the display name az-sp-create.sh printed at creation. Read-only, so this runs
@@ -114,39 +142,129 @@ if [ "$MATCH_COUNT" -gt 1 ]; then
   exit 1
 fi
 APP_ID="$MATCHES"
-echo "resolved: display name '$DISPLAY_NAME' -> appId $APP_ID"
+echo "✅ App Registration '$DISPLAY_NAME' resolved to appId $APP_ID"
 
 # Read-only, so this runs regardless of --apply: the whole point of a dry run with --delete-old
 # is to see the real, current list of what would be removed, not a generic statement that
 # something might exist. Queried once, up front, and reused for the actual deletion later so the
 # apply path acts on exactly what the plan just showed — not a second, possibly different read.
 #
+# Queried unconditionally, not just under --delete-old: without it the script cannot tell whether
+# any pre-existing credential will survive this run, and a warning that fires regardless of
+# whether anything is there says nothing.
+#
 # `az ad app credential list` only ever returns password credentials (client secrets) — it always
 # comes back empty for a cert-only app, even when one is visibly attached in the portal.
 # Certificates live under the app object's own `keyCredentials` property, which only `az ad app
 # show` exposes; that's the source of truth here, not the credential-list command its name
 # suggests should cover this.
-OLD_CREDS=''
-if [ "$DELETE_OLD" -eq 1 ]; then
-  OLD_CREDS=$(az ad app show --id "$APP_ID" --query 'keyCredentials[].{keyId:keyId,displayName:displayName,startDateTime:startDateTime,endDateTime:endDateTime}' -o tsv)
+OLD_CREDS=$(az ad app show --id "$APP_ID" --query 'keyCredentials[].{keyId:keyId,customKeyIdentifier:customKeyIdentifier,displayName:displayName,startDateTime:startDateTime,endDateTime:endDateTime}' -o tsv)
+
+# What is actually in the Keychain, which is the thing that decides whether this run has any work
+# to do. Without reading it the script cannot tell "nothing is stored" from "the right certificate
+# is already stored", and so treats every run as a rotation.
+STORED_PEM=$(security find-generic-password -s "$SERVICE" -a "$ACCOUNT" -w 2>/dev/null || true)
+
+# `security ... -w` prints the password as one long hex string instead of its raw bytes whenever
+# the data is multi-line, which a PEM always is. Nothing is wrong with what was stored — this is
+# purely how the command-line tool renders it, and keychain-native reads the same item through the
+# macOS API and gets the raw bytes. Detected by content rather than by a flag, because there is no
+# option to turn it off: a PEM contains '-', '/' and newlines, so anything that is nothing but hex
+# digits is the encoded form.
+case "$STORED_PEM" in
+  '') ;;
+  *[!0-9a-fA-F]*) ;;
+  *) STORED_PEM=$(printf '%s' "$STORED_PEM" | xxd -r -p) ;;
+esac
+
+# The SHA-1 fingerprint is what ties the two together: Entra records each certificate credential's
+# SHA-1 thumbprint in customKeyIdentifier, and the stored PEM is that same certificate. Comparing
+# them is exact — either the app accepts what is stored, or it does not.
+STORED_THUMBPRINT=''
+if [ -n "$STORED_PEM" ]; then
+  STORED_THUMBPRINT=$(printf '%s\n' "$STORED_PEM" | openssl x509 -noout -fingerprint -sha1 2>/dev/null | sed 's/^.*=//' | tr -d ':' | tr '[:lower:]' '[:upper:]' || true)
 fi
 
-echo "plan: az ad app credential reset --id $APP_ID --create-cert --years 1 --append"
-echo "plan: store the resulting certificate in Keychain item service='$SERVICE' account='$ACCOUNT' (overwriting any existing value there)"
-echo "plan: delete the certificate's temp file once stored"
-if [ "$DELETE_OLD" -eq 1 ]; then
-  if [ -z "$OLD_CREDS" ]; then
-    echo "plan: --delete-old — no pre-existing Entra credentials found on $APP_ID, nothing to remove"
-  else
-    echo "plan: --delete-old — remove these pre-existing Entra credentials on $APP_ID:"
-    printf '%s\n' "$OLD_CREDS" | while IFS="$(printf '\t')" read -r KEY_ID CRED_NAME START END; do
-      echo "  keyId=$KEY_ID displayName='$CRED_NAME' start=$START end=$END"
+# Fed by here-document rather than a pipe: a `... | while read` loop runs in a subshell, so the
+# match it found would be lost the moment the loop ended.
+MATCH_KEY_ID=''
+MATCH_END=''
+if [ -n "$STORED_THUMBPRINT" ] && [ -n "$OLD_CREDS" ]; then
+  while IFS="$(printf '\t')" read -r KEY_ID CKI CRED_NAME START END; do
+    [ -n "$CKI" ] || continue
+    # az prints customKeyIdentifier as a hex thumbprint, while raw Microsoft Graph returns the
+    # same bytes base64-encoded. Which one arrives here depends on the CLI version, and
+    # base64-decoding a value that is already hex turns an exact match into garbage, so the form
+    # is detected rather than assumed: a SHA-1 thumbprint in hex is 40 hex digits and nothing
+    # else, where its base64 form is 28 characters ending in '='.
+    case "$CKI" in
+      [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])
+        CKI_HEX=$(printf '%s' "$CKI" | tr '[:lower:]' '[:upper:]')
+        ;;
+      *)
+        CKI_HEX=$(printf '%s' "$CKI" | openssl base64 -d -A 2>/dev/null | od -An -tx1 | tr -d ' \n' | tr '[:lower:]' '[:upper:]' || true)
+        ;;
+    esac
+    if [ "$CKI_HEX" = "$STORED_THUMBPRINT" ]; then
+      MATCH_KEY_ID="$KEY_ID"
+      MATCH_END="$END"
+    fi
+  done <<EOF
+$OLD_CREDS
+EOF
+fi
+
+# BSD and GNU date take different flags for arithmetic, and these scripts run on both. Compared as
+# YYYYMMDDHHMMSS integers so no date parsing is needed on the other side, only digit extraction.
+EXPIRY_THRESHOLD=$(date -u -v+${EXPIRY_DAYS}d '+%Y%m%d%H%M%S' 2>/dev/null || date -u -d "+$EXPIRY_DAYS days" '+%Y%m%d%H%M%S')
+MATCH_END_NUM=$(printf '%s' "$MATCH_END" | tr -dc '0-9' | cut -c1-14)
+
+NEED_CERT=1
+if [ "$ROTATE" -eq 1 ]; then
+  REASON='--rotate was given'
+elif [ -z "$STORED_PEM" ]; then
+  REASON="nothing is stored in Keychain item account='$ACCOUNT'"
+elif [ -z "$STORED_THUMBPRINT" ]; then
+  REASON="the value stored at '$ACCOUNT' is not a readable certificate"
+elif [ -z "$MATCH_KEY_ID" ]; then
+  REASON="the certificate stored at '$ACCOUNT' is not one this App Registration accepts"
+elif [ "$MATCH_END_NUM" -lt "$EXPIRY_THRESHOLD" ]; then
+  REASON="the stored certificate expires $MATCH_END, within $EXPIRY_DAYS days"
+else
+  NEED_CERT=0
+fi
+
+if [ "$NEED_CERT" -eq 0 ]; then
+  echo "✅ the certificate stored at '$ACCOUNT' is credential $MATCH_KEY_ID on $APP_ID, valid until $MATCH_END"
+  echo "✅ Nothing to do — running this with --apply would change nothing (pass --rotate to replace it anyway)"
+  exit 0
+fi
+
+# The plan is what a dry run is for. Under --apply the same information would appear twice, once
+# as intent and once as outcome, and an operator scanning for whether it worked has to tell the
+# two apart. So --apply prints only what has actually happened, and every line it prints is a
+# completed step.
+if [ "$APPLY" -eq 0 ]; then
+  echo "⚡ generate a new certificate on $APP_ID (valid 1 year) — $REASON"
+  echo "⚡ store it in Keychain item service='$SERVICE' account='$ACCOUNT', overwriting any existing value"
+
+  # --append means the app ends up holding the pre-existing credentials plus the new one. Only the
+  # pre-existing ones that survive are worth saying anything about, so this reports what is
+  # actually on the app rather than describing the flag's behaviour.
+  if [ -n "$OLD_CREDS" ]; then
+    if [ "$DELETE_OLD" -eq 1 ]; then
+      echo "🗑️  remove these pre-existing Entra credentials on $APP_ID:"
+    else
+      echo "⚠️  these pre-existing Entra credentials stay on $APP_ID alongside the new one — pass --delete-old to remove them:"
+    fi
+    printf '%s\n' "$OLD_CREDS" | while IFS="$(printf '\t')" read -r KEY_ID CKI CRED_NAME START END; do
+      echo "   keyId=$KEY_ID displayName='$CRED_NAME' start=$START end=$END"
     done
   fi
-fi
 
-if [ "$APPLY" -eq 0 ]; then
-  echo "dry run only — pass --apply to generate and store"
+  echo ""
+  echo "to apply, re-run:"
+  echo "$0 --tenant $TENANT --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY$DELETE_OLD_ARG$ROTATE_ARG --apply"
   exit 0
 fi
 
@@ -179,9 +297,12 @@ if [ "$DELETE_OLD" -eq 1 ] && [ -n "$OLD_KEY_IDS" ]; then
     # --cert: without it this targets a password credential with this keyId, which never exists
     # for a cert-only app — the delete would silently no-op instead of removing the old key.
     az ad app credential delete --id "$APP_ID" --key-id "$KEY_ID" --cert >/dev/null
-    echo "OK: removed Entra credential keyId='$KEY_ID'"
+    echo "✅ removed Entra credential keyId='$KEY_ID'"
   done
 fi
 
-echo "✓ Certificate generated and stored in Keychain"
-echo "account: $ACCOUNT"
+echo "✅ Certificate generated and stored in Keychain item '$ACCOUNT'"
+
+if [ "$DELETE_OLD" -eq 0 ] && [ -n "$OLD_CREDS" ]; then
+  echo "⚠️  the credentials that were already on $APP_ID are still there — re-run with --delete-old to remove them"
+fi

--- a/.claude/scripts/az-role-create.sh
+++ b/.claude/scripts/az-role-create.sh
@@ -1,0 +1,187 @@
+#!/bin/sh
+# Creates or updates the custom "Contributor (No Delete)" role definition — Contributor's own
+# actions and notActions plus a wildcard */delete NotAction — and sets the scopes it is
+# assignable at.
+#
+# Its own script, separate from az-sp-create.sh, because a role definition is a single
+# tenant-level object shared by every service principal ever assigned it, while an SP is created
+# once and a certificate rotates repeatedly. Three lifecycles, three scripts. The role also
+# outlives any individual SP: adding a scope years later must not mean touching an SP at all.
+#
+# The role name is not an argument. There is exactly one custom role in this scheme, and a
+# free-text name would only make it possible to create a second one by typo, then assign it and
+# wonder why the permissions differ.
+#
+# Idempotent. Run it as often as you like: an absent role is created, an existing one has its
+# assignableScopes updated in place, and its actions/notActions are carried through untouched
+# rather than rewritten from this script's idea of them.
+#
+# --scope is repeatable and describes the desired state. By default the script is additive: it
+# adds scopes that are missing and reports — but does not remove — scopes present on the role
+# that you did not pass. --remove-extra opts in to removing them. Azure refuses to remove a scope
+# that still has live role assignments beneath it, so a prune with assignments outstanding fails
+# at the az call rather than silently orphaning them.
+#
+# A scope is a subscription, a resource group, or a management group
+# (/providers/Microsoft.Management/managementGroups/<id>). A management group scope is inherited
+# by every subscription beneath it, including ones created later.
+#
+# --tenant is required and pins every az call to that Entra tenant, in an AZURE_CONFIG_DIR
+# isolated from the operator's real ~/.azure. See lib/az-session.sh for how the session is
+# derived and reused.
+#
+# Dry run by default: prints the plan, touches nothing. Pass --apply to actually create or update.
+#
+# Usage:
+#   .claude/scripts/az-role-create.sh --tenant <tenant-id> --scope /providers/Microsoft.Management/managementGroups/alz
+#   .claude/scripts/az-role-create.sh --tenant <tenant-id> --scope /providers/Microsoft.Management/managementGroups/alz --scope /subscriptions/<id> --apply
+#   .claude/scripts/az-role-create.sh --tenant <tenant-id> --scope /providers/Microsoft.Management/managementGroups/alz --remove-extra --apply
+
+set -eu
+
+ROLE_NAME='Contributor (No Delete)'
+TENANT=''
+SCOPES=''
+SCOPE_ARGS=''
+APPLY=0
+REMOVE_EXTRA=0
+REMOVE_EXTRA_ARG=''
+ROLE_JSON=''
+
+while [ $# -gt 0 ]; do
+  # Checked before the case below reads $2, because `set -u` turns a flag with no value into a
+  # bare "$2: unbound variable" shell error rather than anything that says which flag was wrong.
+  case "$1" in
+    --tenant | --scope)
+      if [ $# -lt 2 ]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  case "$1" in
+    --tenant) TENANT="$2"; shift 2 ;;
+    --scope) SCOPES="${SCOPES:+$SCOPES }$2"; SCOPE_ARGS="${SCOPE_ARGS:+$SCOPE_ARGS }--scope $2"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    --remove-extra) REMOVE_EXTRA=1; REMOVE_EXTRA_ARG=' --remove-extra'; shift ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$TENANT" ] || [ -z "$SCOPES" ]; then
+  echo "usage: az-role-create.sh --tenant TENANT --scope SCOPE [--scope SCOPE ...] [--remove-extra] [--apply]" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ -n "$ROLE_JSON" ]; then
+    rm -f "$ROLE_JSON"
+  fi
+}
+trap cleanup EXIT
+
+# Read-only calls happen below regardless of --apply, so the session is established
+# unconditionally: a dry run must report against the actual target tenant, not whatever the
+# ambient session defaults to.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/lib/az-session.sh"
+az_session_begin "$TENANT"
+
+# Word splitting on $SCOPES is deliberate throughout: these are jq positional arguments and az
+# list arguments, and an Azure resource ID can contain neither a space nor a newline.
+#
+# A role definition is one object with one assignableScopes list, so whether it exists is a
+# property of the role rather than of any one scope — looked up once, at the first scope given.
+FIRST_SCOPE=${SCOPES%% *}
+
+EXISTING=$(az role definition list --name "$ROLE_NAME" --scope "$FIRST_SCOPE" --custom-role-only true --output json)
+
+if [ "$(printf '%s' "$EXISTING" | jq 'length')" -eq 0 ]; then
+  if [ "$APPLY" -eq 0 ]; then
+    echo "⚡ create custom role '$ROLE_NAME' assignable at:"
+    for SCOPE in $SCOPES; do
+      echo "   $SCOPE"
+    done
+    echo ""
+    echo "to apply, re-run:"
+    echo "$0 --tenant $TENANT $SCOPE_ARGS$REMOVE_EXTRA_ARG --apply"
+    exit 0
+  fi
+
+  ROLE_JSON=$(mktemp)
+  jq -n --arg name "$ROLE_NAME" --args '{Name: $name, IsCustom: true, Description: "Contributor without delete permissions across resource providers.", Actions: ["*"], NotActions: ["Microsoft.Authorization/*/Delete", "Microsoft.Authorization/*/Write", "Microsoft.Authorization/elevateAccess/Action", "Microsoft.Blueprint/blueprintAssignments/write", "Microsoft.Blueprint/blueprintAssignments/delete", "Microsoft.Compute/galleries/share/action", "Microsoft.Purview/consents/write", "Microsoft.Purview/consents/delete", "Microsoft.Resources/deploymentStacks/manageDenySetting/action", "Microsoft.Subscription/cancel/action", "Microsoft.Subscription/enable/action", "*/delete"], DataActions: [], NotDataActions: [], AssignableScopes: $ARGS.positional}' -- $SCOPES > "$ROLE_JSON"
+  az role definition create --role-definition "$ROLE_JSON" >/dev/null
+
+  echo "✅ Custom role '$ROLE_NAME' created"
+  exit 0
+fi
+
+MISSING=$(printf '%s' "$EXISTING" | jq -r --args '($ARGS.positional - .[0].assignableScopes)[]' -- $SCOPES)
+EXTRA=$(printf '%s' "$EXISTING" | jq -r --args '(.[0].assignableScopes - $ARGS.positional)[]' -- $SCOPES)
+
+echo "✅ custom role '$ROLE_NAME' exists"
+
+# Counts what --apply would actually change, so the last line of a dry run can answer the only
+# question the operator has: is there any point running this again with --apply?
+PENDING=0
+
+if [ -n "$MISSING" ]; then
+  PENDING=$((PENDING + $(printf '%s\n' "$MISSING" | grep -c .)))
+fi
+if [ -n "$EXTRA" ] && [ "$REMOVE_EXTRA" -eq 1 ]; then
+  PENDING=$((PENDING + $(printf '%s\n' "$EXTRA" | grep -c .)))
+fi
+
+# Intent is what a dry run is for. Under --apply the same facts appear again as outcomes, and two
+# versions of the same list is what makes an apply hard to read, so --apply prints only what has
+# actually happened.
+if [ -z "$MISSING" ]; then
+  echo "✅ every scope you passed is already assignable"
+elif [ "$APPLY" -eq 0 ]; then
+  echo "⚡ add these scopes to assignableScopes:"
+  printf '   %s\n' $MISSING
+fi
+
+if [ -z "$EXTRA" ]; then
+  echo "✅ no scopes present outside the ones you passed"
+elif [ "$APPLY" -eq 0 ]; then
+  if [ "$REMOVE_EXTRA" -eq 1 ]; then
+    echo "🗑️  remove these scopes from assignableScopes:"
+  else
+    echo "⚠️  these scopes are present but you did not pass them — left alone, pass --remove-extra to remove them:"
+  fi
+  printf '   %s\n' $EXTRA
+elif [ "$REMOVE_EXTRA" -eq 0 ]; then
+  echo "⚠️  scopes are present that you did not pass — re-run with --remove-extra to remove them"
+fi
+
+if [ "$PENDING" -eq 0 ]; then
+  echo "✅ Nothing to do — running this with --apply would change nothing"
+  exit 0
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  echo ""
+  echo "to apply, re-run:"
+  echo "$0 --tenant $TENANT $SCOPE_ARGS$REMOVE_EXTRA_ARG --apply"
+  exit 0
+fi
+
+# Built by editing the definition az just returned rather than by reconstructing one: the role's
+# actions, notActions and identity are carried through exactly as they are, so this script can
+# never quietly rewrite the permission set while only meaning to change a scope.
+if [ "$REMOVE_EXTRA" -eq 1 ]; then
+  UPDATED=$(printf '%s' "$EXISTING" | jq --args '.[0] | .assignableScopes = $ARGS.positional' -- $SCOPES)
+else
+  UPDATED=$(printf '%s' "$EXISTING" | jq --args '.[0] | .assignableScopes = (.assignableScopes + $ARGS.positional | unique)' -- $SCOPES)
+fi
+
+ROLE_JSON=$(mktemp)
+printf '%s' "$UPDATED" > "$ROLE_JSON"
+az role definition update --role-definition "$ROLE_JSON" >/dev/null
+
+echo "✅ Custom role '$ROLE_NAME' updated"

--- a/.claude/scripts/az-sp-create.sh
+++ b/.claude/scripts/az-sp-create.sh
@@ -1,47 +1,89 @@
 #!/bin/sh
 # Creates an Entra ID App Registration + Service Principal with NO credential (no password, no
-# certificate — same as leaving both blank in the portal) and assigns an RBAC role. Credential
-# generation is a separate script (see az-keychain-cert-create.sh), because SP/role creation and
-# certificate lifecycle are different operations with different failure modes: recreating a whole
-# SP just to regenerate a cert (rotation, or fixing a wrong Keychain account name) is wasteful and
-# invalidates whatever else was already wired to the old SP's appId. This script runs once per SP;
-# az-keychain-cert-create.sh can run again any time against the same SP.
+# certificate — same as leaving both blank in the portal) and reconciles its RBAC role
+# assignments to the scopes you pass.
 #
-# --display-name is Entra's own free-text display name (--name on `az ad sp
-# create-for-rbac`), shown in the portal, read back by nothing — it is not, and is never meant to
-# be, the Keychain account name used later.
+# One of three scripts, split by lifecycle. az-role-create.sh owns the custom role definition,
+# which is a single tenant-level object shared by every SP assigned it. This script owns the SP
+# and its assignments. az-keychain-cert-create.sh owns the certificate, which rotates repeatedly
+# without the SP changing at all. Recreating an SP to regenerate a cert would invalidate whatever
+# else was already wired to the old appId; rewriting a shared role definition to add one SP's
+# scope would change permissions for every other SP using it.
 #
-# The role is not a free-text argument. --identity reader|holder maps to a fixed role below —
-# there is deliberately nothing else to pass, so a fat-fingered role can't happen here. The
-# holder's role is the custom "Contributor (No Delete)" role (Contributor's own actions minus
-# a wildcard */delete NotAction), created here if it doesn't already exist at the target scope
-# — not plain Contributor. A holder created with plain Contributor and fixed up afterward by a
-# separate script is exactly the gap this script used to have: "unprivileged"/"no delete" must
-# be what the tooling creates, not a follow-up step an operator has to remember to run.
+# --display-name is Entra's own free-text display name, shown in the portal. It is also this
+# script's identity key: the app is looked up by it, created only when no match exists, and
+# reused otherwise. That is what makes repeated runs safe. Entra permits duplicate display names,
+# so an ambiguous match is a hard error rather than a guess — generating credentials for the
+# wrong SP is not a failure you want discovered later.
+#
+# The role is not a free-text argument. --identity reader|holder maps to a fixed role: reader
+# gets the built-in Reader, holder gets the custom "Contributor (No Delete)" role, which must
+# already exist — run az-role-create.sh first. A holder created with plain Contributor and fixed
+# up afterward by a separate script is exactly the gap this pair used to have: "unprivileged" and
+# "no delete" must be what the tooling creates, not a follow-up step someone has to remember.
+#
+# Idempotent. --scope is repeatable and describes the desired assignments. By default the script
+# is additive: it creates assignments that are missing and reports — but does not remove —
+# assignments this principal holds that you did not pass. --remove-extra opts in to removing
+# them. Removal is destructive and a role assignment may have been made deliberately elsewhere,
+# so it is never what a bare run does.
+#
+# A scope is a subscription, a resource group, or a management group
+# (/providers/Microsoft.Management/managementGroups/<id>). A management group scope is inherited
+# by every subscription beneath it, including ones created later.
+#
+# The holder additionally requests the Microsoft Graph 'User.Read.All' application permission,
+# which the reader never gets. Requested only — admin consent is a privileged act for a person
+# with Global Administrator or Privileged Role Administrator, so the script asks for the
+# permission and warns while consent is outstanding, rather than granting it.
+#
+# --tenant is required and pins every az call to that Entra tenant, in an AZURE_CONFIG_DIR
+# isolated from the operator's real ~/.azure. It matters most here: an app looked up in the wrong
+# directory is simply not found, and this script would helpfully create a second one there. See
+# lib/az-session.sh for how the session is derived and reused.
 #
 # Dry run by default: prints the plan, touches nothing. Pass --apply to actually create.
 #
 # Usage:
-#   .claude/scripts/az-sp-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --scope /subscriptions/<id>
-#   .claude/scripts/az-sp-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --scope /subscriptions/<id> --apply
-#   .claude/scripts/az-keychain-cert-create.sh --display-name "Hope Ventures (Holder)" --account-name hopeventures --identity holder --apply
+#   .claude/scripts/az-sp-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Reader)" --account-name hopeventures --identity reader --scope /subscriptions/<id>
+#   .claude/scripts/az-sp-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Reader)" --account-name hopeventures --identity reader --scope /subscriptions/<id> --scope /providers/Microsoft.Management/managementGroups/<mg> --apply
+#   .claude/scripts/az-keychain-cert-create.sh --tenant <tenant-id> --display-name "Hope Ventures (Reader)" --account-name hopeventures --identity reader --apply
 
 set -eu
 
 HOLDER_ROLE_NAME='Contributor (No Delete)'
+GRAPH_APP_ID='00000003-0000-0000-c000-000000000000'
+GRAPH_PERMISSION='User.Read.All'
+TENANT=''
 DISPLAY_NAME=''
 ACCOUNT_NAME=''
 IDENTITY=''
-SCOPE=''
+SCOPES=''
+SCOPE_ARGS=''
 APPLY=0
+REMOVE_EXTRA=0
+REMOVE_EXTRA_ARG=''
 
 while [ $# -gt 0 ]; do
+  # Checked before the case below reads $2, because `set -u` turns a flag with no value into a
+  # bare "$2: unbound variable" shell error rather than anything that says which flag was wrong.
   case "$1" in
+    --tenant | --display-name | --account-name | --identity | --scope)
+      if [ $# -lt 2 ]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  case "$1" in
+    --tenant) TENANT="$2"; shift 2 ;;
     --display-name) DISPLAY_NAME="$2"; shift 2 ;;
     --account-name) ACCOUNT_NAME="$2"; shift 2 ;;
     --identity) IDENTITY="$2"; shift 2 ;;
-    --scope) SCOPE="$2"; shift 2 ;;
+    --scope) SCOPES="${SCOPES:+$SCOPES }$2"; SCOPE_ARGS="${SCOPE_ARGS:+$SCOPE_ARGS }--scope $2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
+    --remove-extra) REMOVE_EXTRA=1; REMOVE_EXTRA_ARG=' --remove-extra'; shift ;;
     *)
       echo "unknown argument: $1" >&2
       exit 1
@@ -49,8 +91,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ] || [ -z "$SCOPE" ]; then
-  echo "usage: az-sp-create.sh --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder --scope SCOPE [--apply]" >&2
+if [ -z "$TENANT" ] || [ -z "$DISPLAY_NAME" ] || [ -z "$ACCOUNT_NAME" ] || [ -z "$IDENTITY" ] || [ -z "$SCOPES" ]; then
+  echo "usage: az-sp-create.sh --tenant TENANT --display-name DISPLAY_NAME --account-name ACCOUNT_NAME --identity reader|holder --scope SCOPE [--scope SCOPE ...] [--remove-extra] [--apply]" >&2
   exit 1
 fi
 
@@ -63,68 +105,205 @@ case "$IDENTITY" in
     ;;
 esac
 
-if [ "$IDENTITY" = 'holder' ]; then
-  echo "plan: create custom role '$HOLDER_ROLE_NAME' at scope $SCOPE if it doesn't already exist — Contributor's own actions/notActions plus a */delete NotAction"
-fi
-echo "plan: az ad sp create-for-rbac --name '$DISPLAY_NAME' --role '$ROLE' --scopes $SCOPE --create-password false"
-echo "plan: print appId, tenantId to stdout (non-secret) — no credential is created here"
-echo "plan: next step (separate, by hand): az-keychain-cert-create.sh --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY --apply"
+# Read-only calls happen below regardless of --apply, so the session is established
+# unconditionally: a dry run must report against the actual target tenant, not whatever the
+# ambient session defaults to.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/lib/az-session.sh"
+az_session_begin "$TENANT"
 
+# Word splitting on $SCOPES is deliberate throughout: these are jq positional arguments, and an
+# Azure resource ID can contain neither a space nor a newline.
+FIRST_SCOPE=${SCOPES%% *}
+
+if [ "$IDENTITY" = 'holder' ] && ! az role definition list --name "$HOLDER_ROLE_NAME" --scope "$FIRST_SCOPE" --custom-role-only true --query '[0].roleName' -o tsv | grep -q .; then
+  echo "error: custom role '$HOLDER_ROLE_NAME' does not exist at $FIRST_SCOPE — create it first: az-role-create.sh --tenant $TENANT --scope $FIRST_SCOPE --apply" >&2
+  exit 1
+fi
+
+# Read-only, so this runs regardless of --apply: a dry run should report against the app that
+# actually exists, not describe a creation that may not be what happens. An exact-match filter
+# and an explicit count check, because a display name is not unique in Entra by default.
+MATCHES=$(az ad app list --display-name "$DISPLAY_NAME" --query "[?displayName=='$DISPLAY_NAME'].appId" -o tsv)
+MATCH_COUNT=$(printf '%s\n' "$MATCHES" | grep -c . || true)
+
+if [ "$MATCH_COUNT" -gt 1 ]; then
+  echo "error: more than one App Registration has display name '$DISPLAY_NAME' — resolve the ambiguity in Entra before running this script:" >&2
+  printf '%s\n' "$MATCHES" >&2
+  exit 1
+fi
+
+# Counts what --apply would actually change, so a dry run can say whether there is any point
+# running it again with --apply.
+PENDING=0
+
+# Intent is what a dry run is for. Under --apply the same facts appear again as outcomes, and two
+# versions of the same list is what makes an apply hard to read, so --apply prints only what has
+# actually happened.
+plan() {
+  if [ "$APPLY" -eq 0 ]; then
+    echo "$1"
+  fi
+}
+
+APP_ID=''
+if [ "$MATCH_COUNT" -eq 1 ]; then
+  APP_ID="$MATCHES"
+  echo "✅ App Registration '$DISPLAY_NAME' exists (appId $APP_ID)"
+else
+  plan "⚡ create App Registration '$DISPLAY_NAME' (no credential — see az-keychain-cert-create.sh)"
+  PENDING=$((PENDING + 1))
+fi
+
+# An App Registration and its Service Principal are separate objects, and an app can exist
+# without one — created by hand in the portal, or left behind by a partial earlier run. So the
+# SP is checked and created independently of the app rather than assumed to follow it.
+OBJECT_ID=''
+if [ -n "$APP_ID" ]; then
+  OBJECT_ID=$(az ad sp show --id "$APP_ID" --query id -o tsv 2>/dev/null || true)
+fi
+
+if [ -n "$OBJECT_ID" ]; then
+  echo "✅ Service Principal exists (objectId $OBJECT_ID)"
+else
+  plan "⚡ create Service Principal"
+  PENDING=$((PENDING + 1))
+fi
+
+# Assignments are listed for the principal rather than per scope, so an assignment at a scope you
+# did not pass is visible at all — that is the whole point of reconciling. It reports only what
+# the calling identity can read, so run this as an account with read across the scopes involved
+# or an "extra" assignment may simply be invisible rather than absent.
+EXISTING_ASSIGNMENTS='[]'
+if [ -n "$OBJECT_ID" ]; then
+  EXISTING_ASSIGNMENTS=$(az role assignment list --assignee "$APP_ID" --all --query '[].{id: id, role: roleDefinitionName, scope: scope}' --output json)
+fi
+
+DESIRED=$(jq -n --arg role "$ROLE" --args '[$ARGS.positional[] | {role: $role, scope: .}]' -- $SCOPES)
+MISSING=$(printf '%s' "$DESIRED" | jq -r --argjson existing "$EXISTING_ASSIGNMENTS" '[.[] | . as $d | select(($existing | map({role: .role, scope: .scope})) | index($d) | not)] | .[].scope')
+EXTRA=$(printf '%s' "$EXISTING_ASSIGNMENTS" | jq -r --argjson desired "$DESIRED" '[.[] | . as $a | select(($desired | index({role: $a.role, scope: $a.scope})) | not)] | .[] | "\(.id)\t\(.role)\t\(.scope)"')
+
+if [ -n "$MISSING" ]; then
+  PENDING=$((PENDING + $(printf '%s\n' "$MISSING" | grep -c .)))
+fi
+if [ -n "$EXTRA" ] && [ "$REMOVE_EXTRA" -eq 1 ]; then
+  PENDING=$((PENDING + $(printf '%s\n' "$EXTRA" | grep -c .)))
+fi
+
+if [ -z "$MISSING" ]; then
+  echo "✅ every '$ROLE' assignment you passed already exists"
+else
+  plan "⚡ create '$ROLE' assignments at:"
+  if [ "$APPLY" -eq 0 ]; then
+    printf '   %s\n' $MISSING
+  fi
+fi
+
+if [ -z "$EXTRA" ]; then
+  echo "✅ this principal holds no assignments outside the ones you passed"
+elif [ "$APPLY" -eq 0 ]; then
+  if [ "$REMOVE_EXTRA" -eq 1 ]; then
+    echo "🗑️  remove these assignments, which you did not pass:"
+  else
+    echo "⚠️  this principal holds assignments you did not pass — left alone, pass --remove-extra to remove them:"
+  fi
+  printf '%s\n' "$EXTRA" | while IFS="$(printf '\t')" read -r A_ID A_ROLE A_SCOPE; do
+    echo "   role='$A_ROLE' scope=$A_SCOPE"
+  done
+elif [ "$REMOVE_EXTRA" -eq 0 ]; then
+  echo "⚠️  this principal holds assignments you did not pass — re-run with --remove-extra to remove them"
+fi
+
+# Microsoft Graph is a separate permission system from Azure RBAC: a role on a subscription or
+# management group grants nothing at all against graph.microsoft.com. The holder needs directory
+# read, so it is requested here; the reader deliberately gets no Graph permissions.
+#
+# The script only ever *requests* the permission. Granting it is admin consent, which needs
+# Global Administrator or Privileged Role Administrator and is a decision a person makes, not
+# something tooling should do on their behalf. What the script owes you is knowing whether it has
+# happened, because a requested-but-unconsented permission looks configured in the portal and
+# fails at runtime.
+GRAPH_ROLE_ID=''
+PERMISSION_REQUESTED=0
+PERMISSION_CONSENTED=0
+
+if [ "$IDENTITY" = 'holder' ]; then
+  # Resolved from Graph rather than hardcoded. The well-known GUID for this permission is easy to
+  # find and easy to get subtly wrong, and a wrong one fails at consent time rather than here.
+  GRAPH_ROLE_ID=$(az ad sp show --id "$GRAPH_APP_ID" --query "appRoles[?value=='$GRAPH_PERMISSION' && contains(allowedMemberTypes, 'Application')].id | [0]" -o tsv)
+  if [ -z "$GRAPH_ROLE_ID" ]; then
+    echo "error: could not resolve the '$GRAPH_PERMISSION' application permission id from Microsoft Graph" >&2
+    exit 1
+  fi
+
+  if [ -n "$APP_ID" ] && az ad app show --id "$APP_ID" --query "requiredResourceAccess[?resourceAppId=='$GRAPH_APP_ID'].resourceAccess[] | [?id=='$GRAPH_ROLE_ID'].id" -o tsv | grep -q .; then
+    PERMISSION_REQUESTED=1
+  fi
+
+  # Consent shows up as an app role assignment on the service principal, not on the app
+  # registration — the request and the grant live on two different objects.
+  if [ -n "$OBJECT_ID" ] && az rest --method get --url "https://graph.microsoft.com/v1.0/servicePrincipals/$OBJECT_ID/appRoleAssignments" --query "value[?appRoleId=='$GRAPH_ROLE_ID'].id" -o tsv 2>/dev/null | grep -q .; then
+    PERMISSION_CONSENTED=1
+  fi
+
+  if [ "$PERMISSION_REQUESTED" -eq 1 ]; then
+    echo "✅ Microsoft Graph '$GRAPH_PERMISSION' is requested on the app registration"
+  else
+    plan "⚡ request Microsoft Graph '$GRAPH_PERMISSION' (application permission) on the app registration"
+    PENDING=$((PENDING + 1))
+  fi
+
+  if [ "$PERMISSION_CONSENTED" -eq 1 ]; then
+    echo "✅ admin consent for '$GRAPH_PERMISSION' has been granted"
+  else
+    echo "⚠️  admin consent for '$GRAPH_PERMISSION' has not been granted — nothing uses the permission until a Global Administrator or Privileged Role Administrator grants it in Entra"
+  fi
+fi
+
+# The only next step a dry run has is applying itself. Naming the certificate script here instead
+# reads as the thing to do next and sends the operator to a script that cannot work yet, because
+# the App Registration it looks up does not exist until this one has been applied.
 if [ "$APPLY" -eq 0 ]; then
-  echo "dry run only — pass --apply to create"
+  if [ "$PENDING" -eq 0 ]; then
+    echo "✅ Nothing to do — running this with --apply would change nothing"
+  else
+    echo ""
+    echo "to apply, re-run:"
+    echo "$0 --tenant $TENANT --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY $SCOPE_ARGS$REMOVE_EXTRA_ARG --apply"
+  fi
   exit 0
 fi
 
-if [ "$IDENTITY" = 'holder' ] && ! az role definition list --name "$HOLDER_ROLE_NAME" --scope "$SCOPE" --query '[0].roleName' -o tsv | grep -q .; then
-  ROLE_JSON=$(mktemp)
-  trap 'rm -f "$ROLE_JSON"' EXIT
-  cat > "$ROLE_JSON" <<EOF
-{
-  "Name": "$HOLDER_ROLE_NAME",
-  "IsCustom": true,
-  "Description": "Contributor without delete permissions across resource providers.",
-  "Actions": ["*"],
-  "NotActions": [
-    "Microsoft.Authorization/*/Delete",
-    "Microsoft.Authorization/*/Write",
-    "Microsoft.Authorization/elevateAccess/Action",
-    "Microsoft.Blueprint/blueprintAssignments/write",
-    "Microsoft.Blueprint/blueprintAssignments/delete",
-    "Microsoft.Compute/galleries/share/action",
-    "Microsoft.Purview/consents/write",
-    "Microsoft.Purview/consents/delete",
-    "Microsoft.Resources/deploymentStacks/manageDenySetting/action",
-    "Microsoft.Subscription/cancel/action",
-    "Microsoft.Subscription/enable/action",
-    "*/delete"
-  ],
-  "DataActions": [],
-  "NotDataActions": [],
-  "AssignableScopes": ["$SCOPE"]
-}
-EOF
-  az role definition create --role-definition "$ROLE_JSON" >/dev/null
-  rm -f "$ROLE_JSON"
-  trap - EXIT
-  echo "OK: custom role '$HOLDER_ROLE_NAME' created"
+if [ -z "$APP_ID" ]; then
+  APP_ID=$(az ad app create --display-name "$DISPLAY_NAME" --query appId -o tsv)
+  echo "✅ App Registration created, appId=$APP_ID"
 fi
 
-OUTPUT=$(az ad sp create-for-rbac --name "$DISPLAY_NAME" --role "$ROLE" --scopes "$SCOPE" --create-password false --output json)
-
-APP_ID=$(printf '%s' "$OUTPUT" | jq -r '.appId')
-TENANT_ID=$(printf '%s' "$OUTPUT" | jq -r '.tenant')
-
-if [ "$IDENTITY" = 'reader' ]; then
-  READER_FIELD="\"$APP_ID\""
-  HOLDER_FIELD='null'
-else
-  READER_FIELD='null'
-  HOLDER_FIELD="\"$APP_ID\""
+if [ -z "$OBJECT_ID" ]; then
+  OBJECT_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
+  echo "✅ Service Principal created, objectId=$OBJECT_ID"
 fi
 
-echo "✓ Service principal created, no credential yet"
+for SCOPE in $MISSING; do
+  az role assignment create --assignee-object-id "$OBJECT_ID" --assignee-principal-type ServicePrincipal --role "$ROLE" --scope "$SCOPE" >/dev/null
+  echo "✅ assigned '$ROLE' at $SCOPE"
+done
+
+if [ "$IDENTITY" = 'holder' ] && [ "$PERMISSION_REQUESTED" -eq 0 ]; then
+  az ad app permission add --id "$APP_ID" --api "$GRAPH_APP_ID" --api-permissions "$GRAPH_ROLE_ID=Role" >/dev/null
+  echo "✅ requested Microsoft Graph '$GRAPH_PERMISSION' on the app registration"
+fi
+
+if [ "$REMOVE_EXTRA" -eq 1 ] && [ -n "$EXTRA" ]; then
+  printf '%s\n' "$EXTRA" | while IFS="$(printf '\t')" read -r A_ID A_ROLE A_SCOPE; do
+    az role assignment delete --ids "$A_ID" >/dev/null
+    echo "✅ removed '$A_ROLE' at $A_SCOPE"
+  done
+fi
+
+echo "✅ Service principal in place, no credential yet"
 echo "appId:     $APP_ID"
-echo "tenantId:  $TENANT_ID"
-echo "Merge this into sdk-config.json (it only fills the $IDENTITY field — fill the other identity's clientId when its own SP exists, or leave it null):"
-jq -n --arg account "$ACCOUNT_NAME" --arg tenantId "$TENANT_ID" --argjson reader "$READER_FIELD" --argjson holder "$HOLDER_FIELD" '{az: {accounts: {($account): {tenantId: $tenantId, readerClientId: $reader, holderClientId: $holder}}}}'
-echo "Then generate and store its certificate: az-keychain-cert-create.sh --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY --apply"
+echo "tenantId:  $TENANT"
+echo "Merge this into sdk-config.json (it only fills the $IDENTITY identity — the other one is configured separately):"
+jq -n --arg account "$ACCOUNT_NAME" --arg tenantId "$TENANT" --arg identity "$IDENTITY" --arg clientId "$APP_ID" '{az: {accounts: {($account): {tenantId: $tenantId, ($identity): {type: "cert", clientId: $clientId}}}}}'
+echo "Then generate and store its certificate: az-keychain-cert-create.sh --tenant $TENANT --display-name '$DISPLAY_NAME' --account-name $ACCOUNT_NAME --identity $IDENTITY --apply"

--- a/.claude/scripts/lib/az-session.sh
+++ b/.claude/scripts/lib/az-session.sh
@@ -1,0 +1,60 @@
+# Shared az session setup, sourced by the scripts in the parent directory. Not executable and not
+# runnable on its own: it defines one function and is meant to be dotted in.
+#
+# Every one of these scripts must act on the tenant it was told to act on, never on whatever the
+# operator's ambient `az login` session happens to default to. An operator who is a guest across
+# several tenants otherwise gets silent wrong-directory failures: an app looked up in the wrong
+# tenant is simply not found, and a role definition created there looks like success.
+#
+# So each script gets its own AZURE_CONFIG_DIR, isolated from the real ~/.azure. The directory is
+# derived from the tenant id rather than being a fresh mktemp per run, which means a dry run and
+# the --apply that follows it share one session and cost one login between them instead of two.
+# It also means the reader and holder runs for the same tenant share a session, while different
+# tenants never do.
+#
+# It lives under $TMPDIR so the OS reclaims it: the MSAL token cache inside is plaintext on macOS
+# and Linux, per Microsoft's own docs, so a session left behind is a credential left behind. The
+# cost of that reclamation is an occasional extra login after a reboot or a few days idle, which
+# is the right trade for not keeping token caches indefinitely.
+#
+# The uid is in the path because $TMPDIR is per-user on macOS but usually plain /tmp on Linux and
+# WSL, where a fixed shared name is another user's to create first. Owning a uid-scoped parent
+# means the directory this script writes into is always its own.
+
+# Sets up AZURE_CONFIG_DIR for the given tenant and logs in only if that session isn't already
+# live. Call once, early, before any other az call in the script.
+az_session_begin() {
+  az_session_tenant="$1"
+
+  # $az_session_tenant becomes a path component, so anything that isn't a GUID is rejected before
+  # it is used. Catches a traversal attempt, and more usefully catches passing a tenant domain
+  # like 'contoso.com' where an id belongs.
+  az_session_hex4='[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+  az_session_guid="$az_session_hex4$az_session_hex4-$az_session_hex4-$az_session_hex4-$az_session_hex4-$az_session_hex4$az_session_hex4$az_session_hex4"
+
+  case "$az_session_tenant" in
+    $az_session_guid) ;;
+    *)
+      echo "error: --tenant must be a tenant id GUID, got '$az_session_tenant'" >&2
+      return 1
+      ;;
+  esac
+
+  az_session_tmp="${TMPDIR:-/tmp}"
+  az_session_root="${az_session_tmp%/}/shellicar-az-$(id -u)"
+  AZURE_CONFIG_DIR="$az_session_root/$az_session_tenant"
+  export AZURE_CONFIG_DIR
+
+  mkdir -p "$AZURE_CONFIG_DIR"
+  chmod 700 "$az_session_root" "$AZURE_CONFIG_DIR"
+
+  # Reusing the session is the whole point of the stable path, so the login is conditional. Any
+  # failure here — no session, expired refresh token, a cache the CLI can't read — means log in.
+  if az account show >/dev/null 2>&1; then
+    echo "session: reusing existing login for tenant $az_session_tenant ($AZURE_CONFIG_DIR)"
+    return 0
+  fi
+
+  echo "session: az login --tenant $az_session_tenant --allow-no-subscriptions ($AZURE_CONFIG_DIR)"
+  az login --tenant "$az_session_tenant" --allow-no-subscriptions >/dev/null
+}


### PR DESCRIPTION
## Summary

- Creating an identity is now three scripts, split by how often each part changes: the custom role, the service principal, and the certificate.
- Re-running any of them is safe. Each reports what already exists and what applying would change.
- A dry run ends with the exact command to apply it, and says plainly when there is nothing to do.
- The stored certificate is matched to the app registration by thumbprint, so a Keychain item that has drifted from the app is detected instead of assumed healthy.
- A certificate within 30 days of expiring is treated as work to do, and `--rotate` forces a new one.
- Every script requires `--tenant` and runs against an isolated session for that tenant, never the ambient `az` login.
- A dry run and the apply that follows share one login instead of two.
- The holder identity requests the Microsoft Graph `User.Read.All` permission and warns while admin consent is outstanding.
- `--scope` is repeatable, so one run can cover several subscriptions or a management group.
- Existing role assignments and credentials outside what you passed are reported, and removed only when explicitly asked.
